### PR TITLE
Add more array stuff and clean up field access

### DIFF
--- a/common/goos/Object.h
+++ b/common/goos/Object.h
@@ -285,6 +285,13 @@ class Object {
     return integer_obj.value;
   }
 
+  const IntType& as_int() const {
+    if (type != ObjectType::INTEGER) {
+      throw std::runtime_error("as_int called on a " + object_type_to_string(type) + " " + print());
+    }
+    return integer_obj.value;
+  }
+
   FloatType& as_float() {
     if (type != ObjectType::FLOAT) {
       throw std::runtime_error("as_float called on a " + object_type_to_string(type) + " " +

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -19,3 +19,6 @@
 - There is a `&-` which returns a `uint` and works with basically any input types
 - The `&` operator works on fields and elements in arrays
 - The `&->` operator has been added
+- The `new` operator can create arrays and inline arrays on heaps
+- The value of `deftype` is now `none`
+- Creating a method with more than 8 arguments is an error instead of a crash.

--- a/goal_src/kernel-defs.gc
+++ b/goal_src/kernel-defs.gc
@@ -72,7 +72,7 @@
 (define-extern loado (function string kheap object))
 (define-extern unload (function string none))
 (define-extern _format (function _varargs_ object))
-(define-extern malloc (function kheap int pointer))
+(define-extern malloc (function symbol int pointer))
 (define-extern kmalloc (function kheap int int string))
 (define-extern new-dynamic-structure (function kheap type int structure))
 (define-extern method-set! (function type int function none)) ;; may actually return function.

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -50,6 +50,12 @@ class Compiler {
   Val* compile_string(const std::string& str, Env* env, int seg = MAIN_SEGMENT);
   Val* compile_get_symbol_value(const std::string& name, Env* env);
   Val* compile_function_or_method_call(const goos::Object& form, Env* env);
+
+  Val* get_field_of_structure(const StructureType* type,
+                              Val* object,
+                              const std::string& field_name,
+                              Env* env);
+
   SymbolVal* compile_get_sym_obj(const std::string& name, Env* env);
   void color_object_file(FileEnv* env);
   std::vector<u8> codegen_object_file(FileEnv* env);
@@ -83,6 +89,8 @@ class Compiler {
                                   const std::vector<RegVal*>& args,
                                   Env* env,
                                   const std::string& method_type_name = "");
+
+  bool try_getting_constant_integer(const goos::Object& in, int64_t* out, Env* env);
 
   TypeSystem m_ts;
   std::unique_ptr<GlobalEnv> m_global_env = nullptr;

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -185,3 +185,14 @@ bool Compiler::is_none(Val* in) {
 bool Compiler::is_basic(const TypeSpec& ts) {
   return m_ts.typecheck(m_ts.make_typespec("basic"), ts, "", false, false);
 }
+
+bool Compiler::try_getting_constant_integer(const goos::Object& in, int64_t* out, Env* env) {
+  (void)env;
+  if (in.is_int()) {
+    *out = in.as_int();
+    return true;
+  }
+
+  // todo, try more things before giving up.
+  return false;
+}

--- a/test/goalc/source_templates/with_game/test-new-array.gc
+++ b/test/goalc/source_templates/with_game/test-new-array.gc
@@ -1,0 +1,37 @@
+(start-test "new-array")
+
+;; align the heap.
+(new 'global 'array 'uint8 16)
+
+;; get the current alignment
+(let ((current (-> global current)))
+  (expect-true (= current (new 'global 'array 'uint16 3))) ;; 6 bytes
+  (expect-true (= (&+ current 6) (-> global current)))
+  )
+
+;; align the heap.
+(new 'global 'array 'uint8 16)
+
+;; get the current alignment
+(let ((current (-> global current)))
+  (expect-true (= current (new 'global 'array 'bfloat 3))) ;; 3 * 4 = 12 bytes
+  (expect-true (= (&+ current 12) (-> global current)))
+  )
+
+;; align the heap.
+(new 'global 'array 'uint8 16)
+
+;; get the current alignment
+(let ((current (-> global current)))
+  (expect-true (= current (new 'global 'inline-array 'bfloat 3))) ;; 3*4 = 12 bytes
+  (expect-true (= (&+ current 48) (-> global current)))
+  )
+
+;; get the current alignment
+(let ((current (-> global current))
+      (three 3))
+  (expect-true (= current (new 'global 'inline-array 'bfloat (* three 4)))) ;; 12*16 = 36 bytes
+  (expect-true (= (&+ current 192) (-> global current)))
+  )
+
+(finish-test)

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -62,6 +62,12 @@ std::thread WithGameTests::runtime_thread;
 Compiler WithGameTests::compiler;
 GoalTest::CompilerTestRunner WithGameTests::runner;
 
+namespace {
+std::vector<std::string> get_test_pass_string(const std::string& name, int count) {
+  return {fmt::format("Test \"{}\": {} Passes\n0\n", name, count)};
+}
+}  // namespace
+
 // TODO - havn't done anything with these really yet
 TEST_F(WithGameTests, All) {
   runner.run_static_test(env, testCategory, "defun-return-constant.static.gc", {"12\n"});
@@ -109,15 +115,16 @@ TEST_F(WithGameTests, All) {
                          {"Test \"test-type-arrays\": 3 Passes\n0\n"});
   runner.run_static_test(env, testCategory, "test-number-comparison.gc",
                          {"Test \"number-comparison\": 14 Passes\n0\n"});
-  /*runner.run_static_test(env, testCategory, "test-approx-pi.gc",
+  runner.run_static_test(env, testCategory, "test-approx-pi.gc",
                          get_test_pass_string("approx-pi", 4));
   runner.run_static_test(env, testCategory, "test-dynamic-type.gc",
                          get_test_pass_string("dynamic-type", 4));
   runner.run_static_test(env, testCategory, "test-string-type.gc",
                          get_test_pass_string("string-type", 4));
   runner.run_static_test(env, testCategory, "test-new-string.gc",
-                         get_test_pass_string("new-string", 5));*/
-  // runner.run_static_test(env, testCategory, "test-addr-of.gc", get_test_pass_string("addr-of",
-  // 2));
+                         get_test_pass_string("new-string", 5));
+  runner.run_static_test(env, testCategory, "test-addr-of.gc", get_test_pass_string("addr-of", 2));
   runner.run_static_test(env, testCategory, "test-set-self.gc", {"#t\n0\n"});
+  runner.run_static_test(env, testCategory, "test-new-array.gc",
+                         get_test_pass_string("new-array", 8));
 }


### PR DESCRIPTION
The `new` operator now can create arrays and inline arrays on heaps, as required for https://github.com/water111/jak-project/issues/49

Field access is split into a separate function with comments.