### PR TITLE
Add some debugger memory utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,9 @@ add_subdirectory(third-party/spdlog)
 # build zydis third party library for disassembling x86
 option(ZYDIS_BUILD_TOOLS "" OFF)
 option(ZYDIS_BUILD_EXAMPLES "" OFF)
+option(ZYDIS_BUILD_SHARED_LIB "" ON)
 add_subdirectory("third-party/zydis")
+
 
 # windows memory management lib
 IF (WIN32)

--- a/common/cross_os_debug/xdbg.cpp
+++ b/common/cross_os_debug/xdbg.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file xdbg.cpp
  * Debugging utility library. This hides the platform specific details of the debugger.
+ * Nothing in here should hold state, that should all be managed in Debugger.
  */
 
 #include <cstring>
@@ -44,6 +45,7 @@ std::string ThreadID::to_string() const {
 
 /*!
  * Get the ThreadID of whatever called this function.
+ * The runtime calls this to get the Thread to be debugged.
  */
 ThreadID get_current_thread_id() {
   return ThreadID(syscall(SYS_gettid));
@@ -82,6 +84,12 @@ bool attach_and_break(const ThreadID& tid) {
   }
 }
 
+/*!
+ * Has the given thread transitioned from running to stopped?
+ * If the thread has transitioned to stop, check_stopped should only return true once.
+ * If true, populates out with information about why it stopped.
+ * This shouldn't hang if the thread doesn't stop.
+ */
 bool check_stopped(const ThreadID& tid, SignalInfo* out) {
   int status;
   if (waitpid(tid.id, &status, WNOHANG) < 0) {
@@ -117,6 +125,7 @@ bool check_stopped(const ThreadID& tid, SignalInfo* out) {
 
 /*!
  * Open memory of target. Assumes we are already connected and halted.
+ * If successful returns true and populates out with a "handle" to the memory.
  */
 bool open_memory(const ThreadID& tid, MemoryHandle* out) {
   int fd = open(fmt::format("/proc/{}/mem", tid.id).c_str(), O_RDWR);
@@ -214,8 +223,46 @@ bool get_regs_now(const ThreadID& tid, Regs* out) {
 }
 
 /*!
+ * Set all registers now. Must be attached and stopped
+ */
+bool set_regs_now(const ThreadID& tid, const Regs& out) {
+  user regs = {};
+  if (ptrace(PTRACE_GETREGS, tid.id, nullptr, &regs) < 0) {
+    printf("[Debugger] Failed to PTRACE_GETREGS %s\n", strerror(errno));
+    return false;
+  }
+
+  regs.regs.rax = out.gprs[0];
+  regs.regs.rcx = out.gprs[1];
+  regs.regs.rdx = out.gprs[2];
+  regs.regs.rbx = out.gprs[3];
+  regs.regs.rsp = out.gprs[4];
+  regs.regs.rbp = out.gprs[5];
+  regs.regs.rsi = out.gprs[6];
+  regs.regs.rdi = out.gprs[7];
+  regs.regs.r8 = out.gprs[8];
+  regs.regs.r9 = out.gprs[9];
+  regs.regs.r10 = out.gprs[10];
+  regs.regs.r11 = out.gprs[11];
+  regs.regs.r12 = out.gprs[12];
+  regs.regs.r13 = out.gprs[13];
+  regs.regs.r14 = out.gprs[14];
+  regs.regs.r15 = out.gprs[15];
+  regs.regs.rip = out.rip;
+
+  if (ptrace(PTRACE_SETREGS, tid.id, nullptr, &regs) < 0) {
+    printf("[Debugger] Failed to PTRACE_SETREGS %s\n", strerror(errno));
+    return false;
+  }
+  // todo, set fprs.
+  return true;
+}
+
+/*!
  * Break the given thread.  Must be attached and running.
- * Waits for the given thread to actually stop first.
+ * Does not wait for the thread to stop.
+ * Eventually check_stop should return true with a reason of BREAK, unless the target gets really
+ * lucky and manages to crash before the SIGTRAP reaches the target
  */
 bool break_now(const ThreadID& tid) {
   if (ptrace(PTRACE_INTERRUPT, tid.id, nullptr, nullptr) < 0) {

--- a/common/cross_os_debug/xdbg.cpp
+++ b/common/cross_os_debug/xdbg.cpp
@@ -351,6 +351,10 @@ bool write_goal_memory(const u8* src_buffer,
 bool check_stopped(const ThreadID& tid, SignalInfo* out) {
   return false;
 }
+
+bool set_regs_now(const ThreadID& tid, const Regs& out) {
+  return false;
+}
 #endif
 
 const char* gpr_names[] = {"rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi",

--- a/common/cross_os_debug/xdbg.h
+++ b/common/cross_os_debug/xdbg.h
@@ -19,6 +19,9 @@
 namespace xdbg {
 #ifdef __linux
 
+/*!
+ * Identification for a thread.
+ */
 struct ThreadID {
   pid_t id = 0;
 
@@ -28,6 +31,9 @@ struct ThreadID {
   ThreadID() = default;
 };
 
+/*!
+ * Handle for the memory of a process.
+ */
 struct MemoryHandle {
   int fd;
 };
@@ -45,12 +51,18 @@ struct MemoryHandle {
 };
 #endif
 
+/*!
+ * The info required to debug the target.
+ */
 struct DebugContext {
-  ThreadID tid;
-  uintptr_t base;
-  uint32_t s7;
+  ThreadID tid;    //! The target's GOAL thread
+  uintptr_t base;  //! The base address for the GOAL memory
+  uint32_t s7;     //! The value of s7 (GOAL address)
 };
 
+/*!
+ * The x86-64 registers, including rip.
+ */
 struct Regs {
   u64 gprs[16];
   u128 xmms[16];
@@ -63,6 +75,9 @@ struct Regs {
   std::string print_xmms_as_flt_vec() const;
 };
 
+/*!
+ * Information about why the target has stopped.
+ */
 struct SignalInfo {
   enum Kind {
     SEGFAULT,        // access bad memory
@@ -78,6 +93,7 @@ bool attach_and_break(const ThreadID& tid);
 void allow_debugging();
 bool detach_and_resume(const ThreadID& tid);
 bool get_regs_now(const ThreadID& tid, Regs* out);
+bool set_regs_now(const ThreadID& tid, const Regs& in);
 bool break_now(const ThreadID& tid);
 bool cont_now(const ThreadID& tid);
 bool open_memory(const ThreadID& tid, MemoryHandle* out);

--- a/common/cross_os_debug/xdbg.h
+++ b/common/cross_os_debug/xdbg.h
@@ -63,6 +63,15 @@ struct Regs {
   std::string print_xmms_as_flt_vec() const;
 };
 
+struct SignalInfo {
+  enum Kind {
+    SEGFAULT,        // access bad memory
+    BREAK,           // hit a breakpoint or execute int3
+    MATH_EXCEPTION,  // divide by zero
+    UNKNOWN          // some other signal that is unsupported
+  } kind = UNKNOWN;
+};
+
 // Functions
 ThreadID get_current_thread_id();
 bool attach_and_break(const ThreadID& tid);
@@ -92,5 +101,7 @@ bool write_goal_value(T& value,
                       const MemoryHandle& handle) {
   return write_goal_memory(&value, sizeof(value), goal_addr, context, handle);
 }
+
+bool check_stopped(const ThreadID& tid, SignalInfo* out);
 
 }  // namespace xdbg

--- a/common/goal_constants.h
+++ b/common/goal_constants.h
@@ -11,6 +11,9 @@ constexpr int POINTER_SIZE = 4;
 constexpr int BASIC_OFFSET = 4;
 constexpr int STRUCTURE_ALIGNMENT = 16;
 
+constexpr s32 GOAL_MAX_SYMBOLS = 0x2000;
+constexpr s32 SYM_INFO_OFFSET = 0xff34;
+
 enum class RegKind { GPR_64, FLOAT, INT_128, FLOAT_4X, INVALID };
 
 constexpr u32 GOAL_NEW_METHOD = 0;       // method ID of GOAL new

--- a/doc/goal_dbg_doc.md
+++ b/doc/goal_dbg_doc.md
@@ -51,3 +51,172 @@ Dump all GOAL memory to a file. Must be stopped.
 The path is relative to the Jak project folder.
 
 The file will be the exact size of `EE_MAIN_MEM_SIZE`, but the first `EE_LOW_MEM_PROTECT` bytes are zero, as these cannot be written or read.
+
+## Address Spec
+Anywhere an address can be used, you can also use an "address spec", which gives you easier ways to input addresses. For now, the address spec is pretty simple, but there will be more features in the future.
+
+- `(sym-val <sym-name>)`. Get the address stored in the symbol with the given name. Currently there's no check to see if the symbol actually stores an address or not. This is like "evaluate `<sym-name>`, then treat the value as an address"
+- `(sym <sym-name>)`. Get the address of the symbol object itself, including the basic offet.
+
+Example to show the difference:
+```lisp
+
+;; the symbol is at 0x142d1c
+gc> (inspect '*kernel-context*)
+[  142d1c] symbol
+	name: *kernel-context*
+	hash: #x8f9a35ff
+	value: #<kernel-context @ #x164a84>
+1322268
+
+;; the object is at 0x164a84
+gc> (inspect *kernel-context*)
+[00164a84] kernel-context
+	prevent-from-run: 65
+	require-for-run: 0
+	allow-to-run: 0
+	next-pid: 2
+	fast-stack-top: 1879064576
+	current-process: #f
+	relocating-process: #f
+	relocating-min: 0
+	relocating-max: 0
+	relocating-offset: 0
+	low-memory-message: #t
+1460868
+
+;; break, so we can debug
+gc> (:break)
+Read symbol table (159872 bytes, 226 reads, 225 symbols, 1.96 ms)
+rax: 0xfffffffffffffdfc rcx: 0x00007f745b508361 rdx: 0x00007f745b3ffca0 rbx: 0x0000000000147d24 
+rsp: 0x00007f745b3ffc40 rbp: 0x00007f745b3ffcc0 rsi: 0x0000000000000000 rdi: 0x0000000000000000 
+ r8: 0x0000000000000000  r9: 0x0000000000000008 r10: 0x00007f745b3ffca0 r11: 0x0000000000000293 
+r12: 0x0000000000147d24 r13: 0x00007ffdff32cfaf r14: 0x00007ffdff32cfb0 r15: 0x00007f745b3fffc0 
+rip: 0x00007f745b508361
+
+;; reads the symbol's memory:
+;; at 0x142d1c there is the value 0x164a84
+gc> (dw (sym *kernel-context*) 1)
+ 0x00142d1c: 0x00164a84 
+
+;; treat the symbol's value as an address and read the memory there.
+;; notice that the 0x41 in the first word is decimal 65, the first field of the kernel-context.
+gc> (dw (sym-val *kernel-context*) 10)
+ 0x00164a84: 0x00000041 0x00000000 0x00000000 0x00000002 
+ 0x00164a94: 0x70004000 0x00147d24 0x00147d24 0x00000000 
+ 0x00164aa4: 0x00000000 0x00000000 
+```
+
+
+## `(:pm)`
+Print memory
+
+```
+(:pm elt-size addr elt-count [:print-mode mode])
+```
+
+The element size is the size of each word to print. It can be 1, 2, 4, 8 currently.  The address is the GOAL Address to print at. The elt-count is the number of words to print.  The print mode is option and defaults to `hex`. There is also an `unsigned-decimal`, a `signed-decimal`, and `float`. The `float` mode only works when `elt-size` is 4.
+
+There are some useful macros inspired by the original PS2 TOOL debugger (`dsedb`) for the different sizes. They are `db`, `dh`, `dw`, and `dd` for 1, 2, 4, and 8 byte hex prints which follows the naming convention of MIPS load/stores. There is also a `df` for printing floats. See the example below.
+
+
+```lisp
+OpenGOAL Compiler 0.1
+
+;; first connect the listener
+g> (lt)
+[Listener] Socket connected established! (took 0 tries). Waiting for version...
+Got version 0.1 OK!
+[OUTPUT] reset #x147d24 #x2000000000 53371
+
+[Debugger] Context: valid = true, s7 = 0x147d24, base = 0x2000000000, tid = 53371
+
+;; define a new array of floats, and set a few values
+gc> (define x (new 'global 'array 'float 12))
+1452224
+
+gc> (set! (-> x 0) 1.0)
+1065353216
+
+gc> (set! (-> x 2) 2.0)
+1073741824
+
+;; attach the debugger (halts the target)
+gc> (dbg)
+[Debugger] PTRACE_ATTACHED! Waiting for process to stop...
+rax: 0xfffffffffffffdfc rcx: 0x00007f6b94964361 rdx: 0x00007f6b8fffeca0 rbx: 0x0000000000147d24 
+rsp: 0x00007f6b8fffec40 rbp: 0x00007f6b8fffecc0 rsi: 0x0000000000000000 rdi: 0x0000000000000000 
+ r8: 0x0000000000000000  r9: 0x000000000000000b r10: 0x00007f6b8fffeca0 r11: 0x0000000000000293 
+r12: 0x0000000000147d24 r13: 0x00007ffd16fb117f r14: 0x00007ffd16fb1180 r15: 0x00007f6b8fffefc0 
+rip: 0x00007f6b94964361
+Debugger connected.
+
+;; print memory as 10 bytes
+gc> (db 1452224 10)
+ 0x001628c0: 0x00 0x00 0x80 0x3f 0x00 0x00 0x00 0x00 0x00 0x00 
+
+;; print memory as 10 words (32-bit words)
+gc> (dw 1452224 10)
+ 0x001628c0: 0x3f800000 0x00000000 0x40000000 0x00000000 
+ 0x001628d0: 0x00000000 0x00000000 0x00000000 0x00000000 
+ 0x001628e0: 0x00000000 0x00000000 
+
+;; print memory as 10 floats
+gc> (df 1452224 10)
+ 0x001628c0:   1.0000   0.0000   2.0000   0.0000 
+ 0x001628d0:   0.0000   0.0000   0.0000   0.0000 
+ 0x001628e0:   0.0000   0.0000 
+
+;; set some more values, must unbreak first
+gc> (:cont)
+gc> (set! (-> x 1) (the-as float -12))
+-12
+
+;; break and print as decimal
+gc> (:break)
+rax: 0xfffffffffffffdfc rcx: 0x00007f6b94964361 rdx: 0x00007f6b8fffeca0 rbx: 0x0000000000147d24 
+rsp: 0x00007f6b8fffec40 rbp: 0x00007f6b8fffecc0 rsi: 0x0000000000000000 rdi: 0x0000000000000000 
+ r8: 0x0000000000000000  r9: 0x0000000000000004 r10: 0x00007f6b8fffeca0 r11: 0x0000000000000293 
+r12: 0x0000000000147d24 r13: 0x00007ffd16fb117f r14: 0x00007ffd16fb1180 r15: 0x00007f6b8fffefc0 
+rip: 0x00007f6b94964361
+gc> (:pm 4 1452224 10 :print-mode unsigned-dec)
+ 0x001628c0:   1065353216   4294967284   1073741824            0 
+ 0x001628d0:            0            0            0            0 
+ 0x001628e0:            0            0 
+gc> (:pm 4 1452224 10 :print-mode signed-dec)
+ 0x001628c0:   1065353216          -12   1073741824            0 
+ 0x001628d0:            0            0            0            0 
+ 0x001628e0:            0            0 
+```
+
+
+## `(:di)`
+Disassembly instructions in memory
+
+```
+(:di addr len)
+```
+
+Example (after doing a `(lt)`, `(blg)`, `(dbg)`):
+```asm
+gc> (:di (sym-val basic-type?) 80)
+[0x2000162ae4] mov eax, [r15+rdi*1-0x04]
+[0x2000162ae9] mov ecx, [r15+r14*1+0x38]
+[0x2000162af1] mov rdx, rax
+[0x2000162af4] cmp rdx, rsi
+[0x2000162af7] jnz 0x0000002000162B0F
+[0x2000162afd] mov eax, [r15+r14*1+0x08]
+[0x2000162b05] jmp 0x0000002000162B32
+[0x2000162b0a] jmp 0x0000002000162B19
+[0x2000162b0f] mov rax, r14
+[0x2000162b12] add rax, 0x00
+[0x2000162b19] mov eax, [r15+rdx*1+0x04]
+[0x2000162b1e] mov rdx, rax
+[0x2000162b21] cmp rax, rcx
+[0x2000162b24] jnz 0x0000002000162AF4
+[0x2000162b2a] mov eax, [r15+r14*1]
+[0x2000162b32] ret
+
+```
+
+For now, the disassembly is pretty basic, but it should eventually support GOAL symbols.

--- a/game/kernel/kmalloc.cpp
+++ b/game/kernel/kmalloc.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+#include "common/goal_constants.h"
 #include "kmalloc.h"
 #include "kprint.h"
 #include "kscheme.h"

--- a/game/kernel/kscheme.cpp
+++ b/game/kernel/kscheme.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include "kscheme.h"
 #include "common/common_types.h"
+#include "common/goal_constants.h"
 #include "kmachine.h"
 #include "klisten.h"
 #include "kmalloc.h"

--- a/game/kernel/kscheme.h
+++ b/game/kernel/kscheme.h
@@ -9,6 +9,7 @@
 #define JAK_KSCHEME_H
 
 #include "common/common_types.h"
+#include "common/goal_constants.h"
 #include "kmachine.h"
 #include "kmalloc.h"
 
@@ -19,9 +20,6 @@ extern Ptr<u32> s7;
 extern Ptr<u32> SymbolTable2;
 extern Ptr<u32> LastSymbol;
 
-constexpr s32 GOAL_MAX_SYMBOLS = 0x2000;
-
-constexpr s32 SYM_INFO_OFFSET = 0xff34;
 constexpr u32 EMPTY_HASH = 0x8454B6E6;
 constexpr u32 OFFSET_MASK = 7;
 constexpr u32 CRC_POLY = 0x04c11db7;

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -126,6 +126,14 @@
   `(:pm 4 ,@args :print-mode float)
   )
 
+(defmacro segfault ()
+  `(-> (the (pointer int) 0))
+  )
+
+(defmacro fpe ()
+  `(/ 0 0)
+  )
+
 ;;;;;;;;;;;;;;;;;;;
 ;; GOAL Syntax
 ;;;;;;;;;;;;;;;;;;;

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -102,6 +102,29 @@
     )
   )
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; DEBUGGER MACROS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmacro db (&rest args)
+  `(:pm 1 ,@args)
+  )
+
+(defmacro dh (&rest args)
+  `(:pm 2 ,@args)
+  )
+
+(defmacro dw (&rest args)
+  `(:pm 4 ,@args)
+  )
+
+(defmacro dd (&rest args)
+  `(:pm 8 ,@args)
+  )
+
+(defmacro df (&rest args)
+  `(:pm 4 ,@args :print-mode float)
+  )
 
 ;;;;;;;;;;;;;;;;;;;
 ;; GOAL Syntax

--- a/goalc/CMakeLists.txt
+++ b/goalc/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(compiler
         emitter/ObjectFileData.cpp
         emitter/ObjectGenerator.cpp
         emitter/Register.cpp
+        emitter/disassemble.cpp
         compiler/Compiler.cpp
         compiler/Env.cpp
         compiler/Val.cpp
@@ -35,10 +36,10 @@ add_library(compiler
 add_executable(goalc main.cpp)
 
 IF (WIN32)
-    target_link_libraries(compiler goos type_system mman common_util spdlog cross_os_debug cross_sockets)
+    target_link_libraries(compiler goos type_system mman common_util spdlog cross_os_debug cross_sockets Zydis)
 
 ELSE ()
-    target_link_libraries(compiler goos type_system common_util spdlog cross_os_debug cross_sockets)
+    target_link_libraries(compiler goos type_system common_util spdlog cross_os_debug cross_sockets Zydis)
 ENDIF ()
 
 target_link_libraries(goalc goos compiler type_system)

--- a/goalc/compiler/Compiler.cpp
+++ b/goalc/compiler/Compiler.cpp
@@ -26,12 +26,21 @@ void Compiler::execute_repl() {
   while (!m_want_exit) {
     try {
       // 1). get a line from the user (READ)
-      std::string prompt;
+      std::string prompt = "g";
       if (m_listener.is_connected()) {
-        prompt = "gc";
+        prompt += "c";
       } else {
-        prompt = "g";
+        prompt += " ";
       }
+
+      if (m_debugger.is_halted()) {
+        prompt += "s";
+      } else if (m_debugger.is_attached()) {
+        prompt += "r";
+      } else {
+        prompt += " ";
+      }
+
       Object code = m_goos.reader.read_from_stdin(prompt);
 
       // 2). compile
@@ -246,6 +255,10 @@ std::vector<std::string> Compiler::run_test_no_load(const std::string& source_co
 }
 
 void Compiler::shutdown_target() {
+  if (m_debugger.is_attached()) {
+    m_debugger.detach();
+  }
+
   if (m_listener.is_connected()) {
     m_listener.send_reset(true);
   }

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -198,6 +198,9 @@ class Compiler {
   Val* compile_dump_all(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_pm(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_di(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_disasm(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_bp(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_ubp(const goos::Object& form, const goos::Object& rest, Env* env);
   u32 parse_address_spec(const goos::Object& form);
 
   // Macro

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -196,6 +196,9 @@ class Compiler {
   Val* compile_break(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_cont(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_dump_all(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_pm(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_di(const goos::Object& form, const goos::Object& rest, Env* env);
+  u32 parse_address_spec(const goos::Object& form);
 
   // Macro
   Val* compile_gscond(const goos::Object& form, const goos::Object& rest, Env* env);

--- a/goalc/compiler/compilation/Atoms.cpp
+++ b/goalc/compiler/compilation/Atoms.cpp
@@ -60,6 +60,9 @@ static const std::unordered_map<
         {":dump-all-mem", &Compiler::compile_dump_all},
         {":pm", &Compiler::compile_pm},
         {":di", &Compiler::compile_di},
+        {":disasm", &Compiler::compile_disasm},
+        {":bp", &Compiler::compile_bp},
+        {":ubp", &Compiler::compile_ubp},
 
         // TYPE
         {"deftype", &Compiler::compile_deftype},

--- a/goalc/compiler/compilation/Atoms.cpp
+++ b/goalc/compiler/compilation/Atoms.cpp
@@ -58,6 +58,8 @@ static const std::unordered_map<
         {":cont", &Compiler::compile_cont},
         {":break", &Compiler::compile_break},
         {":dump-all-mem", &Compiler::compile_dump_all},
+        {":pm", &Compiler::compile_pm},
+        {":di", &Compiler::compile_di},
 
         // TYPE
         {"deftype", &Compiler::compile_deftype},

--- a/goalc/compiler/compilation/CompilerControl.cpp
+++ b/goalc/compiler/compilation/CompilerControl.cpp
@@ -17,6 +17,11 @@ Val* Compiler::compile_exit(const goos::Object& form, const goos::Object& rest, 
   (void)env;
   auto args = get_va(form, rest);
   va_check(form, args, {}, {});
+
+  if (m_debugger.is_attached()) {
+    m_debugger.detach();
+  }
+
   if (m_listener.is_connected()) {
     m_listener.send_reset(false);
   }

--- a/goalc/compiler/compilation/Debug.cpp
+++ b/goalc/compiler/compilation/Debug.cpp
@@ -308,7 +308,7 @@ Val* Compiler::compile_di(const goos::Object& form, const goos::Object& rest, En
         "Cannot get debug info, the debugger must be connected and the target must be halted.");
   }
 
-  m_debugger.read_symbols_and_regs();
+  m_debugger.get_break_info();
   return get_none();
 }
 

--- a/goalc/compiler/compilation/Debug.cpp
+++ b/goalc/compiler/compilation/Debug.cpp
@@ -1,6 +1,49 @@
 #include "goalc/compiler/Compiler.h"
+#include "goalc/emitter/disassemble.h"
 #include "common/util/FileUtil.h"
 #include "third-party/fmt/core.h"
+
+u32 Compiler::parse_address_spec(const goos::Object& form) {
+  if (form.is_int()) {
+    return form.as_int();
+  }
+
+  if (form.is_pair()) {
+    auto first = form.as_pair()->car;
+    auto rest = form.as_pair()->cdr;
+    if (first.is_symbol() && symbol_string(first) == "sym") {
+      if (rest.is_pair() && rest.as_pair()->car.is_symbol()) {
+        u32 addr = m_debugger.get_symbol_address(symbol_string(rest.as_pair()->car));
+        if (!addr) {
+          throw_compile_error(form, "debugger doesn't know where the symbol is");
+        }
+        return addr;
+      } else {
+        throw_compile_error(form, "invalid sym form");
+        return 0;
+      }
+    } else if (first.is_symbol() && symbol_string(first) == "sym-val") {
+      if (rest.is_pair() && rest.as_pair()->car.is_symbol()) {
+        u32 addr = 0;
+        if (!m_debugger.get_symbol_value(symbol_string(rest.as_pair()->car), &addr)) {
+          throw_compile_error(form, "debugger doesn't know where the symbol is");
+        }
+        return addr;
+      } else {
+        throw_compile_error(form, "invalid sym-val form");
+        return 0;
+      }
+    }
+
+    else {
+      throw_compile_error(form, "can't parse this address spec");
+      return 0;
+    }
+  } else {
+    throw_compile_error(form, "can't parse this address spec");
+    return 0;
+  }
+}
 
 Val* Compiler::compile_dbg(const goos::Object& form, const goos::Object& rest, Env* env) {
   // todo - do something with args.
@@ -104,5 +147,187 @@ Val* Compiler::compile_dump_all(const goos::Object& form, const goos::Object& re
   } else {
     file_util::write_binary_file(file_util::get_file_path({dest_file}), buffer, EE_MAIN_MEM_SIZE);
   }
+  return get_none();
+}
+
+namespace {
+
+enum PrintMode { HEX, UNSIGNED_DEC, SIGNED_DEC, FLOAT };
+
+template <typename T>
+void mem_print(T* data, int count, u32 start_addr, PrintMode mode) {
+  // always print 16 bytes / line.
+  int elt_per_line = 16 / sizeof(T);
+
+  // pad wit the correct number of zeros.
+  std::string format_string;
+
+  switch (mode) {
+    case HEX:
+      format_string = "0x{:0" + std::to_string(2 * sizeof(T)) + "x} ";
+      break;
+    case UNSIGNED_DEC:
+    case SIGNED_DEC:
+      format_string = "{:" + std::to_string(3 * sizeof(T)) + "d} ";
+      break;
+    case FLOAT:
+      format_string = "{:8.4f} ";  // todo, is this what we want?
+      break;
+    default:
+      assert(false);
+  }
+
+  // loop over elts
+  for (int i = 0; i < count; i++) {
+    if ((i % elt_per_line) == 0) {
+      // first in line, so we should print the GOAL address
+      fmt::print(" 0x{:08x}: ", start_addr + (i * sizeof(T)));
+    }
+
+    // print the thing
+    fmt::print(format_string, data[i]);
+
+    if ((i % elt_per_line) == (elt_per_line - 1)) {
+      // last in line, newline!
+      fmt::print("\n");
+    }
+  }
+  fmt::print("\n");
+}
+}  // namespace
+
+Val* Compiler::compile_pm(const goos::Object& form, const goos::Object& rest, Env* env) {
+  (void)env;
+  auto args = get_va(form, rest);
+  va_check(form, args, {goos::ObjectType::INTEGER, {}, goos::ObjectType::INTEGER},
+           {{"print-mode", {false, goos::ObjectType::SYMBOL}}});
+
+  int elt_size = args.unnamed.at(0).as_int();
+  u32 addr = parse_address_spec(args.unnamed.at(1));
+  u32 elts = args.unnamed.at(2).as_int();
+
+  PrintMode mode = HEX;
+
+  if (args.has_named("print-mode")) {
+    auto mode_name = symbol_string(args.get_named("print-mode"));
+    if (mode_name == "hex") {
+      mode = HEX;
+    } else if (mode_name == "unsigned-dec") {
+      mode = UNSIGNED_DEC;
+    } else if (mode_name == "signed-dec") {
+      mode = SIGNED_DEC;
+    } else if (mode_name == "float") {
+      mode = FLOAT;
+    } else {
+      throw_compile_error(form, "Unknown print-mode for :pm " + mode_name);
+    }
+  }
+
+  if (!m_debugger.is_halted()) {
+    throw_compile_error(
+        form, "Cannot print memory, the debugger must be connected and the target must be halted.");
+  }
+
+  auto mem_size = elts * elt_size;
+  if (mem_size > 1024 * 1024) {
+    throw_compile_error(
+        form,
+        fmt::format(":pm used on over 1 MB of memory, this probably isn't what you meant to do."));
+  }
+
+  std::vector<u8> mem;
+  mem.resize(mem_size);
+
+  if (addr < EE_MAIN_MEM_LOW_PROTECT || (addr + mem_size) > EE_MAIN_MEM_SIZE) {
+    throw_compile_error(form, ":pm memory out of range");
+  }
+
+  m_debugger.read_memory(mem.data(), mem_size, addr);
+
+  switch (mode) {
+    case HEX:
+    case UNSIGNED_DEC:
+      switch (elt_size) {
+        case 1:
+          mem_print((u8*)mem.data(), elts, addr, mode);
+          break;
+        case 2:
+          mem_print((u16*)mem.data(), elts, addr, mode);
+          break;
+        case 4:
+          mem_print((u32*)mem.data(), elts, addr, mode);
+          break;
+        case 8:
+          mem_print((u64*)mem.data(), elts, addr, mode);
+          break;
+        default:
+          throw_compile_error(form, ":pm bad element size");
+      }
+      break;
+    case SIGNED_DEC:
+      switch (elt_size) {
+        case 1:
+          mem_print((s8*)mem.data(), elts, addr, mode);
+          break;
+        case 2:
+          mem_print((s16*)mem.data(), elts, addr, mode);
+          break;
+        case 4:
+          mem_print((s32*)mem.data(), elts, addr, mode);
+          break;
+        case 8:
+          mem_print((s64*)mem.data(), elts, addr, mode);
+          break;
+        default:
+          throw_compile_error(form, ":pm bad element size");
+      }
+      break;
+    case FLOAT:
+      switch (elt_size) {
+        case 4:
+          mem_print((float*)mem.data(), elts, addr, mode);
+          break;
+        default:
+          throw_compile_error(form, ":pm bad element size");
+      }
+      break;
+    default:
+      assert(false);
+  }
+
+  return get_none();
+}
+
+Val* Compiler::compile_di(const goos::Object& form, const goos::Object& rest, Env* env) {
+  (void)env;
+  auto args = get_va(form, rest);
+  va_check(form, args, {{}, goos::ObjectType::INTEGER}, {});
+  u32 addr = parse_address_spec(args.unnamed.at(0));
+  u32 size = args.unnamed.at(1).as_int();
+
+  if (!m_debugger.is_halted()) {
+    throw_compile_error(
+        form,
+        "Cannot disassemble memory, the debugger must be connected and the target must be halted.");
+  }
+
+  if (size > 1024 * 1024) {
+    throw_compile_error(
+        form,
+        fmt::format(":di used on over 1 MB of memory, this probably isn't what you meant to do."));
+  }
+
+  std::vector<u8> mem;
+  mem.resize(size);
+
+  if (addr < EE_MAIN_MEM_LOW_PROTECT || (addr + size) > EE_MAIN_MEM_SIZE) {
+    throw_compile_error(form, ":di memory out of range");
+  }
+
+  m_debugger.read_memory(mem.data(), size, addr);
+
+  fmt::print("{}\n",
+             disassemble_x86(mem.data(), mem.size(), m_debugger.get_x86_base_addr() + addr));
+
   return get_none();
 }

--- a/goalc/debugger/Debugger.h
+++ b/goalc/debugger/Debugger.h
@@ -6,12 +6,17 @@
 #pragma once
 
 #include <unordered_map>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
 #include "common/common_types.h"
 #include "common/cross_os_debug/xdbg.h"
 
 class Debugger {
  public:
   Debugger() = default;
+  ~Debugger();
   bool is_halted() const;  // are we halted?
   bool is_valid() const;
   bool is_attached() const;
@@ -23,6 +28,11 @@ class Debugger {
   u64 get_x86_base_addr() const {
     assert(m_context_valid);
     return m_debug_context.base;
+  }
+
+  const xdbg::ThreadID& get_thread_id() {
+    assert(m_context_valid);
+    return m_debug_context.tid;
   }
 
   bool attach_and_break();
@@ -48,12 +58,54 @@ class Debugger {
   u32 get_symbol_address(const std::string& sym_name);
   bool get_symbol_value(const std::string& sym_name, u32* output);
 
+  bool regs_valid() const { return m_regs_valid; }
+
+  void add_addr_breakpoint(u32 addr);
+  void remove_addr_breakpoint(u32 addr);
+
+  void read_symbols_and_regs();
+
  private:
+  static constexpr int INSTR_DUMP_SIZE_REV = 32;
+  static constexpr int INSTR_DUMP_SIZE_FWD = 64;
   std::unordered_map<std::string, s32> m_symbol_name_to_offset_map;
   std::unordered_map<std::string, u32> m_symbol_name_to_value_map;
   std::unordered_map<s32, std::string> m_symbol_offset_to_name_map;
   xdbg::DebugContext m_debug_context;
   xdbg::MemoryHandle m_memory_handle;
+  xdbg::Regs m_regs_at_break;
+
+  bool m_watcher_should_stop = false;
+  bool m_watcher_running = false;
+  bool m_regs_valid = false;
+
+  void start_watcher();
+  void stop_watcher();
+
+  void watcher();
+
+  struct SignalInfo {
+    xdbg::SignalInfo::Kind kind;
+  };
+
+  struct Breakpoint {
+    u32 goal_addr = 0;
+    int id = -1;
+    u8 old_data = 0;
+  };
+
+  std::unordered_map<u32, Breakpoint> m_addr_breakpoints;
+
+  std::queue<SignalInfo> m_watcher_queue;
+  std::mutex m_watcher_mutex;
+  std::condition_variable m_watcher_cv;
+  std::thread m_watcher_thread;
+
+  bool try_pop_signal(SignalInfo* out);
+  SignalInfo pop_signal();
+  int get_signal_count();
+  void clear_signal_queue();
+
   bool m_context_valid = false;
   bool m_running = true;
   bool m_attached = false;

--- a/goalc/debugger/Debugger.h
+++ b/goalc/debugger/Debugger.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include "common/common_types.h"
 #include "common/cross_os_debug/xdbg.h"
 
@@ -19,6 +20,10 @@ class Debugger {
   void invalidate();
   void set_context(u32 s7, uintptr_t base, const std::string& thread_id);
   std::string get_context_string() const;
+  u64 get_x86_base_addr() const {
+    assert(m_context_valid);
+    return m_debug_context.base;
+  }
 
   bool attach_and_break();
 
@@ -38,7 +43,15 @@ class Debugger {
     return read_memory((u8*)value, sizeof(T), goal_addr);
   }
 
+  void read_symbol_table();
+
+  u32 get_symbol_address(const std::string& sym_name);
+  bool get_symbol_value(const std::string& sym_name, u32* output);
+
  private:
+  std::unordered_map<std::string, s32> m_symbol_name_to_offset_map;
+  std::unordered_map<std::string, u32> m_symbol_name_to_value_map;
+  std::unordered_map<s32, std::string> m_symbol_offset_to_name_map;
   xdbg::DebugContext m_debug_context;
   xdbg::MemoryHandle m_memory_handle;
   bool m_context_valid = false;

--- a/goalc/debugger/Debugger.h
+++ b/goalc/debugger/Debugger.h
@@ -1,6 +1,7 @@
 /*!
  * @file Debugger.h
  * The OpenGOAL debugger.
+ * Uses xdbg functions to debug an OpenGOAL target.
  */
 
 #pragma once
@@ -17,7 +18,7 @@ class Debugger {
  public:
   Debugger() = default;
   ~Debugger();
-  bool is_halted() const;  // are we halted?
+  bool is_halted() const;
   bool is_valid() const;
   bool is_attached() const;
   bool is_running() const;
@@ -25,52 +26,71 @@ class Debugger {
   void invalidate();
   void set_context(u32 s7, uintptr_t base, const std::string& thread_id);
   std::string get_context_string() const;
+  bool attach_and_break();
+  bool do_break();
+  bool do_continue();
+  bool read_memory(u8* dest_buffer, int size, u32 goal_addr);
+  bool write_memory(const u8* src_buffer, int size, u32 goal_addr);
+  void read_symbol_table();
+  u32 get_symbol_address(const std::string& sym_name);
+  bool get_symbol_value(const std::string& sym_name, u32* output);
+  void add_addr_breakpoint(u32 addr);
+  void remove_addr_breakpoint(u32 addr);
+  void get_break_info();
+
+  /*!
+   * Get the x86 address of GOAL memory
+   */
   u64 get_x86_base_addr() const {
     assert(m_context_valid);
     return m_debug_context.base;
   }
 
-  const xdbg::ThreadID& get_thread_id() {
+  /*!
+   * Get the thread being debugged.
+   */
+  const xdbg::ThreadID& get_thread_id() const {
     assert(m_context_valid);
     return m_debug_context.tid;
   }
 
-  bool attach_and_break();
+  /*!
+   * Are the register values currently stored by the debugger currently accurate?
+   */
+  bool regs_valid() const { return m_regs_valid; }
 
-  bool do_break();
-  bool do_continue();
-
-  bool read_memory(u8* dest_buffer, int size, u32 goal_addr);
-  bool write_memory(const u8* src_buffer, int size, u32 goal_addr);
-
+  /*!
+   * Write a value to GOAL memory
+   */
   template <typename T>
   bool write_value(const T& value, u32 goal_addr) {
     return write_memory((const u8*)&value, sizeof(T), goal_addr);
   }
 
+  /*!
+   * Read a value from GOAL memory
+   */
   template <typename T>
   bool read_value(T* value, u32 goal_addr) {
     return read_memory((u8*)value, sizeof(T), goal_addr);
   }
 
-  void read_symbol_table();
-
-  u32 get_symbol_address(const std::string& sym_name);
-  bool get_symbol_value(const std::string& sym_name, u32* output);
-
-  bool regs_valid() const { return m_regs_valid; }
-
-  void add_addr_breakpoint(u32 addr);
-  void remove_addr_breakpoint(u32 addr);
-
-  void read_symbols_and_regs();
+  const xdbg::Regs& get_regs() {
+    assert(m_regs_valid);
+    return m_regs_at_break;
+  }
 
  private:
+  // how many bytes of instructions to look at ahead of / behind rip when stopping
   static constexpr int INSTR_DUMP_SIZE_REV = 32;
   static constexpr int INSTR_DUMP_SIZE_FWD = 64;
+
+  // symbol table info (all s7-relative offsets)
   std::unordered_map<std::string, s32> m_symbol_name_to_offset_map;
   std::unordered_map<std::string, u32> m_symbol_name_to_value_map;
   std::unordered_map<s32, std::string> m_symbol_offset_to_name_map;
+
+  // debug state
   xdbg::DebugContext m_debug_context;
   xdbg::MemoryHandle m_memory_handle;
   xdbg::Regs m_regs_at_break;
@@ -81,26 +101,34 @@ class Debugger {
 
   void start_watcher();
   void stop_watcher();
-
   void watcher();
-
-  struct SignalInfo {
-    xdbg::SignalInfo::Kind kind;
-  };
+  void update_continue_info();
 
   struct Breakpoint {
-    u32 goal_addr = 0;
-    int id = -1;
-    u8 old_data = 0;
+    u32 goal_addr = 0;  // address to break at
+    int id = -1;        // breakpoint ID
+    u8 old_data = 0;    // byte originally stored at goal_addr
   };
+
+  bool m_expecting_immeidate_break = false;
 
   std::unordered_map<u32, Breakpoint> m_addr_breakpoints;
 
-  std::queue<SignalInfo> m_watcher_queue;
   std::mutex m_watcher_mutex;
   std::condition_variable m_watcher_cv;
   std::thread m_watcher_thread;
 
+  struct ContinueInfo {
+    bool subtract_1 = false;
+    bool valid = false;
+  } m_continue_info;
+
+  // for more complicated breakpoint stuff, we have a queue of stops.
+  // right now it's barely used for anything other than waiting for a "break" to be acknowledged.
+  struct SignalInfo {
+    xdbg::SignalInfo::Kind kind;
+  };
+  std::queue<SignalInfo> m_watcher_queue;
   bool try_pop_signal(SignalInfo* out);
   SignalInfo pop_signal();
   int get_signal_count();

--- a/goalc/emitter/disassemble.cpp
+++ b/goalc/emitter/disassemble.cpp
@@ -1,0 +1,27 @@
+#include "disassemble.h"
+#include "Zydis/Zydis.h"
+#include "third-party/fmt/core.h"
+
+std::string disassemble_x86(u8* data, int len, u64 base_addr) {
+  std::string result;
+  ZydisDecoder decoder;
+  ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64);
+  ZydisFormatter formatter;
+  ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);
+  ZydisDecodedInstruction instr;
+
+  constexpr int print_buff_size = 512;
+  char print_buff[print_buff_size];
+  int offset = 0;
+  while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, data + offset, len - offset, &instr))) {
+    result += fmt::format("[0x{:x}] ", base_addr);
+    ZydisFormatterFormatInstruction(&formatter, &instr, print_buff, print_buff_size, base_addr);
+    result += print_buff;
+    result += "\n";
+
+    offset += instr.length;
+    base_addr += instr.length;
+  }
+
+  return result;
+}

--- a/goalc/emitter/disassemble.cpp
+++ b/goalc/emitter/disassemble.cpp
@@ -25,3 +25,35 @@ std::string disassemble_x86(u8* data, int len, u64 base_addr) {
 
   return result;
 }
+
+std::string disassemble_x86(u8* data, int len, u64 base_addr, u64 highlight_addr) {
+  std::string result;
+  ZydisDecoder decoder;
+  ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64);
+  ZydisFormatter formatter;
+  ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);
+  ZydisDecodedInstruction instr;
+
+  constexpr int print_buff_size = 512;
+  char print_buff[print_buff_size];
+  int offset = 0;
+
+  assert(highlight_addr > base_addr);
+  int mark_offset = int(highlight_addr - base_addr);
+  while (offset < len) {
+    char prefix = (offset == mark_offset) ? '-' : ' ';
+    if (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, data + offset, len - offset, &instr))) {
+      result += fmt::format("{:c} [0x{:x}] ", prefix, base_addr);
+      ZydisFormatterFormatInstruction(&formatter, &instr, print_buff, print_buff_size, base_addr);
+      result += print_buff;
+      result += "\n";
+      offset += instr.length;
+      base_addr += instr.length;
+    } else {
+      result += fmt::format("{:c} [0x{:x}] INVALID (0x{:02x})\n", prefix, base_addr, data[offset]);
+      offset++;
+    }
+  }
+
+  return result;
+}

--- a/goalc/emitter/disassemble.h
+++ b/goalc/emitter/disassemble.h
@@ -4,3 +4,4 @@
 #include "common/common_types.h"
 
 std::string disassemble_x86(u8* data, int len, u64 base_addr);
+std::string disassemble_x86(u8* data, int len, u64 base_addr, u64 highlight_addr);

--- a/goalc/emitter/disassemble.h
+++ b/goalc/emitter/disassemble.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+#include "common/common_types.h"
+
+std::string disassemble_x86(u8* data, int len, u64 base_addr);


### PR DESCRIPTION
Add utilities to print memory in several ways, including disassembling.

Load the symbol table on break, and allow using symbols (or their values) as addresses in debugging forms.

Build Zydis as a shared library.