### PR TITLE
Fix a Listener Bug

### DIFF
--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -16,10 +16,8 @@ std::string file_util::get_project_path() {
 #ifdef _WIN32
   char buffer[FILENAME_MAX];
   GetModuleFileNameA(NULL, buffer, FILENAME_MAX);
-  printf("using path %s\n", buffer);
   std::string::size_type pos =
       std::string(buffer).rfind("jak-project");  // Strip file path down to \jak-project\ directory
-  printf("rfind returned %lld\n", pos);
   return std::string(buffer).substr(
       0, pos + 11);  // + 12 to include "\jak-project" in the returned filepath
 #else

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -224,7 +224,7 @@ void Deci2Server::run() {
 
   int sent_to_program = 0;
   while (!want_exit() && (hdr->rsvd < hdr->len || sent_to_program < hdr->rsvd)) {
-    printf("recv loop top: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
+    fprintf(stderr, "recv loop top: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
     // send what we have to the program
     if (sent_to_program < hdr->rsvd) {
       //      driver.next_recv_size = 0;
@@ -245,10 +245,10 @@ void Deci2Server::run() {
       got += x > 0 ? x : 0;
       hdr->rsvd += got;
     }
-    printf("recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
+    fprintf(stderr, "recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
   }
 
-  printf("exit recv loop\n");
+  fprintf(stderr, "exit recv loop\n");
   (driver.handler)(DECI2_READDONE, 0, driver.opt);
   unlock();
 }

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -243,6 +243,7 @@ void Deci2Server::run() {
         return;
       }
       got += x > 0 ? x : 0;
+      fprintf(stderr, "wanted %d, got %d\n", hdr->len - hdr->rsvd, got);
       hdr->rsvd += got;
     }
     fprintf(stderr, "recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -224,7 +224,6 @@ void Deci2Server::run() {
 
   int sent_to_program = 0;
   while (!want_exit() && (hdr->rsvd < hdr->len || sent_to_program < hdr->rsvd)) {
-    fprintf(stderr, "recv loop top: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
     // send what we have to the program
     if (sent_to_program < hdr->rsvd) {
       //      driver.next_recv_size = 0;
@@ -243,13 +242,10 @@ void Deci2Server::run() {
         return;
       }
       got += x > 0 ? x : 0;
-      fprintf(stderr, "wanted %d, got %d\n", hdr->len - hdr->rsvd, got);
       hdr->rsvd = got;
     }
-    fprintf(stderr, "recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
   }
 
-  fprintf(stderr, "exit recv loop\n");
   (driver.handler)(DECI2_READDONE, 0, driver.opt);
   unlock();
 }

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -224,7 +224,7 @@ void Deci2Server::run() {
 
   int sent_to_program = 0;
   while (!want_exit() && (hdr->rsvd < hdr->len || sent_to_program < hdr->rsvd)) {
-    printf("recv loop: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
+    printf("recv loop top: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
     // send what we have to the program
     if (sent_to_program < hdr->rsvd) {
       //      driver.next_recv_size = 0;
@@ -245,8 +245,10 @@ void Deci2Server::run() {
       got += x > 0 ? x : 0;
       hdr->rsvd += got;
     }
+    printf("recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
   }
 
+  printf("exit recv loop\n");
   (driver.handler)(DECI2_READDONE, 0, driver.opt);
   unlock();
 }

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -244,7 +244,7 @@ void Deci2Server::run() {
       }
       got += x > 0 ? x : 0;
       fprintf(stderr, "wanted %d, got %d\n", hdr->len - hdr->rsvd, got);
-      hdr->rsvd += got;
+      hdr->rsvd = got;
     }
     fprintf(stderr, "recv loop bot: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
   }

--- a/game/system/Deci2Server.cpp
+++ b/game/system/Deci2Server.cpp
@@ -224,6 +224,7 @@ void Deci2Server::run() {
 
   int sent_to_program = 0;
   while (!want_exit() && (hdr->rsvd < hdr->len || sent_to_program < hdr->rsvd)) {
+    printf("recv loop: user %d, rsvd %d, len %d\n", sent_to_program, hdr->rsvd, hdr->len);
     // send what we have to the program
     if (sent_to_program < hdr->rsvd) {
       //      driver.next_recv_size = 0;

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -341,7 +341,7 @@ void Listener::send_buffer(int sz) {
   int wrote = 0;
 
   if (debug_listener) {
-    printf("[L -> T] sending %d bytes...\n", sz);
+    fprintf(stderr, "[L -> T] sending %d bytes...\n", sz);
   }
 
   got_ack = false;
@@ -350,7 +350,7 @@ void Listener::send_buffer(int sz) {
     auto to_send = std::min(512, sz - wrote);
     auto x = write_to_socket(listen_socket, m_buffer + wrote, to_send);
     wrote += x > 0 ? x : 0;
-    printf("wrote %d\n", wrote);
+    fprintf(stderr, "wrote %d\n", wrote);
   }
 
   if (debug_listener) {

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -32,7 +32,7 @@
 #include "common/versions.h"
 
 using namespace versions;
-constexpr bool debug_listener = true;
+constexpr bool debug_listener = false;
 
 namespace listener {
 Listener::Listener() {
@@ -350,7 +350,6 @@ void Listener::send_buffer(int sz) {
     auto to_send = std::min(512, sz - wrote);
     auto x = write_to_socket(listen_socket, m_buffer + wrote, to_send);
     wrote += x > 0 ? x : 0;
-    fprintf(stderr, "wrote %d\n", wrote);
   }
 
   if (debug_listener) {

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -32,7 +32,7 @@
 #include "common/versions.h"
 
 using namespace versions;
-constexpr bool debug_listener = false;
+constexpr bool debug_listener = true;
 
 namespace listener {
 Listener::Listener() {
@@ -349,10 +349,8 @@ void Listener::send_buffer(int sz) {
   while (wrote < sz) {
     auto to_send = std::min(512, sz - wrote);
     auto x = write_to_socket(listen_socket, m_buffer + wrote, to_send);
-    if (x == -1) {
-      continue;
-    }
-    wrote += x;
+    wrote += x > 0 ? x : 0;
+    printf("wrote %d\n", wrote);
   }
 
   if (debug_listener) {

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -349,6 +349,9 @@ void Listener::send_buffer(int sz) {
   while (wrote < sz) {
     auto to_send = std::min(512, sz - wrote);
     auto x = write_to_socket(listen_socket, m_buffer + wrote, to_send);
+    if (x == -1) {
+      continue;
+    }
     wrote += x;
   }
 

--- a/test/test_compiler_and_runtime.cpp
+++ b/test/test_compiler_and_runtime.cpp
@@ -253,20 +253,20 @@ TEST(CompilerAndRuntime, CompilerTests) {
   runner.run_test("test-factorial-loop.gc", {"3628800\n"});
   runner.run_test("test-protect.gc", {"33\n"});
 
-  expected =
-      "test newline\nnewline\ntest tilde ~ \ntest A print boxed-string: \"boxed string!\"\ntest A "
-      "print symbol: a-symbol\ntest A make boxed object longer:             \"srt\"!\ntest A "
-      "non-default pad: zzzzzzpad-me\ntest A shorten(4): a23~\ntest A don'tchange(4): a234\ntest A "
-      "shorten with pad(4): sho~\ntest A a few things \"one thing\" a-second integer #<compiled "
-      "function @ #x161544>\n";
-
-  expected += "test S a string a-symbol another string!\n";
-  expected += "test C ) ]\n";
-  expected += "test P (no type) #<compiled function @ #x161544>\n";
-  expected += "test P (with type) 1447236\n";
-
-  // todo, finish format testing.
-  runner.run_test("test-format.gc", {expected}, expected.size());
+  //  expected =
+  //      "test newline\nnewline\ntest tilde ~ \ntest A print boxed-string: \"boxed string!\"\ntest
+  //      A " "print symbol: a-symbol\ntest A make boxed object longer:             \"srt\"!\ntest A
+  //      " "non-default pad: zzzzzzpad-me\ntest A shorten(4): a23~\ntest A don'tchange(4):
+  //      a234\ntest A " "shorten with pad(4): sho~\ntest A a few things \"one thing\" a-second
+  //      integer #<compiled " "function @ #x161544>\n";
+  //
+  //  expected += "test S a string a-symbol another string!\n";
+  //  expected += "test C ) ]\n";
+  //  expected += "test P (no type) #<compiled function @ #x161544>\n";
+  //  expected += "test P (with type) 1447236\n";
+  //
+  //  // todo, finish format testing.
+  //  runner.run_test("test-format.gc", {expected}, expected.size());
 
   compiler.shutdown_target();
   runtime_thread.join();

--- a/test/test_compiler_and_runtime.cpp
+++ b/test/test_compiler_and_runtime.cpp
@@ -253,20 +253,20 @@ TEST(CompilerAndRuntime, CompilerTests) {
   runner.run_test("test-factorial-loop.gc", {"3628800\n"});
   runner.run_test("test-protect.gc", {"33\n"});
 
-  //  expected =
-  //      "test newline\nnewline\ntest tilde ~ \ntest A print boxed-string: \"boxed string!\"\ntest
-  //      A " "print symbol: a-symbol\ntest A make boxed object longer:             \"srt\"!\ntest A
-  //      " "non-default pad: zzzzzzpad-me\ntest A shorten(4): a23~\ntest A don'tchange(4):
-  //      a234\ntest A " "shorten with pad(4): sho~\ntest A a few things \"one thing\" a-second
-  //      integer #<compiled " "function @ #x161544>\n";
-  //
-  //  expected += "test S a string a-symbol another string!\n";
-  //  expected += "test C ) ]\n";
-  //  expected += "test P (no type) #<compiled function @ #x161544>\n";
-  //  expected += "test P (with type) 1447236\n";
-  //
-  //  // todo, finish format testing.
-  //  runner.run_test("test-format.gc", {expected}, expected.size());
+  expected =
+      "test newline\nnewline\ntest tilde ~ \ntest A print boxed-string: \"boxed string!\"\ntest A "
+      "print symbol: a-symbol\ntest A make boxed object longer:             \"srt\"!\ntest A "
+      "non-default pad: zzzzzzpad-me\ntest A shorten(4): a23~\ntest A don'tchange(4): a234\ntest A "
+      "shorten with pad(4): sho~\ntest A a few things \"one thing\" a-second integer #<compiled "
+      "function @ #x161544>\n";
+
+  expected += "test S a string a-symbol another string!\n";
+  expected += "test C ) ]\n";
+  expected += "test P (no type) #<compiled function @ #x161544>\n";
+  expected += "test P (with type) 1447236\n";
+
+  // todo, finish format testing.
+  runner.run_test("test-format.gc", {expected}, expected.size());
 
   compiler.shutdown_target();
   runtime_thread.join();


### PR DESCRIPTION
We've had a few random test failures related to the listener connection on github, and recently a test for `format` that sent a lot of data and failed always on github actions.  It seems like the listener can send data faster than the runtime can read it, causing an error that I wasn't checking for. After adding the error check, the `format` test seems to pass.

If all tests pass on this PR, I think this is the fix.