### PR TITLE
Fix Listener Socket Timeout on Windows

### DIFF
--- a/common/cross_sockets/xsocket.cpp
+++ b/common/cross_sockets/xsocket.cpp
@@ -88,11 +88,11 @@ int read_from_socket(int socket, char* buf, int len) {
 }
 
 bool socket_timed_out() {
-  //#ifdef __linux
+#ifdef __linux
   return errno == EAGAIN;
-  //#elif _WIN32
-  //  auto err = WSAGetLastError();
-  //  printf("windows error %d\n", err);
-  //  return err == WSAETIMEDOUT;
-  //#endif
+#elif _WIN32
+  auto err = WSAGetLastError();
+  printf("windows error %d\n", err);
+  return err == WSAETIMEDOUT;
+#endif
 }

--- a/common/cross_sockets/xsocket.cpp
+++ b/common/cross_sockets/xsocket.cpp
@@ -88,11 +88,11 @@ int read_from_socket(int socket, char* buf, int len) {
 }
 
 bool socket_timed_out() {
-#ifdef __linux
+  //#ifdef __linux
   return errno == EAGAIN;
-#elif _WIN32
-  auto err = WSAGetLastError();
-  printf("windows error %d\n", err);
-  return err == WSAETIMEDOUT;
-#endif
+  //#elif _WIN32
+  //  auto err = WSAGetLastError();
+  //  printf("windows error %d\n", err);
+  //  return err == WSAETIMEDOUT;
+  //#endif
 }

--- a/common/cross_sockets/xsocket.cpp
+++ b/common/cross_sockets/xsocket.cpp
@@ -86,3 +86,13 @@ int read_from_socket(int socket, char* buf, int len) {
   return recv(socket, buf, len, 0);
 #endif
 }
+
+bool socket_timed_out() {
+#ifdef __linux
+  return errno == EAGAIN;
+#elif _WIN32
+  auto err = WSAGetLastError();
+  printf("windows error %d\n", err);
+  return err == WSAETIMEDOUT;
+#endif
+}

--- a/common/cross_sockets/xsocket.cpp
+++ b/common/cross_sockets/xsocket.cpp
@@ -92,7 +92,6 @@ bool socket_timed_out() {
   return errno == EAGAIN;
 #elif _WIN32
   auto err = WSAGetLastError();
-  printf("windows error %d\n", err);
   return err == WSAETIMEDOUT;
 #endif
 }

--- a/common/cross_sockets/xsocket.h
+++ b/common/cross_sockets/xsocket.h
@@ -18,3 +18,4 @@ int set_socket_option(int socket, int level, int optname, const void* optval, in
 int set_socket_timeout(int socket, long microSeconds);
 int write_to_socket(int socket, const char* buf, int len);
 int read_from_socket(int socket, char* buf, int len);
+bool socket_timed_out();

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -123,7 +123,7 @@ bool Listener::connect_to_target(int n_tries, const std::string& ip, int port) {
     listen_socket = -1;
     return false;
   } else {
-    printf("[Listener] Socket connected established! (took %d tries)\n", i);
+    printf("[Listener] Socket connected established! (took %d tries). Waiting for version...\n", i);
   }
 
   // get the GOAL version number, to make sure we connected to the right thing
@@ -133,11 +133,13 @@ bool Listener::connect_to_target(int n_tries, const std::string& ip, int port) {
   bool ok = true;
   while (prog < 8) {
     auto r = read_from_socket(listen_socket, (char*)version_buffer + prog, 8 - prog);
-    if (r < 0) {
-      ok = false;
-      break;
-    }
-    prog += r;
+    std::this_thread::sleep_for(std::chrono::microseconds(100000));
+
+    //    if (r < 0) {
+    //      ok = false;
+    //      break;
+    //    }
+    prog += r > 0 ? r : 0;
     read_tries++;
     if (read_tries > 50) {
       ok = false;
@@ -181,7 +183,8 @@ void Listener::receive_func() {
       rcvd += got > 0 ? got : 0;
 
       // kick us out if we got a bogus read result
-      if (got == 0 || (got == -1 && errno != EAGAIN)) {
+      if (got == 0 || (got == -1 && !socket_timed_out())) {
+        printf("receive disconnect 1\n");
         m_connected = false;
       }
 
@@ -238,7 +241,8 @@ void Listener::receive_func() {
           got = got > 0 ? got : 0;
           rcvd += got;
           msg_prog += got;
-          if (got == 0 || (got == -1 && errno != EAGAIN)) {
+          if (got == 0 || (got == -1 && !socket_timed_out())) {
+            printf("receive disconnect 2\n");
             m_connected = false;
           }
         }

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -134,11 +134,6 @@ bool Listener::connect_to_target(int n_tries, const std::string& ip, int port) {
   while (prog < 8) {
     auto r = read_from_socket(listen_socket, (char*)version_buffer + prog, 8 - prog);
     std::this_thread::sleep_for(std::chrono::microseconds(100000));
-
-    //    if (r < 0) {
-    //      ok = false;
-    //      break;
-    //    }
     prog += r > 0 ? r : 0;
     read_tries++;
     if (read_tries > 50) {

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -184,7 +184,6 @@ void Listener::receive_func() {
 
       // kick us out if we got a bogus read result
       if (got == 0 || (got == -1 && !socket_timed_out())) {
-        printf("receive disconnect 1\n");
         m_connected = false;
       }
 
@@ -242,7 +241,6 @@ void Listener::receive_func() {
           rcvd += got;
           msg_prog += got;
           if (got == 0 || (got == -1 && !socket_timed_out())) {
-            printf("receive disconnect 2\n");
             m_connected = false;
           }
         }

--- a/test/test_listener_deci2.cpp
+++ b/test/test_listener_deci2.cpp
@@ -45,6 +45,24 @@ TEST(Listener, DeciCheckNoListener) {
   EXPECT_FALSE(s.check_for_listener());
 }
 
+TEST(Listener, CheckConnectionStaysAlive) {
+  Deci2Server s(always_false);
+  EXPECT_TRUE(s.init());
+  EXPECT_FALSE(s.check_for_listener());
+  Listener l;
+  EXPECT_FALSE(s.check_for_listener());
+  bool connected = l.connect_to_target();
+  EXPECT_TRUE(connected);
+  // TODO - some sort of backoff and retry would be better
+  while (connected && !s.check_for_listener()) {
+  }
+
+  EXPECT_TRUE(s.check_for_listener());
+  std::this_thread::sleep_for(std::chrono::seconds(5));  // sorry for making tests slow.
+  EXPECT_TRUE(s.check_for_listener());
+  EXPECT_TRUE(l.is_connected());
+}
+
 TEST(Listener, DeciThenListener) {
   for (int i = 0; i < 3; i++) {
     Deci2Server s(always_false);

--- a/test/test_listener_deci2.cpp
+++ b/test/test_listener_deci2.cpp
@@ -58,7 +58,7 @@ TEST(Listener, CheckConnectionStaysAlive) {
   }
 
   EXPECT_TRUE(s.check_for_listener());
-  std::this_thread::sleep_for(std::chrono::seconds(5));  // sorry for making tests slow.
+  std::this_thread::sleep_for(std::chrono::seconds(2));  // sorry for making tests slow.
   EXPECT_TRUE(s.check_for_listener());
   EXPECT_TRUE(l.is_connected());
 }


### PR DESCRIPTION
The listener periodically times out waiting on the runtime, which doesn't always mean something is wrong. On windows I mistook this for a socket error instead of just a normal timeout, causing the connection to drop out very quickly if nothing was sent.