### PR TITLE
Tweak logger settings to make logging happen in order

### DIFF
--- a/game/main.cpp
+++ b/game/main.cpp
@@ -2,19 +2,43 @@
  * @file main.cpp
  * Main for the game. Launches the runtime.
  */
-#include <cstdio>
+
+#include <string>
 #include "runtime.h"
 #include "common/versions.h"
 #include "third-party/spdlog/include/spdlog/spdlog.h"
 #include "third-party/spdlog/include/spdlog/sinks/basic_file_sink.h"
+#include "third-party/spdlog/include/spdlog/sinks/stdout_color_sinks.h"
 
-int main(int argc, char** argv) {
-  while (true) {
-    spdlog::set_level(spdlog::level::debug);
-    auto game_logger = spdlog::basic_logger_mt("GOAL Runtime", "logs/runtime.log");
+void setup_logging(bool verbose) {
+  spdlog::set_level(spdlog::level::debug);
+  if (verbose) {
+    auto game_logger = spdlog::stdout_color_mt("GOAL Runtime");
     spdlog::set_default_logger(game_logger);
     spdlog::flush_on(spdlog::level::info);
+    spdlog::set_pattern("%v");
+    spdlog::info("Verbose logging enabled");
+  } else {
+    auto game_logger = spdlog::basic_logger_mt("GOAL Runtime", "logs/runtime.log");
+    spdlog::set_default_logger(game_logger);
+    spdlog::flush_on(spdlog::level::debug);
+    printf("OpenGOAL Runtime %d.%d\n", versions::GOAL_VERSION_MAJOR,
+           versions::GOAL_VERSION_MINOR);
+  }
+}
 
+int main(int argc, char** argv) {
+  bool verbose = false;
+  for (int i = 1; i < argc; i++) {
+    if (std::string("-v") == argv[i]) {
+      verbose = true;
+      break;
+    }
+  }
+
+  setup_logging(verbose);
+
+  while (true) {
     // run the runtime in a loop so we can reset the game and have it restart cleanly
     spdlog::info("OpenGOAL Runtime {}.{}", versions::GOAL_VERSION_MAJOR,
                  versions::GOAL_VERSION_MINOR);

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -22,8 +22,7 @@ void setup_logging(bool verbose) {
     auto game_logger = spdlog::basic_logger_mt("GOAL Runtime", "logs/runtime.log");
     spdlog::set_default_logger(game_logger);
     spdlog::flush_on(spdlog::level::debug);
-    printf("OpenGOAL Runtime %d.%d\n", versions::GOAL_VERSION_MAJOR,
-           versions::GOAL_VERSION_MINOR);
+    printf("OpenGOAL Runtime %d.%d\n", versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
   }
 }
 

--- a/gk.sh
+++ b/gk.sh
@@ -3,4 +3,4 @@
 # Directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-$DIR/build/game/gk -fakeiso -debug -nokernel
+$DIR/build/game/gk -fakeiso -debug -nokernel "$@"


### PR DESCRIPTION
Add a `-v` option to runtime to log everything to stdout and flush after each message. This can be used to make all print statements appear in the correct order in the same place, which is useful for debugging.