### PR TITLE
Print strings in assembly

### DIFF
--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -561,10 +561,10 @@ std::string LinkedObjectFile::print_disassembly() {
               line.append(40 - line.length(), ' ');
             }
             line += ";; " + func.get_basic_op_at_instr(i)->print(*this);
-            for(int iidx = 0; iidx < instr.n_src; iidx++) {
-              if(instr.get_src(iidx).is_label()) {
+            for (int iidx = 0; iidx < instr.n_src; iidx++) {
+              if (instr.get_src(iidx).is_label()) {
                 auto lab = labels.at(instr.get_src(iidx).get_label());
-                if(is_string(lab.target_segment, lab.offset)) {
+                if (is_string(lab.target_segment, lab.offset)) {
                   line += " " + get_goal_string(lab.target_segment, lab.offset / 4 - 1);
                 }
               }

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -561,6 +561,14 @@ std::string LinkedObjectFile::print_disassembly() {
               line.append(40 - line.length(), ' ');
             }
             line += ";; " + func.get_basic_op_at_instr(i)->print(*this);
+            for(int iidx = 0; iidx < instr.n_src; iidx++) {
+              if(instr.get_src(iidx).is_label()) {
+                auto lab = labels.at(instr.get_src(iidx).get_label());
+                if(is_string(lab.target_segment, lab.offset)) {
+                  line += " " + get_goal_string(lab.target_segment, lab.offset / 4 - 1);
+                }
+              }
+            }
           }
           result += line + "\n";
         }


### PR DESCRIPTION
```
    lw t9, format(s7)                   ;; (set! t9 format)
    daddiu a0, s7, #t                   ;; (set! a0 '#t)
    daddiu a1, fp, L66                  ;; (set! a1 L66) "~Tprocess: ~A~%"
    lwu a2, 4(gp)                       ;; (set! a2 (l.wu (+.i gp 4)))
    jalr ra, t9                         ;; (call!)
    sll v0, ra, 0
```
If an instruction references a string, includes the contents of the string on the comment. 