### PR TITLE
fix float loads, add dgo loading to game test

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -31214,7 +31214,7 @@
 ;;(define-extern vector4ub object) ;; unknown type
 ;;(define-extern vector2w object) ;; unknown type
 ;;(define-extern isphere object) ;; unknown type
-(define-extern vector-dot-vu function)
+(define-extern vector-dot-vu (function vector vector float))
 ;;(define-extern vertical-planes object) ;; unknown type
 ;;(define-extern cylinder object) ;; unknown type
 ;;(define-extern *x-vector* object) ;; unknown type
@@ -31229,7 +31229,7 @@
 ;;(define-extern cylinder-flat object) ;; unknown type
 ;;(define-extern plane object) ;; unknown type
 ;;(define-extern vector3s object) ;; unknown type
-(define-extern vector-dot function)
+(define-extern vector-dot (function vector vector float))
 ;;(define-extern *zero-vector* object) ;; unknown type
 ;;(define-extern vector4h object) ;; unknown type
 ;;(define-extern vector4w object) ;; unknown type
@@ -31240,13 +31240,13 @@
 ;;(define-extern vector4b object) ;; unknown type
 ;;(define-extern vector4w-4 object) ;; unknown type
 ;;(define-extern vertical-planes-array object) ;; unknown type
-(define-extern vector4-dot function)
+(define-extern vector4-dot (function vector vector float))
 ;;(define-extern vector2uh object) ;; unknown type
 ;;(define-extern sphere object) ;; unknown type
 ;;(define-extern vector3h object) ;; unknown type
 ;;(define-extern vector4w-3 object) ;; unknown type
 (define-extern vector+! function)
-(define-extern vector4-dot-vu function)
+(define-extern vector4-dot-vu (function vector vector float))
 ;;(define-extern box8s object) ;; unknown type
 ;;(define-extern vector3w object) ;; unknown type
 (define-extern vector-reset! function)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -44,3 +44,4 @@
 - Creating a field of 128-bit value type no longer causes a compiler crash
 - 128-bit fields are inspected as `<cannot-print>`
 - Static fields can now contain floating point values
+- Fixed a bug where loading a float from an object and immediately using it math would cause a compiler crash

--- a/goal_src/engine/math/vector-h.gc
+++ b/goal_src/engine/math/vector-h.gc
@@ -419,15 +419,46 @@
 
 ;; todo dot, dot-vu, 4-dot, 4-dot-vu, +!, -!, zero!, reset!, copy!
 
-; (defun vector-dot ((a vector) (b vector))
-;   "Take the dot product of two vectors.
-;    Only does the x, y, z compoments"
-;    (let ((result 0.))
-;      (+! result (* (-> a x) (-> b x)))
-;      (+! result (* (-> a y) (-> b y)))
-;      (+! result (* (-> a z) (-> b z)))
-;      )
-;    result
-;    )
+(defun vector-dot ((a vector) (b vector))
+  "Take the dot product of two vectors.
+   Only does the x, y, z compoments.
+   Originally handwritten assembly to space out loads and use FPU accumulator"
+   (declare (inline))
+   (let ((result 0.))
+     (+! result (* (-> a x) (-> b x)))
+     (+! result (* (-> a y) (-> b y)))
+     (+! result (* (-> a z) (-> b z)))
+     result
+     )
+   )
+
+(defun vector-dot-vu ((a vector) (b vector))
+  "Take the dot product of two vectors.
+   Only does the x, y, z components.
+   Originally implemented using VU macro ops"
+   (declare (inline))
+   (vector-dot a b)
+  )
+
+(defun vector4-dot ((a vector) (b vector))
+  "Take the dot product of two vectors.
+   Does the x, y, z, and w compoments"
+   (declare (inline))
+   (let ((result 0.))
+     (+! result (* (-> a x) (-> b x)))
+     (+! result (* (-> a y) (-> b y)))
+     (+! result (* (-> a z) (-> b z)))
+     (+! result (* (-> a w) (-> b w)))
+     result
+     )
+   )
+
+(defun vector-dot-vu ((a vector) (b vector))
+  "Take the dot product of two vectors.
+   Does the x, y, z, and w compoments
+   Originally implemented using VU macro ops"
+   (declare (inline))
+   (vector4-dot a b)
+  )
 
 (define *zero-vector* (new 'static 'vector :x 0. :y 0. :z 0. :w 0.))

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -718,8 +718,14 @@ void IR_LoadConstOffset::do_codegen(emitter::ObjectGenerator* gen,
                                        emitter::gRegInfo.get_offset_reg(), m_offset, m_info.size,
                                        m_info.sign_extend),
                    irec);
+  } else if (m_dest->ireg().kind == emitter::RegKind::XMM && m_info.size == 4 &&
+             m_info.sign_extend == false && m_info.reg == ::RegKind::FLOAT) {
+    gen->add_instr(
+        IGen::load_goal_xmm32(get_reg(m_dest, allocs, irec), get_reg(m_base, allocs, irec),
+                              emitter::gRegInfo.get_offset_reg(), m_offset),
+        irec);
   } else {
-    throw std::runtime_error("IR_LoadConstOffset::do_codegen xmm not supported");
+    throw std::runtime_error("IR_LoadConstOffset::do_codegen not supported");
   }
 }
 

--- a/goalc/compiler/Val.cpp
+++ b/goalc/compiler/Val.cpp
@@ -25,6 +25,7 @@ RegVal* Val::to_xmm(Env* fe) {
   if (rv->ireg().kind == emitter::RegKind::XMM) {
     return rv;
   } else {
+    assert(false);
     throw std::runtime_error("Register is not an XMM[0-15] register.");
   }
 }
@@ -121,6 +122,21 @@ RegVal* MemoryDerefVal::to_reg(Env* fe) {
     return re;
   } else {
     auto re = fe->make_gpr(coerce_to_reg_type(m_ts));
+    auto addr = base->to_gpr(fe);
+    fe->emit(std::make_unique<IR_LoadConstOffset>(re, 0, addr, info));
+    return re;
+  }
+}
+
+RegVal* MemoryDerefVal::to_xmm(Env* fe) {
+  auto base_as_co = dynamic_cast<MemoryOffsetConstantVal*>(base);
+  if (base_as_co) {
+    auto re = fe->make_xmm(coerce_to_reg_type(m_ts));
+    fe->emit(std::make_unique<IR_LoadConstOffset>(re, base_as_co->offset,
+                                                  base_as_co->base->to_gpr(fe), info));
+    return re;
+  } else {
+    auto re = fe->make_xmm(coerce_to_reg_type(m_ts));
     auto addr = base->to_gpr(fe);
     fe->emit(std::make_unique<IR_LoadConstOffset>(re, 0, addr, info));
     return re;

--- a/goalc/compiler/Val.h
+++ b/goalc/compiler/Val.h
@@ -184,6 +184,7 @@ class MemoryDerefVal : public Val {
       : Val(std::move(ts)), base(_base), info(_info) {}
   std::string print() const override { return "[" + base->print() + "]"; }
   RegVal* to_reg(Env* fe) override;
+  RegVal* to_xmm(Env* fe) override;
   Val* base = nullptr;
   MemLoadInfo info;
 };

--- a/test/goalc/source_templates/with_game/test-build-game.gc
+++ b/test/goalc/source_templates/with_game/test-build-game.gc
@@ -1,4 +1,2 @@
 (build-game)
-(dgo-load "kernel" global #xf #x200000) ; todo, remove once kernel loads itself.
-(dgo-load "game" global #xf #x200000)
 1

--- a/test/goalc/source_templates/with_game/test-load-game.gc
+++ b/test/goalc/source_templates/with_game/test-load-game.gc
@@ -1,0 +1,2 @@
+(dgo-load "kernel" global #xf #x200000) ; todo, remove once kernel loads itself.
+(dgo-load "game" global #xf #x200000)

--- a/test/goalc/source_templates/with_game/test-vector-dot.gc
+++ b/test/goalc/source_templates/with_game/test-vector-dot.gc
@@ -1,0 +1,14 @@
+(start-test "vector-dot")
+
+(let ((a (new 'global 'vector))
+      (b (new 'global 'vector)))
+  (set! (-> a x) 1.)
+  (set! (-> a y) 2.)
+  (set! (-> a z) 3.)
+  (set! (-> b x) 2.)
+  (set! (-> b y) 3.)
+  (set! (-> b z) 4.)
+  (expect-true (= 20.0 (vector-dot-vu a b)))
+  )
+
+(finish-test)

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -26,15 +26,15 @@ struct WithGameParam {
 class WithGameTests : public testing::TestWithParam<WithGameParam> {
  public:
   static void SetUpTestSuite() {
+    runtime_thread = std::thread((GoalTest::runtime_with_kernel));
+    runner.c = &compiler;
+
     try {
-      compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-game.gc");
+      compiler.run_test("test/goalc/source_templates/with_game/test-build-game.gc");
     } catch (std::exception& e) {
       fprintf(stderr, "caught exception %s\n", e.what());
       EXPECT_TRUE(false);
     }
-
-    runtime_thread = std::thread((GoalTest::runtime_with_kernel));
-    runner.c = &compiler;
   }
 
   static void TearDownTestSuite() {
@@ -131,6 +131,8 @@ TEST_F(WithGameTests, All) {
                          get_test_pass_string("new-static-structure-integers", 7));
   runner.run_static_test(env, testCategory, "test-new-static-basic.gc",
                          get_test_pass_string("new-static-basic", 9));
+  runner.run_static_test(env, testCategory, "test-vector-dot.gc",
+                         get_test_pass_string("vector-dot", 1));
 }
 
 TEST(TypeConsistency, TypeConsistency) {

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -26,8 +26,11 @@ struct WithGameParam {
 class WithGameTests : public testing::TestWithParam<WithGameParam> {
  public:
   static void SetUpTestSuite() {
+    compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-game.gc");
     runtime_thread = std::thread((GoalTest::runtime_with_kernel));
     runner.c = &compiler;
+
+    compiler.run_test("test/goalc/source_templates/with_game/test-load-game.gc");
 
     try {
       compiler.run_test("test/goalc/source_templates/with_game/test-build-game.gc");


### PR DESCRIPTION
Implement a missing case for loading floats that was causing the compiler to error when compiling `vector-dot`, and add a test for this and some functions from the game which use this.

More importantly, this loads GAME.DGO as part of the game tests, which I forgot to do previously. I think KERNEL was being loaded the first time which is why not everything broke.  But that means we never tested a big DGO load (checks for bugs in DGO IOP state machine code) and reloading the kernel (checks for bugs in kscheme on redefinitions) I really hope this works on windows...