### PR TITLE
Resolve a good chunk of windows compiler warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,0 @@
-# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\xtvas\Repositories\jak-project codebase based on best match to current usage at 2020-08-28
-# You can modify the rules from these initially generated values to suit your own policies
-# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
-[*.cs]
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ set(CMAKE_CXX_STANDARD 14)
 if (CMAKE_COMPILER_IS_GNUCXX)
     message(STATUS "GCC detected, adding compile flags")
     set(CMAKE_CXX_FLAGS
-            "${CMAKE_CXX_FLAGS} \
+        "${CMAKE_CXX_FLAGS} \
         -Wall \
-		-Winit-self \
-		-ggdb \
+        -Winit-self \
+        -ggdb \
         -Wextra \
         -Wcast-align \
         -Wcast-qual \

--- a/common/type_system/Type.cpp
+++ b/common/type_system/Type.cpp
@@ -16,7 +16,7 @@ std::string reg_kind_to_string(RegKind kind) {
     case RegKind::FLOAT_4X:
       return "float-4x";
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported RegKind");
   }
 }
 

--- a/decompiler/Disasm/Instruction.cpp
+++ b/decompiler/Disasm/Instruction.cpp
@@ -26,7 +26,7 @@ std::string InstructionAtom::to_string(const LinkedObjectFile& file) const {
     case IMM_SYM:
       return sym;
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported InstructionAtom");
   }
 }
 

--- a/decompiler/Disasm/Register.cpp
+++ b/decompiler/Disasm/Register.cpp
@@ -5,6 +5,7 @@
 
 #include "Register.h"
 #include <cassert>
+#include <stdexcept>
 
 ////////////////////////////
 // Register Name Constants
@@ -126,7 +127,7 @@ const char* Register::to_charp() const {
     case Reg::PCR:
       return pcr_to_charp(get_pcr());
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported Register");
   }
 }
 

--- a/decompiler/Function/Function.h
+++ b/decompiler/Function/Function.h
@@ -30,7 +30,7 @@ struct FunctionName {
       case FunctionKind::UNIDENTIFIED:
         return "(?)";
       default:
-        assert(false);
+        throw std::runtime_error("Unsupported FunctionKind");
     }
   }
 

--- a/decompiler/ObjectFile/ObjectFileDB.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB.cpp
@@ -71,7 +71,7 @@ ObjectFileDB::ObjectFileDB(const std::vector<std::string>& _dgos) {
   }
 
   printf("ObjectFileDB Initialized:\n");
-  printf(" total dgos: %ld\n", _dgos.size());
+  printf(" total dgos: %lld\n", _dgos.size());
   printf(" total data: %d bytes\n", stats.total_dgo_bytes);
   printf(" total objs: %d\n", stats.total_obj_files);
   printf(" unique objs: %d\n", stats.unique_obj_files);

--- a/game/kernel/kboot.cpp
+++ b/game/kernel/kboot.cpp
@@ -151,7 +151,7 @@ void KernelCheckAndDispatch() {
         fprintf(stderr, "\n");
         auto result =
             call_goal(Ptr<Function>(ListenerFunction->value), 0, 0, 0, s7.offset, g_ee_main_mem);
-        fprintf(stderr, "result of listener function: %ld\n", result);
+        fprintf(stderr, "result of listener function: %lld\n", result);
 #ifdef __linux__
         cprintf("%ld\n", result);
 #else

--- a/game/kernel/kprint.cpp
+++ b/game/kernel/kprint.cpp
@@ -884,6 +884,8 @@ s32 format_impl(uint64_t* args) {
                 call_method_of_type(in, type, GOAL_PRINT_METHOD);
               }
             } else {
+              // TODO - if we can't throw exceptions, what is the option?
+              // log, break and continue?
               throw std::runtime_error("failed to find symbol in format!");
             }
           }

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -123,7 +123,7 @@ void ee_runner(SystemThreadInterface& iface) {
     return;
   }
 
-  printf("  Main memory mapped at 0x%016lx\n", (u64)(g_ee_main_mem));
+  printf("  Main memory mapped at 0x%016llx\n", (u64)(g_ee_main_mem));
   printf("  Main memory size 0x%x bytes (%.3f MB)\n", EE_MAIN_MEM_SIZE,
          (double)EE_MAIN_MEM_SIZE / (1 << 20));
 

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -395,7 +395,7 @@ std::string IR_IntegerMath::print() {
     case IntegerMathKind::IDIV_32:
       return fmt::format("idiv {}, {}", m_dest->print(), m_arg->print());
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported IntegerMathKind");
   }
 }
 
@@ -451,7 +451,7 @@ std::string IR_FloatMath::print() {
     case FloatMathKind::DIV_SS:
       return fmt::format("divss {}, {}", m_dest->print(), m_arg->print());
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported FloatMathKind");
   }
 }
 

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -165,7 +165,7 @@ emitter::RegKind Compiler::get_preferred_reg_kind(const TypeSpec& ts) {
     case RegKind::FLOAT:
       return emitter::RegKind::XMM;
     default:
-      assert(false);
+      throw std::runtime_error("Unknown preferred register kind");
   }
 }
 

--- a/goalc/compiler/Val.cpp
+++ b/goalc/compiler/Val.cpp
@@ -25,7 +25,7 @@ RegVal* Val::to_xmm(Env* fe) {
   if (rv->ireg().kind == emitter::RegKind::XMM) {
     return rv;
   } else {
-    assert(false);
+    throw std::runtime_error("Register is not an XMM[0-15] register.");
   }
 }
 

--- a/goalc/compiler/compilation/Define.cpp
+++ b/goalc/compiler/compilation/Define.cpp
@@ -98,5 +98,5 @@ Val* Compiler::compile_set(const goos::Object& form, const goos::Object& rest, E
   } else {
     throw_compile_error(form, "Set not implemented for this yet");
   }
-  assert(false);
+  throw std::runtime_error("Unexpected error in Set");
 }

--- a/goalc/compiler/compilation/Math.cpp
+++ b/goalc/compiler/compilation/Math.cpp
@@ -42,14 +42,13 @@ Val* Compiler::number_to_integer(Val* in, Env* env) {
   (void)env;
   auto ts = in->type();
   if (is_binteger(ts)) {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (a binteger) to an integer.");
   } else if (is_float(ts)) {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (a float) to an integer.");
   } else if (is_integer(ts)) {
     return in;
-  } else {
-    throw std::runtime_error("Can't convert " + in->print() + " to an integer.");
   }
+  throw std::runtime_error("Can't convert " + in->print() + " to an integer.");
 }
 
 Val* Compiler::number_to_binteger(Val* in, Env* env) {
@@ -58,25 +57,24 @@ Val* Compiler::number_to_binteger(Val* in, Env* env) {
   if (is_binteger(ts)) {
     return in;
   } else if (is_float(ts)) {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (a float) to a binteger.");
   } else if (is_integer(ts)) {
-    assert(false);
-  } else {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (an integer) to a binteger.");
   }
+  throw std::runtime_error("Can't convert " + in->print() + " to a binteger.");
 }
 
 Val* Compiler::number_to_float(Val* in, Env* env) {
   (void)env;
   auto ts = in->type();
   if (is_binteger(ts)) {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (a binteger) to a float.");
   } else if (is_float(ts)) {
     return in;
   } else if (is_integer(ts)) {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " (an integer) to a float.");
   } else {
-    assert(false);
+    throw std::runtime_error("Can't convert " + in->print() + " a float.");
   }
 }
 
@@ -89,7 +87,7 @@ Val* Compiler::to_math_type(Val* in, MathMode mode, Env* env) {
     case MATH_FLOAT:
       return number_to_float(in, env);
     default:
-      assert(false);
+      throw std::runtime_error("Unknown math type: " + in->print());
   }
 }
 

--- a/goalc/emitter/CodeTester.h
+++ b/goalc/emitter/CodeTester.h
@@ -13,6 +13,7 @@
 #include "common/common_types.h"
 #include "Register.h"
 #include "Instruction.h"
+#include <stdexcept>
 
 namespace emitter {
 class CodeTester {
@@ -67,7 +68,7 @@ class CodeTester {
       case 3:
         return R9;
       default:
-        assert(false);
+        throw std::runtime_error("Invalid arg register index");
     }
 #else
     switch (i) {
@@ -80,7 +81,7 @@ class CodeTester {
       case 3:
         return RCX;
       default:
-        assert(false);
+        throw std::runtime_error("Invaid arg register index");
     }
 #endif
   }

--- a/goalc/emitter/IGen.h
+++ b/goalc/emitter/IGen.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include "Register.h"
 #include "Instruction.h"
+#include <stdexcept>
 
 namespace emitter {
 class IGen {
@@ -1336,7 +1337,8 @@ class IGen {
     } else if (imm >= INT32_MIN && imm <= INT32_MAX) {
       return add_gpr64_imm32s(reg, imm);
     } else {
-      assert(false);
+      throw std::runtime_error("Invalid `add` with reg[" + reg.print() + "]/imm[" +
+                               std::to_string(imm) + "]");
     }
   }
 
@@ -1346,7 +1348,8 @@ class IGen {
     } else if (imm >= INT32_MIN && imm <= INT32_MAX) {
       return sub_gpr64_imm32s(reg, imm);
     } else {
-      assert(false);
+      throw std::runtime_error("Invalid `sub` with reg[" + reg.print() + "]/imm[" +
+                               std::to_string(imm) + "]");
     }
   }
 

--- a/goalc/emitter/Register.cpp
+++ b/goalc/emitter/Register.cpp
@@ -1,4 +1,5 @@
 #include "Register.h"
+#include <stdexcept>
 
 namespace emitter {
 RegisterInfo RegisterInfo::make_register_info() {
@@ -55,7 +56,7 @@ std::string to_string(RegKind kind) {
     case RegKind::XMM:
       return "xmm";
     default:
-      assert(false);
+      throw std::runtime_error("Unsupported RegKind");
   }
 }
 

--- a/goalc/goos/Object.h
+++ b/goalc/goos/Object.h
@@ -129,7 +129,7 @@ class FixedObject {
       return object_type_to_string(ObjectType::INTEGER);
     if (std::is_same<T, char>())
       return object_type_to_string(ObjectType::CHAR);
-    assert(false);
+    throw std::runtime_error("Unsupported FixedObject type");
   }
 };
 

--- a/goalc/goos/TextDB.cpp
+++ b/goalc/goos/TextDB.cpp
@@ -60,7 +60,8 @@ int SourceText::get_line_idx(int offset) {
       return line;
     }
   }
-  assert(false);
+  throw std::runtime_error("Unable to get line index for character at position " +
+                           std::to_string(offset));
 }
 
 /*!

--- a/goalc/regalloc/Allocator.cpp
+++ b/goalc/regalloc/Allocator.cpp
@@ -60,7 +60,7 @@ void find_basic_blocks(RegAllocCache* cache, const AllocationInput& in) {
       }
     }
     if (!found) {
-      printf("[RegAlloc Error] couldn't find basic block beginning with instr %d of %ld\n", instr,
+      printf("[RegAlloc Error] couldn't find basic block beginning with instr %d of %lld\n", instr,
              in.instructions.size());
     }
     assert(found);
@@ -612,7 +612,7 @@ const std::vector<emitter::Register>& get_default_alloc_order_for_var_spill(int 
   } else if (info.kind == emitter::RegKind::XMM) {
     return emitter::gRegInfo.get_xmm_spill_alloc_order();
   } else {
-    assert(false);
+    throw std::runtime_error("Unsupported RegKind");
   }
 }
 
@@ -624,7 +624,7 @@ const std::vector<emitter::Register>& get_default_alloc_order_for_var(int v, Reg
   } else if (info.kind == emitter::RegKind::XMM) {
     return emitter::gRegInfo.get_xmm_alloc_order();
   } else {
-    assert(false);
+    throw std::runtime_error("Unsupported RegKind");
   }
 }
 

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(CMAKE_CXX_FLAGS "-O3")
+if (CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "-O3")
+else ()
+  set(CMAKE_CXX_FLAGS "/EHsc")
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 include_directories(../)
 add_library(fmt SHARED format.cc)


### PR DESCRIPTION
Mostly revolved around the new MSVC check for functions that don't cover all paths (ie. a switch statement without a default case).  It appears to not see an assert as a valid default case.

I switched assert(false) to exceptions in these cases.  I believe this should also abort the program, but will also provide a hopefully useful message?  Hopefully this is an improvement.