### PR TITLE
Fix high cpu usage from iop thread

### DIFF
--- a/game/system/iop_thread.cpp
+++ b/game/system/iop_thread.cpp
@@ -91,6 +91,9 @@ void IOP::kill_from_ee() {
 void IOP::signal_run_iop() {
   std::unique_lock<std::mutex> lk(iters_mutex);
   iop_iters_des += 100;  // todo, tune this
+  if(iop_iters_des - iop_iters_act > 500) {
+    iop_iters_des = iop_iters_act + 500;
+  }
   iop_run_cv.notify_all();
 }
 

--- a/game/system/iop_thread.cpp
+++ b/game/system/iop_thread.cpp
@@ -91,7 +91,7 @@ void IOP::kill_from_ee() {
 void IOP::signal_run_iop() {
   std::unique_lock<std::mutex> lk(iters_mutex);
   iop_iters_des += 100;  // todo, tune this
-  if(iop_iters_des - iop_iters_act > 500) {
+  if (iop_iters_des - iop_iters_act > 500) {
     iop_iters_des = iop_iters_act + 500;
   }
   iop_run_cv.notify_all();


### PR DESCRIPTION
Previously I implemented a system so the IOP code wouldn't have to run at 100% CPU usage in a busy loop, like it does in the original game. However it was not robust to the case where the game C code calls the "is the IOP done?" function in a loop as fast as possible.  This fixes that issue and the CPU usage of `gk` remains very low when nothing is happening.

