### PR TITLE
Improve Register Allocator

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -189,6 +189,7 @@
 (declare-type process basic)
 (declare-type stack-frame basic)
 (declare-type cpu-thread basic)
+(declare-type state basic)
 
 ;; gkernel-h
 (deftype thread (basic)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -74,3 +74,9 @@
 - Fixed a bug where arguments to a method were unmodifiable.
 - Fixed a bug where multiple anonymous lambda functions in the same file would throw a compiler error related to function name uniqueness.
 - Method declarations can now use compound types. Previously they could only use simple types due to a mistake in deftype parser.
+- Added a declare option for `allow-saved-regs` to let `asm-func`s use saved registers in special cases
+- Improved register allocation for the above case to avoid inserting extra moves to and from temp registers.
+- Fixed a bug where early returns out of methods would not change the return type of the method.
+- Fixed a bug where the return instruction was still emitted and the overridden return type of `asm-func` was ignored for methods
+- Rearranged function stack frames so spilled register variable slots come after stack structures.
+- Added `stack` allocated and constructed basic/structure types.

--- a/goalc/compiler/CodeGenerator.cpp
+++ b/goalc/compiler/CodeGenerator.cpp
@@ -71,7 +71,7 @@ void CodeGenerator::do_goal_function(FunctionEnv* env, int f_idx) {
   // compute how much stack we will use
   int stack_offset = 0;
 
-  // back up xmms
+  // back up xmms (currently not aligned)
   for (auto& saved_reg : allocs.used_saved_regs) {
     if (saved_reg.is_xmm()) {
       m_gen.add_instr_no_ir(f_rec, IGen::sub_gpr64_imm8s(RSP, XMM_SIZE), InstructionInfo::PROLOGUE);
@@ -133,7 +133,9 @@ void CodeGenerator::do_goal_function(FunctionEnv* env, int f_idx) {
     for (auto& op : bonus.ops) {
       if (op.load) {
         if (op.reg.is_gpr()) {
-          m_gen.add_instr(IGen::load64_gpr64_plus_s32(op.reg, op.slot * GPR_SIZE, RSP), i_rec);
+          m_gen.add_instr(IGen::load64_gpr64_plus_s32(
+                              op.reg, allocs.get_slot_for_spill(op.slot) * GPR_SIZE, RSP),
+                          i_rec);
         } else {
           assert(false);
         }
@@ -147,7 +149,9 @@ void CodeGenerator::do_goal_function(FunctionEnv* env, int f_idx) {
     for (auto& op : bonus.ops) {
       if (op.store) {
         if (op.reg.is_gpr()) {
-          m_gen.add_instr(IGen::store64_gpr64_plus_s32(RSP, op.slot * GPR_SIZE, op.reg), i_rec);
+          m_gen.add_instr(IGen::store64_gpr64_plus_s32(
+                              RSP, allocs.get_slot_for_spill(op.slot) * GPR_SIZE, op.reg),
+                          i_rec);
         } else {
           assert(false);
         }

--- a/goalc/compiler/CodeGenerator.cpp
+++ b/goalc/compiler/CodeGenerator.cpp
@@ -51,7 +51,7 @@ std::vector<u8> CodeGenerator::run() {
 
 void CodeGenerator::do_function(FunctionEnv* env, int f_idx) {
   if (env->is_asm_func) {
-    do_asm_function(env, f_idx);
+    do_asm_function(env, f_idx, env->asm_func_saved_regs);
   } else {
     do_goal_function(env, f_idx);
   }
@@ -188,11 +188,11 @@ void CodeGenerator::do_goal_function(FunctionEnv* env, int f_idx) {
   m_gen.add_instr_no_ir(f_rec, IGen::ret(), InstructionInfo::EPILOGUE);
 }
 
-void CodeGenerator::do_asm_function(FunctionEnv* env, int f_idx) {
+void CodeGenerator::do_asm_function(FunctionEnv* env, int f_idx, bool allow_saved_regs) {
   auto f_rec = m_gen.get_existing_function_record(f_idx);
   const auto& allocs = env->alloc_result();
 
-  if (!allocs.used_saved_regs.empty()) {
+  if (!allow_saved_regs && !allocs.used_saved_regs.empty()) {
     std::string err = fmt::format(
         "ASM Function {}'s coloring using the following callee-saved registers: ", env->name());
     for (auto& x : allocs.used_saved_regs) {

--- a/goalc/compiler/CodeGenerator.h
+++ b/goalc/compiler/CodeGenerator.h
@@ -23,7 +23,7 @@ class CodeGenerator {
  private:
   void do_function(FunctionEnv* env, int f_idx);
   void do_goal_function(FunctionEnv* env, int f_idx);
-  void do_asm_function(FunctionEnv* env, int f_idx);
+  void do_asm_function(FunctionEnv* env, int f_idx, bool allow_saved_regs);
   emitter::ObjectGenerator m_gen;
   FileEnv* m_fe = nullptr;
   DebugInfo* m_debug_info = nullptr;

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -88,6 +88,7 @@ class Compiler {
   std::string as_string(const goos::Object& o);
   std::string symbol_string(const goos::Object& o);
   std::string quoted_sym_as_string(const goos::Object& o);
+  goos::Object unquote(const goos::Object& o);
   bool is_quoted_sym(const goos::Object& o);
   bool is_basic(const TypeSpec& ts);
   bool is_structure(const TypeSpec& ts);
@@ -115,6 +116,19 @@ class Compiler {
 
   bool try_getting_constant_integer(const goos::Object& in, int64_t* out, Env* env);
   float try_getting_constant_float(const goos::Object& in, float* out, Env* env);
+  Val* compile_heap_new(const goos::Object& form,
+                        const std::string& allocation,
+                        const goos::Object& type,
+                        const goos::Object* rest,
+                        Env* env);
+  Val* compile_static_new(const goos::Object& form,
+                          const goos::Object& type,
+                          const goos::Object* rest,
+                          Env* env);
+  Val* compile_stack_new(const goos::Object& form,
+                         const goos::Object& type,
+                         const goos::Object* rest,
+                         Env* env);
 
   TypeSystem m_ts;
   std::unique_ptr<GlobalEnv> m_global_env = nullptr;

--- a/goalc/compiler/Env.h
+++ b/goalc/compiler/Env.h
@@ -197,6 +197,7 @@ class FunctionEnv : public DeclareEnv {
   int segment = -1;
   std::string method_of_type_name = "#f";
   bool is_asm_func = false;
+  bool asm_func_saved_regs = false;
   TypeSpec asm_func_return_type;
   std::vector<UnresolvedGoto> unresolved_gotos;
   std::vector<UnresolvedConditionalGoto> unresolved_cond_gotos;

--- a/goalc/compiler/Env.h
+++ b/goalc/compiler/Env.h
@@ -176,6 +176,9 @@ class FunctionEnv : public DeclareEnv {
   const std::string& name() const { return m_name; }
 
   StackVarAddrVal* allocate_stack_variable(const TypeSpec& ts, int size_bytes);
+  StackVarAddrVal* allocate_aligned_stack_variable(const TypeSpec& ts,
+                                                   int size_bytes,
+                                                   int align_bytes);
   int stack_slots_used_for_stack_vars() const { return m_stack_var_slots_used; }
 
   int idx_in_file = -1;

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -949,7 +949,7 @@ void IR_GetStackAddr::do_codegen(emitter::ObjectGenerator* gen,
                                  const AllocationResult& allocs,
                                  emitter::IR_Record irec) {
   auto dest_reg = get_reg(m_dest, allocs, irec);
-  int offset = GPR_SIZE * (m_slot + allocs.stack_slots_for_spills);
+  int offset = GPR_SIZE * allocs.get_slot_for_var(m_slot);
 
   // dest = offset
   load_constant(offset, gen, irec, dest_reg);

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -55,6 +55,15 @@ std::string Compiler::quoted_sym_as_string(const goos::Object& o) {
   return symbol_string(args.unnamed.at(1));
 }
 
+goos::Object Compiler::unquote(const goos::Object& o) {
+  auto args = get_va(o, o);
+  va_check(o, args, {{goos::ObjectType::SYMBOL}, {}}, {});
+  if (symbol_string(args.unnamed.at(0)) != "quote") {
+    throw_compiler_error(o, "Invalid quoted symbol: {}.", o.print());
+  }
+  return args.unnamed.at(1);
+}
+
 bool Compiler::is_quoted_sym(const goos::Object& o) {
   if (o.is_pair()) {
     auto car = pair_car(o);

--- a/goalc/compiler/compilation/Function.cpp
+++ b/goalc/compiler/compilation/Function.cpp
@@ -576,6 +576,14 @@ Val* Compiler::compile_declare(const goos::Object& form, const goos::Object& res
         throw_compiler_error(first, "Invalid print-asm declare");
       }
       settings.print_asm = true;
+
+    } else if (first.as_symbol()->name == "allow-saved-regs") {
+      if (!rrest->is_empty_list()) {
+        throw_compiler_error(first, "Invalid allow-saved-regs declare");
+      }
+      auto fe = get_parent_env_of_type<FunctionEnv>(env);
+      fe->asm_func_saved_regs = true;
+
     } else {
       throw_compiler_error(first, "Unrecognized declare option {}.", first.print());
     }

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -596,161 +596,185 @@ Val* Compiler::compile_print_type(const goos::Object& form, const goos::Object& 
   return get_none();
 }
 
-Val* Compiler::compile_new(const goos::Object& form, const goos::Object& _rest, Env* env) {
-  // todo - support compound types.
-  // todo - stack arrays?
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+/*!
+ * New on global or debug heap.
+ */
+Val* Compiler::compile_heap_new(const goos::Object& form,
+                                const std::string& allocation,
+                                const goos::Object& type,
+                                const goos::Object* rest,
+                                Env* env) {
+  auto main_type = parse_typespec(unquote(type));
+  if (main_type == TypeSpec("inline-array") || main_type == TypeSpec("array")) {
+    bool is_inline = main_type == TypeSpec("inline-array");
+    auto elt_type = quoted_sym_as_string(pair_car(*rest));
+    rest = &pair_cdr(*rest);
 
+    auto count_obj = pair_car(*rest);
+    rest = &pair_cdr(*rest);
+    // try to get the size as a compile time constant.
+    int64_t constant_count = 0;
+    bool is_constant_size = try_getting_constant_integer(count_obj, &constant_count, env);
+
+    if (!rest->is_empty_list()) {
+      // got extra arguments
+      throw_compiler_error(form, "new array form got more arguments than expected");
+    }
+
+    auto ts = is_inline ? m_ts.make_inline_array_typespec(elt_type)
+                        : m_ts.make_pointer_typespec(elt_type);
+    auto info = m_ts.get_deref_info(ts);
+    if (!info.can_deref) {
+      throw_compiler_error(form, "Cannot make an {} of {}\n", main_type.print(), ts.print());
+    }
+
+    auto malloc_func = compile_get_symbol_value(form, "malloc", env)->to_reg(env);
+    std::vector<RegVal*> args;
+    args.push_back(compile_get_sym_obj(allocation, env)->to_reg(env));
+
+    if (is_constant_size) {
+      auto array_size = constant_count * info.stride;
+      args.push_back(compile_integer(array_size, env)->to_reg(env));
+    } else {
+      auto array_size = compile_integer(info.stride, env)->to_reg(env);
+      env->emit(std::make_unique<IR_IntegerMath>(IntegerMathKind::IMUL_32, array_size,
+                                                 compile_error_guard(count_obj, env)->to_gpr(env)));
+      args.push_back(array_size);
+    }
+
+    auto array = compile_real_function_call(form, malloc_func, args, env);
+    array->set_type(ts);
+    return array;
+  } else {
+    if (!m_ts.lookup_type(main_type)->is_reference()) {
+      throw_compiler_error(form, "Cannot heap allocate the value type {}.", main_type.print());
+    }
+    std::vector<RegVal*> args;
+    // allocation
+    args.push_back(compile_get_sym_obj(allocation, env)->to_reg(env));
+    // type
+    args.push_back(compile_get_symbol_value(form, main_type.base_type(), env)->to_reg(env));
+    // the other arguments
+    for_each_in_list(*rest, [&](const goos::Object& o) {
+      args.push_back(compile_error_guard(o, env)->to_reg(env));
+    });
+
+    auto new_method = compile_get_method_of_type(form, main_type, "new", env);
+    auto new_obj = compile_real_function_call(form, new_method, args, env);
+    new_obj->set_type(main_type);
+    return new_obj;
+  }
+}
+
+Val* Compiler::compile_static_new(const goos::Object& form,
+                                  const goos::Object& type,
+                                  const goos::Object* rest,
+                                  Env* env) {
+  auto type_of_object = parse_typespec(unquote(type));
+  if (is_structure(type_of_object)) {
+    return compile_new_static_structure_or_basic(form, type_of_object, *rest, env);
+  }
+
+  if (is_bitfield(type_of_object)) {
+    return compile_new_static_bitfield(form, type_of_object, *rest, env);
+  }
+
+  throw_compiler_error(form,
+                       "Cannot do a static new of a {} because it is not a bitfield or structure.");
+  return get_none();
+}
+
+Val* Compiler::compile_stack_new(const goos::Object& form,
+                                 const goos::Object& type,
+                                 const goos::Object* rest,
+                                 Env* env) {
+  auto type_of_object = parse_typespec(unquote(type));
+  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  if (type_of_object == TypeSpec("inline-array") || type_of_object == TypeSpec("array")) {
+    bool is_inline = type_of_object == TypeSpec("inline-array");
+    auto elt_type = quoted_sym_as_string(pair_car(*rest));
+    rest = &pair_cdr(*rest);
+
+    auto count_obj = pair_car(*rest);
+    rest = &pair_cdr(*rest);
+    // try to get the size as a compile time constant.
+    int64_t constant_count = 0;
+    bool is_constant_size = try_getting_constant_integer(count_obj, &constant_count, env);
+    if (!is_constant_size) {
+      throw_compiler_error(form, "Cannot create a dynamically sized stack array");
+    }
+
+    if (!rest->is_empty_list()) {
+      // got extra arguments
+      throw_compiler_error(form, "New array form got more arguments than expected");
+    }
+
+    auto ts = is_inline ? m_ts.make_inline_array_typespec(elt_type)
+                        : m_ts.make_pointer_typespec(elt_type);
+    auto info = m_ts.get_deref_info(ts);
+    if (!info.can_deref) {
+      throw_compiler_error(form, "Cannot make an {} of {}\n", type_of_object.print(), ts.print());
+    }
+
+    if (!m_ts.lookup_type(elt_type)->is_reference()) {
+      // not a reference type
+      int size_in_bytes = info.stride * constant_count;
+      auto addr = fe->allocate_stack_variable(ts, size_in_bytes);
+      return addr;
+    }
+    // todo
+    throw_compiler_error(form, "Static array of type {} is not yet supported.", ts.print());
+    return get_none();
+  } else {
+    auto ti = m_ts.lookup_type(type_of_object);
+
+    if (!ti->is_reference()) {
+      throw_compiler_error(form, "Cannot stack allocate the value type {}.",
+                           type_of_object.print());
+    }
+    auto ti_as_struct = dynamic_cast<StructureType*>(ti);
+    assert(ti_as_struct);
+
+    if (ti_as_struct->is_dynamic()) {
+      throw_compiler_error(form, "Cannot stack allocate the dynamic type {}.",
+                           type_of_object.print());
+    }
+    std::vector<RegVal*> args;
+    // allocation
+    auto mem = fe->allocate_aligned_stack_variable(type_of_object, ti->get_size_in_memory(), 16)
+                   ->to_gpr(env);
+    // the new method actual takes a "symbol" according the type system. So we have to cheat it.
+    mem->set_type(TypeSpec("symbol"));
+    args.push_back(mem);
+    // type
+    args.push_back(compile_get_symbol_value(form, type_of_object.base_type(), env)->to_reg(env));
+    // the other arguments
+    for_each_in_list(*rest, [&](const goos::Object& o) {
+      args.push_back(compile_error_guard(o, env)->to_reg(env));
+    });
+
+    auto new_method = compile_get_method_of_type(form, type_of_object, "new", env);
+    auto new_obj = compile_real_function_call(form, new_method, args, env);
+    new_obj->set_type(type_of_object);
+    return new_obj;
+  }
+}
+
+Val* Compiler::compile_new(const goos::Object& form, const goos::Object& _rest, Env* env) {
   auto allocation = quoted_sym_as_string(pair_car(_rest));
   auto rest = &pair_cdr(_rest);
 
-  // auto type_of_obj = get_base_typespec(quoted_sym_as_string(pair_car(rest)));
-  auto type_as_string = quoted_sym_as_string(pair_car(*rest));
+  auto type = pair_car(*rest);
   rest = &pair_cdr(*rest);
 
   if (allocation == "global" || allocation == "debug") {
     // allocate on a named heap
-
-    if (type_as_string == "inline-array" || type_as_string == "array") {
-      bool is_inline = type_as_string == "inline-array";
-      auto elt_type = quoted_sym_as_string(pair_car(*rest));
-      rest = &pair_cdr(*rest);
-
-      auto count_obj = pair_car(*rest);
-      rest = &pair_cdr(*rest);
-      // try to get the size as a compile time constant.
-      int64_t constant_count = 0;
-      bool is_constant_size = try_getting_constant_integer(count_obj, &constant_count, env);
-
-      if (!rest->is_empty_list()) {
-        // got extra arguments
-        throw_compiler_error(form, "new array form got more arguments than expected");
-      }
-
-      auto ts = is_inline ? m_ts.make_inline_array_typespec(elt_type)
-                          : m_ts.make_pointer_typespec(elt_type);
-      auto info = m_ts.get_deref_info(ts);
-      if (!info.can_deref) {
-        throw_compiler_error(form, "Cannot make an {} of {}\n", type_as_string, ts.print());
-      }
-
-      auto malloc_func = compile_get_symbol_value(form, "malloc", env)->to_reg(env);
-      std::vector<RegVal*> args;
-      args.push_back(compile_get_sym_obj(allocation, env)->to_reg(env));
-
-      if (is_constant_size) {
-        auto array_size = constant_count * info.stride;
-        args.push_back(compile_integer(array_size, env)->to_reg(env));
-      } else {
-        auto array_size = compile_integer(info.stride, env)->to_reg(env);
-        env->emit(
-            std::make_unique<IR_IntegerMath>(IntegerMathKind::IMUL_32, array_size,
-                                             compile_error_guard(count_obj, env)->to_gpr(env)));
-        args.push_back(array_size);
-      }
-
-      auto array = compile_real_function_call(form, malloc_func, args, env);
-      array->set_type(ts);
-      return array;
-    } else {
-      auto type_of_obj = m_ts.make_typespec(type_as_string);
-      if (!m_ts.lookup_type(type_of_obj)->is_reference()) {
-        throw_compiler_error(form, "Cannot heap allocate the value type {}.", type_of_obj.print());
-      }
-      std::vector<RegVal*> args;
-      // allocation
-      args.push_back(compile_get_sym_obj(allocation, env)->to_reg(env));
-      // type
-      args.push_back(compile_get_symbol_value(form, type_of_obj.base_type(), env)->to_reg(env));
-      // the other arguments
-      for_each_in_list(*rest, [&](const goos::Object& o) {
-        args.push_back(compile_error_guard(o, env)->to_reg(env));
-      });
-
-      auto new_method = compile_get_method_of_type(form, type_of_obj, "new", env);
-      auto new_obj = compile_real_function_call(form, new_method, args, env);
-      new_obj->set_type(type_of_obj);
-      return new_obj;
-    }
+    return compile_heap_new(form, allocation, type, rest, env);
   } else if (allocation == "static") {
-    auto type_of_object = m_ts.make_typespec(type_as_string);
-    if (is_structure(type_of_object)) {
-      return compile_new_static_structure_or_basic(form, type_of_object, *rest, env);
-    }
-
-    if (is_bitfield(type_of_object)) {
-      return compile_new_static_bitfield(form, type_of_object, *rest, env);
-    }
-
+    // put in code.
+    return compile_static_new(form, type, rest, env);
   } else if (allocation == "stack") {
-    auto type_of_object = m_ts.make_typespec(type_as_string);
-
-    if (type_as_string == "inline-array" || type_as_string == "array") {
-      bool is_inline = type_as_string == "inline-array";
-      auto elt_type = quoted_sym_as_string(pair_car(*rest));
-      rest = &pair_cdr(*rest);
-
-      auto count_obj = pair_car(*rest);
-      rest = &pair_cdr(*rest);
-      // try to get the size as a compile time constant.
-      int64_t constant_count = 0;
-      bool is_constant_size = try_getting_constant_integer(count_obj, &constant_count, env);
-      if (!is_constant_size) {
-        throw_compiler_error(form, "Cannot create a dynamically sized stack array");
-      }
-
-      if (!rest->is_empty_list()) {
-        // got extra arguments
-        throw_compiler_error(form, "New array form got more arguments than expected");
-      }
-
-      auto ts = is_inline ? m_ts.make_inline_array_typespec(elt_type)
-                          : m_ts.make_pointer_typespec(elt_type);
-      auto info = m_ts.get_deref_info(ts);
-      if (!info.can_deref) {
-        throw_compiler_error(form, "Cannot make an {} of {}\n", type_as_string, ts.print());
-      }
-
-      if (!m_ts.lookup_type(elt_type)->is_reference()) {
-        // not a reference type
-        int size_in_bytes = info.stride * constant_count;
-        auto addr = fe->allocate_stack_variable(ts, size_in_bytes);
-        return addr;
-      }
-      // todo, stack structure arrays
-    } else {
-      auto type_of_obj = m_ts.make_typespec(type_as_string);
-      auto ti = m_ts.lookup_type(type_of_obj);
-
-      if (!ti->is_reference()) {
-        throw_compiler_error(form, "Cannot stack allocate the value type {}.", type_of_obj.print());
-      }
-      auto ti_as_struct = dynamic_cast<StructureType*>(ti);
-      assert(ti_as_struct);
-
-      if (ti_as_struct->is_dynamic()) {
-        throw_compiler_error(form, "Cannot stack allocate the dynamic type {}.",
-                             type_of_obj.print());
-      }
-      std::vector<RegVal*> args;
-      // allocation
-      auto mem = fe->allocate_aligned_stack_variable(type_of_obj, ti->get_size_in_memory(), 16)
-                     ->to_gpr(env);
-      // the new method actual takes a "symbol" according the type system. So we have to cheat it.
-      mem->set_type(TypeSpec("symbol"));
-      args.push_back(mem);
-      // type
-      args.push_back(compile_get_symbol_value(form, type_of_obj.base_type(), env)->to_reg(env));
-      // the other arguments
-      for_each_in_list(*rest, [&](const goos::Object& o) {
-        args.push_back(compile_error_guard(o, env)->to_reg(env));
-      });
-
-      auto new_method = compile_get_method_of_type(form, type_of_obj, "new", env);
-      auto new_obj = compile_real_function_call(form, new_method, args, env);
-      new_obj->set_type(type_of_obj);
-      return new_obj;
-    }
+    return compile_stack_new(form, type, rest, env);
   }
 
   throw_compiler_error(form, "Unsupported new form");

--- a/goalc/regalloc/Allocator.cpp
+++ b/goalc/regalloc/Allocator.cpp
@@ -178,6 +178,9 @@ void analyze_liveliness(RegAllocCache* cache, const AllocationInput& in) {
   }
   cache->stack_ops.resize(in.instructions.size());
 
+  // cache a list of live ranges which are live at each instruction.
+  // filters out unseen lr's as well.
+  // this makes instr * lr1 * lr2 loop much faster!
   cache->live_ranges_by_instr.resize(in.instructions.size());
   for (u32 lr_idx = 0; lr_idx < cache->live_ranges.size(); lr_idx++) {
     auto& lr = cache->live_ranges.at(lr_idx);

--- a/goalc/regalloc/Allocator.h
+++ b/goalc/regalloc/Allocator.h
@@ -38,6 +38,8 @@ struct RegAllocCache {
   int current_stack_slot = 0;
   bool used_stack = false;
   bool is_asm_func = false;
+
+  std::vector<std::vector<int>> live_ranges_by_instr;
 };
 
 void find_basic_blocks(RegAllocCache* cache, const AllocationInput& in);

--- a/goalc/regalloc/Allocator.h
+++ b/goalc/regalloc/Allocator.h
@@ -4,7 +4,7 @@
 #define JAK_ALLOCATOR_H
 
 #include <vector>
-#include <set>
+#include "IRegSet.h"
 #include <unordered_map>
 #include "IRegister.h"
 #include "allocate.h"
@@ -13,8 +13,8 @@ struct RegAllocBasicBlock {
   std::vector<int> instr_idx;
   std::vector<int> succ;
   std::vector<int> pred;
-  std::vector<std::set<int>> live, dead;
-  std::set<int> use, defs, input, output;
+  std::vector<IRegSet> live, dead;
+  IRegSet use, defs, input, output;
   bool is_entry = false;
   bool is_exit = false;
   int idx = -1;
@@ -23,8 +23,8 @@ struct RegAllocBasicBlock {
                                  const std::vector<RegAllocInstr>& instructions);
   void analyze_liveliness_phase3(std::vector<RegAllocBasicBlock>& blocks,
                                  const std::vector<RegAllocInstr>& instructions);
-  std::string print(const std::vector<RegAllocInstr>& insts) const;
-  std::string print_summary() const;
+  std::string print(const std::vector<RegAllocInstr>& insts);
+  std::string print_summary();
 };
 
 struct RegAllocCache {

--- a/goalc/regalloc/IRegSet.h
+++ b/goalc/regalloc/IRegSet.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <vector>
+#include <cassert>
+#include "common/common_types.h"
+
+class IRegSet {
+ public:
+  IRegSet() = default;
+  void insert(int x) {
+    resize(x + 1);
+    assert(m_bits > x);
+    auto word = x / 64;
+    auto bit = x % 64;
+    m_data.at(word) |= (1ll << bit);
+  }
+
+  void clear() {
+    for (auto& x : m_data) {
+      x = 0;
+    }
+  }
+
+  bool operator[](int x) {
+    resize(x + 1);
+    auto word = x / 64;
+    auto bit = x % 64;
+    return m_data.at(word) & (1ll << bit);
+  }
+
+  int size() const { return m_bits; }
+
+  bool operator==(const IRegSet& other) const {
+    auto compare_size = std::min(m_data.size(), other.m_data.size());
+    size_t i;
+    for (i = 0; i < compare_size; i++) {
+      if (m_data[i] != other.m_data[i]) {
+        return false;
+      }
+    }
+
+    for (size_t j = i; j < m_data.size(); j++) {
+      if (m_data[j]) {
+        return false;
+      }
+    }
+
+    for (size_t j = i; j < other.m_data.size(); j++) {
+      if (other.m_data[j]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool operator!=(const IRegSet& other) const { return !((*this) == other); }
+
+  void resize(int bits) {
+    if (bits > m_bits) {
+      auto new_vector_size = (bits + 63) / 64;
+      m_data.resize(new_vector_size);
+      m_bits = new_vector_size * 64;
+    }
+  }
+
+ private:
+  std::vector<u64> m_data;
+  int m_bits = 0;
+};

--- a/goalc/regalloc/IRegSet.h
+++ b/goalc/regalloc/IRegSet.h
@@ -62,6 +62,37 @@ class IRegSet {
     }
   }
 
+  void make_max_size(IRegSet& other) {
+    if (other.size() < size()) {
+      other.resize(size());
+    } else {
+      resize(other.size());
+    }
+  }
+
+  /*!
+   * this = (this & !other)
+   */
+  void bitwise_and_not(IRegSet& other) {
+    // make same size
+    make_max_size(other);
+
+    for (size_t i = 0; i < m_data.size(); i++) {
+      m_data.at(i) &= ~other.m_data.at(i);
+    }
+  }
+
+  /*!
+   * this = (this | other)
+   */
+  void bitwise_or(IRegSet& other) {
+    make_max_size(other);
+
+    for (size_t i = 0; i < m_data.size(); i++) {
+      m_data.at(i) |= other.m_data.at(i);
+    }
+  }
+
  private:
   std::vector<u64> m_data;
   int m_bits = 0;

--- a/goalc/regalloc/allocate.h
+++ b/goalc/regalloc/allocate.h
@@ -72,6 +72,20 @@ struct AllocationResult {
   int stack_slots_for_vars = 0;
   std::vector<StackOp> stack_ops;  // additional instructions to spill/restore
   bool needs_aligned_stack_for_spills = false;
+
+  // we put the variables before the spills so the variables are 16-byte aligned.
+
+  int total_stack_slots() const { return stack_slots_for_spills + stack_slots_for_vars; }
+
+  int get_slot_for_var(int slot) const {
+    assert(slot < stack_slots_for_vars);
+    return slot;
+  }
+
+  int get_slot_for_spill(int slot) const {
+    assert(slot < stack_slots_for_spills);
+    return slot + stack_slots_for_vars;
+  }
 };
 
 /*!

--- a/test/goalc/source_templates/variables/stack-array-align.gc
+++ b/test/goalc/source_templates/variables/stack-array-align.gc
@@ -1,0 +1,7 @@
+(defun stack-test ()
+  (let ((arr (new 'stack 'array 'uint8 12)))
+    (logand #b1111 (the uint (&-> arr 3)))
+    )
+  )
+
+(stack-test)

--- a/test/goalc/source_templates/variables/stack-structure-align.gc
+++ b/test/goalc/source_templates/variables/stack-structure-align.gc
@@ -1,0 +1,32 @@
+(deftype test-stack-type (basic)
+  ((name string)
+   (count uint32)
+   (pad uint8 12))
+  (:methods
+    (new ((allocation symbol) (type-to-make type) (init-count int)) _type_ 0)
+    )
+  )
+
+(defmethod new test-stack-type ((allocation symbol) (type-to-make type) (init-count int))
+  (let ((obj (object-new)))
+    (set! (-> obj name) "this is my name")
+    (set! (-> obj count) init-count)
+    obj
+    )
+  )
+
+
+(defun stack-test-2 ()
+  (let ((obj (new 'stack 'test-stack-type 12))
+        (obj2 (new 'stack 'test-stack-type 13)))
+    (if (and (= 4 (logand 15 (the uint obj)))
+             (= 4 (logand 15 (the uint obj2)))
+             (= 12 (-> obj count))
+             )
+        1234
+        0
+        )
+    )
+  )
+
+(stack-test-2)

--- a/test/goalc/test_variables.cpp
+++ b/test/goalc/test_variables.cpp
@@ -86,3 +86,11 @@ TEST_F(VariableTests, InlineAsm) {
 TEST_F(VariableTests, StaticBitfieldField) {
   runner.run_static_test(env, testCategory, "static-bitfield-field.gc", {"22\n"});
 }
+
+TEST_F(VariableTests, StackArrayAlignment) {
+  runner.run_static_test(env, testCategory, "stack-array-align.gc", {"3\n"});
+}
+
+TEST_F(VariableTests, StackStructureAlignment) {
+  runner.run_static_test(env, testCategory, "stack-structure-align.gc", {"1234\n"});
+}


### PR DESCRIPTION
Faster and better on inline assembly.

Baseline before speed improvements:
Starting the compiler, building game 3x takes 4.6 seconds on my computer.

MD5's at ac52c7bca3a34d3fc316875cbff799d85362352c
```
a0c2a6111602300db6f441bf983040a5  iso/KERNEL.CGO
c2f58039fc824702ce903f4d76d5a142  iso/GAME.CGO
```