### PR TITLE
[Compiler] Fix return-from, returning none, and inline function block scoping bugs

### DIFF
--- a/common/versions.h
+++ b/common/versions.h
@@ -13,7 +13,7 @@
 namespace versions {
 // language version
 constexpr s32 GOAL_VERSION_MAJOR = 0;
-constexpr s32 GOAL_VERSION_MINOR = 1;
+constexpr s32 GOAL_VERSION_MINOR = 2;
 constexpr u32 ART_FILE_VERSION = 6;
 constexpr u32 LEVEL_FILE_VERSION = 30;
 constexpr u32 DGO_FILE_VERSION = 1;

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -47,3 +47,8 @@
 - Fixed a bug where loading a float from an object and immediately using it math would cause a compiler crash
 
 - Arrays of value types can be created on the stack with `new`.
+
+## V0.2
+- Breaking change: return type of a function using `return-from #f` to return a value from the entire function is now the lowest common ancestor of all possible return values.
+- Fixed bug where `return-from` could reach outside of an inlined function.
+- Fixed bug where `return-from` might not behave correctly when returning from inside a let inside an inlined function.

--- a/doc/goal_doc.md
+++ b/doc/goal_doc.md
@@ -66,7 +66,7 @@ Exit a `block` or function early.
 (return-from block-name value)
 ```
 
-Looks up the block and exits from it with the value. You can exit out nested blocks. If you are enclosed in multiple blocks with the same name, exits from the inner-most one with a matching name. Everything in a function is wrapped in a block named `#f`, so you can use `(return-from #f x)` to return early from a function with `x`.  Unlike returning from a block, using `return-from` to exit a function currently does _not_ modify the return type of your function and does _not_ check the type of what you return. 
+Looks up the block and exits from it with the value. You can exit out nested blocks. If you are enclosed in multiple blocks with the same name, exits from the inner-most one with a matching name. Everything in a function is wrapped in a block named `#f`, so you can use `(return-from #f x)` to return early from a function with `x`.  When using this form, it may change the return type of the function or block. The return type will be the lowest common ancestor type of all written return paths. If there is an unreachable return path, it will still be considered.
 
 Example
 ```lisp
@@ -108,6 +108,9 @@ Example:
 ```
 
 The `goto` form used very rarely outside of macros and inline assembly. Try to avoid using `goto`.
+
+## `top-level`
+This form is reserved by the compiler. Internally all forms in a file are grouped under a `top-level` form, so you may see this in error messages. Do not name anything `top-level`.
 
 # Compiler Forms - Compiler Control
 These forms are used to control the GOAL compiler, and are usually entered at the GOAL REPL, or as part of a macro that's executed at the GOAL REPL. These shouldn't really be used in GOAL source code.

--- a/goal_src/kernel/gcommon.gc
+++ b/goal_src/kernel/gcommon.gc
@@ -477,7 +477,7 @@
   "Delete the first occurance of item from a list and return the list.
   Does nothing if the item isn't in the list."
   (if (eq? (car lst) item)
-      (return-from #f (cdr lst))
+      (return-from #f (the pair (cdr lst)))
       )
   
   (let ((iter (cdr lst))

--- a/goalc/compiler/Env.cpp
+++ b/goalc/compiler/Env.cpp
@@ -248,6 +248,11 @@ std::unordered_map<std::string, Label>& LabelEnv::get_label_map() {
   return m_labels;
 }
 
+BlockEnv* LabelEnv::find_block(const std::string& name) {
+  (void)name;
+  return nullptr;
+}
+
 RegVal* FunctionEnv::lexical_lookup(goos::Object sym) {
   if (!sym.is_symbol()) {
     throw std::runtime_error("invalid symbol in lexical_lookup");

--- a/goalc/compiler/Env.h
+++ b/goalc/compiler/Env.h
@@ -234,6 +234,7 @@ class LabelEnv : public Env {
   explicit LabelEnv(Env* parent) : Env(parent) {}
   std::string print() override { return "labelenv"; }
   std::unordered_map<std::string, Label>& get_label_map() override;
+  BlockEnv* find_block(const std::string& name) override;
 
  protected:
   std::unordered_map<std::string, Label> m_labels;

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -654,7 +654,6 @@ Val* Compiler::compile_new(const goos::Object& form, const goos::Object& _rest, 
   } else if (allocation == "stack") {
     auto type_of_object = m_ts.make_typespec(type_as_string);
 
-    printf("type as string is %s\n", type_as_string.c_str());
     if (type_as_string == "inline-array" || type_as_string == "array") {
       bool is_inline = type_as_string == "inline-array";
       auto elt_type = quoted_sym_as_string(pair_car(*rest));

--- a/test/goalc/source_templates/functions/function-returning-none.static.gc
+++ b/test/goalc/source_templates/functions/function-returning-none.static.gc
@@ -1,0 +1,6 @@
+(defun function-returning-none ()
+  (none)
+  )
+
+(function-returning-none)
+1

--- a/test/goalc/source_templates/functions/inline-with-block-1.static.gc
+++ b/test/goalc/source_templates/functions/inline-with-block-1.static.gc
@@ -1,0 +1,11 @@
+
+; this is testing that return-from's work correctly inside of inlined functions.
+(defun inline-with-block-1 ()
+  (declare (inline))
+  (if (= 123 (block my-block 1 (return-from my-block 123) 2))
+      1
+      0
+      )
+  )
+
+(inline-with-block-1)

--- a/test/goalc/source_templates/functions/inline-with-block-2.static.gc
+++ b/test/goalc/source_templates/functions/inline-with-block-2.static.gc
@@ -1,0 +1,11 @@
+;; testing that we can have a block's final statement be a none.
+
+(defun inline-with-block-2 ()
+  (declare (inline))
+  (block a-block
+         (return-from a-block 3)
+         )
+  )
+
+;; this is a little hacky, this technically returns none.
+(inline-with-block-2)

--- a/test/goalc/source_templates/functions/inline-with-block-3.static.gc
+++ b/test/goalc/source_templates/functions/inline-with-block-3.static.gc
@@ -1,0 +1,10 @@
+(defun inline-with-block-3 ()
+  (declare (inline))
+  (block a-block
+         (return-from a-block 4)
+         )
+  (none)
+  )
+
+(inline-with-block-3)
+4

--- a/test/goalc/source_templates/functions/inline-with-block-4.static.gc
+++ b/test/goalc/source_templates/functions/inline-with-block-4.static.gc
@@ -1,0 +1,14 @@
+(define format _format)
+
+(defun even-odd-to-1-2 ((in int))
+  (declare (inline))
+  (if (= 0 (logand 1 in))
+      (let ((x 1.0))
+        (return-from #f 1.0)
+        )
+      123123.23
+      )
+  2.0
+  )
+
+(format #t "~f~%" (+ (even-odd-to-1-2 11) (even-odd-to-1-2 12)))

--- a/test/goalc/source_templates/functions/return-from-trick.static.gc
+++ b/test/goalc/source_templates/functions/return-from-trick.static.gc
@@ -1,0 +1,8 @@
+(defun return-from-let ()
+  (let ((x 1))
+    (return-from #f x)
+    )
+  3
+  )
+
+(return-from-let)

--- a/test/goalc/test_functions.cpp
+++ b/test/goalc/test_functions.cpp
@@ -114,3 +114,27 @@ TEST_F(FunctionTests, AllowInline) {
   EXPECT_EQ(got_mult, 1);
   EXPECT_EQ(got_call, 1);
 }
+
+TEST_F(FunctionTests, ReturnNone) {
+  runner.run_static_test(env, testCategory, "function-returning-none.static.gc", {"1\n"});
+}
+
+TEST_F(FunctionTests, InlineBlock1) {
+  runner.run_static_test(env, testCategory, "inline-with-block-1.static.gc", {"1\n"});
+}
+
+TEST_F(FunctionTests, InlineBlock2) {
+  runner.run_static_test(env, testCategory, "inline-with-block-2.static.gc", {"3\n"});
+}
+
+TEST_F(FunctionTests, InlineBlock3) {
+  runner.run_static_test(env, testCategory, "inline-with-block-3.static.gc", {"4\n"});
+}
+
+TEST_F(FunctionTests, InlineBlock4) {
+  runner.run_static_test(env, testCategory, "inline-with-block-4.static.gc", {"3.0000\n0\n"});
+}
+
+TEST_F(FunctionTests, ReturnFromTrick) {
+  runner.run_static_test(env, testCategory, "return-from-trick.static.gc", {"1\n"});
+}


### PR DESCRIPTION
Will close https://github.com/water111/jak-project/issues/137 and will close https://github.com/water111/jak-project/issues/136

Inlined functions (either through `(declare (inline))` or through putting `(inline func)` as the head) no longer can access blocks defined in the enclosing function. Immediate lambdas (`let`s) still can do this. Inlined functions have a block environment with their own `#f` that they can `return-from`. It takes the same optimization as `block`, where it only forces you to return in a separate GPR ireg if you actually use a `return-from`.

Functions using `return-from #f` to return early from the entire function will now have the correct return type. This is a breaking change that broke existing code so the compiler version was increased.

Functions and `block`s can now end in `none` and won't cause a compile time error.