### PR TITLE
[Reader] Support escape codes for any character

### DIFF
--- a/common/goos/Reader.h
+++ b/common/goos/Reader.h
@@ -101,6 +101,8 @@ class Reader {
 
   std::unordered_map<std::string, std::string> reader_macros;
 };
+
+std::string get_readable_string(const char* in);
 }  // namespace goos
 
 #endif  // JAK1_READER_H

--- a/doc/goal_doc.md
+++ b/doc/goal_doc.md
@@ -776,6 +776,7 @@ There is an escape code `\` for string:
 - `\t` tab character
 - `\\` the `\` character
 - `\"` the `"` character
+- `\cXX` where `XX` is a two character hex number: insert this character.
 - Any other character following a `\` is an error.
 
 OpenGOAL stores strings in the same segment of the function which uses the string. I believe GOAL does the same. 

--- a/test/test_reader.cpp
+++ b/test/test_reader.cpp
@@ -171,6 +171,28 @@ TEST(GoosReader, String) {
   EXPECT_ANY_THROW(reader.read_from_string("\"\\w\""));  // "\w" invalid escape
 }
 
+TEST(GoosReader, StringWithNumberEscapes) {
+  Reader reader;
+
+  // build a weird test string
+  std::string str;
+  for (int i = 1; i < 256; i++) {
+    str.push_back(i);
+  }
+
+  // create a readable string:
+  std::string readable = "\"";
+  readable += goos::get_readable_string(str.data());
+  readable.push_back('"');
+
+  EXPECT_TRUE(check_first_string(reader.read_from_string(readable), str));
+  EXPECT_ANY_THROW(reader.read_from_string("\"\\c\""));
+  EXPECT_ANY_THROW(reader.read_from_string("\"\\c1\""));
+  EXPECT_ANY_THROW(reader.read_from_string("\"\\cag\""));
+  EXPECT_ANY_THROW(reader.read_from_string("\"\\c-1\""));
+  EXPECT_ANY_THROW(reader.read_from_string("\"\\c-2\""));
+}
+
 TEST(GoosReader, Symbol) {
   std::vector<std::string> test_symbols = {
       "test", "test-two", "__werid-sym__", "-a", "-", "/", "*", "+", "a", "#f"};


### PR DESCRIPTION
Game text has weird non-printable characters that the reader can't handle. Now you can do something like `"\cab"` and it will insert the character for `0xab`. This involves fiddling with the string to number and number to string stuff, which is always a pain on Windows so I'm making this a separate PR for testing.