### PR TITLE
[Decompiler] Experimental Expression Stack

### DIFF
--- a/common/type_system/TypeSpec.h
+++ b/common/type_system/TypeSpec.h
@@ -51,6 +51,7 @@ class TypeSpec {
   size_t arg_count() const { return m_arguments.size(); }
 
   const TypeSpec& get_arg(int idx) const { return m_arguments.at(idx); }
+  TypeSpec& get_arg(int idx) { return m_arguments.at(idx); }
   const TypeSpec& last_arg() const {
     assert(!m_arguments.empty());
     return m_arguments.back();

--- a/common/type_system/TypeSystem.cpp
+++ b/common/type_system/TypeSystem.cpp
@@ -1198,8 +1198,10 @@ bool TypeSystem::reverse_deref(const ReverseDerefInputInfo& input,
           *result_type = base_type;
           return true;
         } else {
-          printf("load size %d %d, sext %d %d, input %s\n", di.load_size, input.load_size,
-                 di.sign_extend, input.sign_extend, input.input_type.print().c_str());
+          if (debug_reverse_deref) {
+            fmt::print("load size {} {}, sext {} {}, input {}\n", di.load_size, input.load_size,
+                       di.sign_extend, input.sign_extend, input.input_type.print().c_str());
+          }
           return false;
         }
       } else {

--- a/common/type_system/TypeSystem.cpp
+++ b/common/type_system/TypeSystem.cpp
@@ -1189,10 +1189,19 @@ bool TypeSystem::reverse_deref(const ReverseDerefInputInfo& input,
     assert(di.mem_deref);
     if (offset_into_elt == 0) {
       if (input.mem_deref) {
-        path->push_back(token);
-        *addr_of = false;
-        *result_type = base_type;
-        return true;
+        // todo - this is a hack to let quadword loads always succeed because we don't support it
+        // correctly at this point.
+        if (input.load_size == 16 ||
+            (di.load_size == input.load_size && di.sign_extend == input.sign_extend)) {
+          path->push_back(token);
+          *addr_of = false;
+          *result_type = base_type;
+          return true;
+        } else {
+          printf("load size %d %d, sext %d %d, input %s\n", di.load_size, input.load_size,
+                 di.sign_extend, input.sign_extend, input.input_type.print().c_str());
+          return false;
+        }
       } else {
         path->push_back(token);
         *addr_of = true;

--- a/common/type_system/TypeSystem.cpp
+++ b/common/type_system/TypeSystem.cpp
@@ -1095,6 +1095,11 @@ std::string TypeSystem::lca_base(const std::string& a, const std::string& b) {
  */
 TypeSpec TypeSystem::lowest_common_ancestor(const TypeSpec& a, const TypeSpec& b) {
   auto result = make_typespec(lca_base(a.base_type(), b.base_type()));
+  if (result == TypeSpec("function") && a.m_arguments.size() == 2 && b.m_arguments.size() == 2 &&
+      (a.m_arguments.at(0) == TypeSpec("_varargs_") ||
+       b.m_arguments.at(0) == TypeSpec("_varargs_"))) {
+    return TypeSpec("function");
+  }
   if (!a.m_arguments.empty() && !b.m_arguments.empty() &&
       a.m_arguments.size() == b.m_arguments.size()) {
     // recursively add arguments

--- a/common/type_system/TypeSystem.h
+++ b/common/type_system/TypeSystem.h
@@ -46,6 +46,16 @@ struct ReverseDerefInfo {
     enum Kind { INDEX, FIELD } kind;
     std::string name;
     int index;
+    std::string print() const {
+      switch (kind) {
+        case INDEX:
+          return std::to_string(index);
+        case FIELD:
+          return name;
+        default:
+          assert(false);
+      }
+    }
   };
 
   TypeSpec result_type;

--- a/decompiler/CMakeLists.txt
+++ b/decompiler/CMakeLists.txt
@@ -23,7 +23,11 @@ add_executable(decompiler
 		data/game_count.cpp
 		Function/TypeAnalysis.cpp
 		IR/IR_TypeAnalysis.cpp
-		util/TP_Type.cpp)
+		util/TP_Type.cpp
+		Function/RegUsage.cpp
+		Function/ExpressionBuilder.cpp
+		Function/ExpressionStack.cpp
+		IR/IR_ExpressionStack.cpp)
 
 target_link_libraries(decompiler
         goos

--- a/decompiler/Disasm/Register.cpp
+++ b/decompiler/Disasm/Register.cpp
@@ -109,6 +109,26 @@ Register::Register(Reg::RegisterKind kind, uint32_t num) {
   }
 }
 
+Register::Register(const std::string& name) {
+  // first try gprs,
+  for (int i = 0; i < Reg::MAX_GPR; i++) {
+    if (name == gpr_names[i]) {
+      id = (Reg::GPR << 8) | i;
+      return;
+    }
+  }
+
+  // next fprs
+  for (int i = 0; i < 32; i++) {
+    if (name == fpr_names[i]) {
+      id = (Reg::FPR << 8) | i;
+      return;
+    }
+  }
+
+  throw std::runtime_error("Unknown register name: " + name);
+}
+
 /*!
  * Convert to string. The register must be valid.
  */

--- a/decompiler/Disasm/Register.h
+++ b/decompiler/Disasm/Register.h
@@ -127,6 +127,7 @@ class Register {
  public:
   Register() = default;
   Register(Reg::RegisterKind kind, uint32_t num);
+  Register(const std::string& name);
   const char* to_charp() const;
   std::string to_string() const;
   Reg::RegisterKind get_kind() const;

--- a/decompiler/Function/BasicBlocks.h
+++ b/decompiler/Function/BasicBlocks.h
@@ -10,19 +10,32 @@
 class LinkedObjectFile;
 class Function;
 
+using RegSet = std::unordered_set<Register, Register::hash>;
+
 struct BasicBlock {
   int start_word;
   int end_word;
   TypeState init_types;
 
+  // [start, end)
   int start_basic_op = -1;
   int end_basic_op = -1;
+  int basic_op_size() const { return end_basic_op - start_basic_op; }
 
   std::string label_name;
 
   std::vector<int> pred;
   int succ_ft = -1;
   int succ_branch = -1;
+
+  std::vector<RegSet> live, dead;
+  RegSet use, defs;
+  RegSet input, output;
+
+  bool op_has_reg_live_out(int basic_op_idx, Register reg) {
+    auto& lv = live.at(basic_op_idx - start_basic_op);
+    return lv.find(reg) != lv.end();
+  }
 
   BasicBlock(int _start_word, int _end_word) : start_word(_start_word), end_word(_end_word) {}
 };

--- a/decompiler/Function/CfgVtx.cpp
+++ b/decompiler/Function/CfgVtx.cpp
@@ -1850,7 +1850,7 @@ std::shared_ptr<ControlFlowGraph> build_cfg(const LinkedObjectFile& file, int se
   }
 
   if (!cfg->is_fully_resolved()) {
-    func.warnings += "Failed to fully resolve CFG\n";
+    func.warnings += ";; Failed to fully resolve CFG\n";
   }
 
   return cfg;

--- a/decompiler/Function/ExpressionBuilder.cpp
+++ b/decompiler/Function/ExpressionBuilder.cpp
@@ -1,0 +1,53 @@
+#include "Function.h"
+#include "decompiler/IR/IR.h"
+#include "ExpressionStack.h"
+
+namespace {
+bool expressionize_begin(IR_Begin* begin, LinkedObjectFile& file) {
+  ExpressionStack stack;
+  // todo - this might need to run multiple times?
+  for (auto& op : begin->forms) {
+    op->expression_stack(stack, file);
+  }
+  begin->forms = stack.get_result();
+  return true;
+}
+}  // namespace
+
+bool Function::build_expression(LinkedObjectFile& file) {
+  if (!ir) {
+    return false;
+  }
+
+  try {
+    // first we get a list of begins, which are where we can build up expressions.
+    // we want to start with innermost begins because we'll probably need to do some fixing up
+    // or more complicated analysis to do as good as possible on outer begins.
+    auto all_children = ir->get_all_ir(file);
+    std::vector<IR_Begin*> all_begins;
+    for (auto i = all_children.size(); i-- > 0;) {
+      auto as_begin = dynamic_cast<IR_Begin*>(all_children.at(i).get());
+      if (as_begin) {
+        all_begins.push_back(as_begin);
+      }
+    }
+
+    // the top level may also be a begin
+    auto as_begin = dynamic_cast<IR_Begin*>(ir.get());
+    if (as_begin) {
+      all_begins.push_back(as_begin);
+    }
+
+    // turn each begin into an expression
+    for (auto b : all_begins) {
+      if (!expressionize_begin(b, file)) {
+        return false;
+      }
+    }
+  } catch (std::exception& e) {
+    printf("build_expression failed on %s due to %s\n", guessed_name.to_string().c_str(), e.what());
+    return false;
+  }
+
+  return true;
+}

--- a/decompiler/Function/ExpressionStack.cpp
+++ b/decompiler/Function/ExpressionStack.cpp
@@ -1,0 +1,80 @@
+#include "third-party/fmt/core.h"
+#include "ExpressionStack.h"
+
+std::string ExpressionStack::StackEntry::print(LinkedObjectFile& file) {
+  return fmt::format("d: {} {} <- {}", display, destination.to_charp(), source->print(file));
+}
+
+std::string ExpressionStack::print(LinkedObjectFile& file) {
+  std::string result;
+  for (auto& x : m_stack) {
+    result += x.print(file);
+    result += '\n';
+  }
+  return result;
+}
+
+void ExpressionStack::set(Register reg, std::shared_ptr<IR> value) {
+  StackEntry entry;
+  entry.display = true;  // by default, we should display everything!
+  entry.destination = reg;
+  entry.source = std::move(value);
+  m_stack.push_back(entry);
+}
+
+bool ExpressionStack::is_single_expression() {
+  int count = 0;
+  for (auto& e : m_stack) {
+    if (e.display) {
+      count++;
+    }
+  }
+  return count == 1;
+}
+
+std::shared_ptr<IR> ExpressionStack::get(Register reg) {
+  // see if the stack top is this register...
+  if (!display_stack_empty()) {
+    auto& top = get_display_stack_top();
+    if (top.destination == reg) {
+      // yep. We can compact!
+      top.display = false;
+      return top.source;
+    }
+  }
+  return std::make_shared<IR_Register>(reg, -1);
+}
+
+std::vector<std::shared_ptr<IR>> ExpressionStack::get_result() {
+  std::vector<std::shared_ptr<IR>> result;
+
+  for (auto& e : m_stack) {
+    if (!e.display) {
+      continue;
+    }
+    auto dst_reg = std::make_shared<IR_Register>(e.destination, -1);
+    auto op = std::make_shared<IR_Set>(IR_Set::EXPR, dst_reg, e.source);
+    result.push_back(op);
+  }
+
+  return result;
+}
+
+bool ExpressionStack::display_stack_empty() {
+  for (auto& e : m_stack) {
+    if (e.display) {
+      return false;
+    }
+  }
+  return true;
+}
+
+ExpressionStack::StackEntry& ExpressionStack::get_display_stack_top() {
+  for (size_t i = m_stack.size(); i-- > 0;) {
+    auto& entry = m_stack.at(i);
+    if (entry.display) {
+      return entry;
+    }
+  }
+  assert(false);
+}

--- a/decompiler/Function/ExpressionStack.h
+++ b/decompiler/Function/ExpressionStack.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+#include "decompiler/IR/IR.h"
+#include "decompiler/Disasm/Register.h"
+#include "decompiler/util/TP_Type.h"
+
+class ExpressionStack {
+ public:
+  ExpressionStack() = default;
+  void set(Register reg, std::shared_ptr<IR> value);
+  std::shared_ptr<IR> get(Register reg);
+  bool is_single_expression();
+  std::string print(LinkedObjectFile& file);
+  std::vector<std::shared_ptr<IR>> get_result();
+
+ private:
+  struct StackEntry {
+    bool display = true;         // should this appear in the output?
+    Register destination;        // what register we are setting
+    std::shared_ptr<IR> source;  // the value we are setting the register to.
+    // TP_Type type;
+    std::string print(LinkedObjectFile& file);
+  };
+  std::vector<StackEntry> m_stack;
+
+  bool display_stack_empty();
+  StackEntry& get_display_stack_top();
+};

--- a/decompiler/Function/Function.cpp
+++ b/decompiler/Function/Function.cpp
@@ -71,7 +71,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
       if (instr.kind == InstructionKind::SW && instr.get_src(0).get_reg() == make_gpr(Reg::SP)) {
         printf("[Warning] %s Suspected ASM function based on this instruction in prologue: %s\n",
                guessed_name.to_string().c_str(), instr.to_string(file).c_str());
-        warnings += "Flagged as ASM function because of " + instr.to_string(file) + "\n";
+        warnings += ";; Flagged as ASM function because of " + instr.to_string(file) + "\n";
         suspected_asm = true;
         return;
       }
@@ -94,7 +94,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
       if (instr.kind == InstructionKind::SD && instr.get_src(0).get_reg() == make_gpr(Reg::S7)) {
         spdlog::warn("{} Suspected ASM function based on this instruction in prologue: {}\n",
                      guessed_name.to_string(), instr.to_string(file));
-        warnings += "Flagged as ASM function because of " + instr.to_string(file) + "\n";
+        warnings += ";; Flagged as ASM function because of " + instr.to_string(file) + "\n";
         suspected_asm = true;
         return;
       }
@@ -134,7 +134,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
             "[Warning] %s Stack Zeroing Detected in Function::analyze_prologue, prologue may be "
             "wrong\n",
             guessed_name.to_string().c_str());
-        warnings += "Stack Zeroing Detected, prologue may be wrong\n";
+        warnings += ";; Stack Zeroing Detected, prologue may be wrong\n";
         expect_nothing_after_gprs = true;
         break;
       }
@@ -146,7 +146,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
         printf(
             "[Warning] %s Suspected ASM function because register $a0 was stored on the stack!\n",
             guessed_name.to_string().c_str());
-        warnings += "a0 on stack detected, flagging as asm\n";
+        warnings += ";; a0 on stack detected, flagging as asm\n";
         return;
       }
 
@@ -165,7 +165,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
           printf("[Warning] %s Suspected asm function that isn't flagged due to stack store %s\n",
                  guessed_name.to_string().c_str(),
                  instructions.at(idx + i).to_string(file).c_str());
-          warnings += "Suspected asm function due to stack store: " +
+          warnings += ";; Suspected asm function due to stack store: " +
                       instructions.at(idx + i).to_string(file) + "\n";
           return;
         }
@@ -195,7 +195,7 @@ void Function::analyze_prologue(const LinkedObjectFile& file) {
             printf("[Warning] %s Suspected asm function that isn't flagged due to stack store %s\n",
                    guessed_name.to_string().c_str(),
                    instructions.at(idx + i).to_string(file).c_str());
-            warnings += "Suspected asm function due to stack store: " +
+            warnings += ";; Suspected asm function due to stack store: " +
                         instructions.at(idx + i).to_string(file) + "\n";
             return;
           }
@@ -356,7 +356,7 @@ void Function::check_epilogue(const LinkedObjectFile& file) {
           "[Warning] %s Double Return Epilogue Hack!  This is probably an ASM function in "
           "disguise\n",
           guessed_name.to_string().c_str());
-      warnings += "Double Return Epilogue - this is probably an ASM function\n";
+      warnings += ";; Double Return Epilogue - this is probably an ASM function\n";
     }
     // delay slot should be daddiu sp, sp, offset
     assert(is_gpr_2_imm_int(instructions.at(idx), InstructionKind::DADDIU, make_gpr(Reg::SP),

--- a/decompiler/Function/Function.h
+++ b/decompiler/Function/Function.h
@@ -7,7 +7,9 @@
 #include <vector>
 #include <unordered_map>
 #include <stdexcept>
+#include <unordered_set>
 #include "decompiler/Disasm/Instruction.h"
+#include "decompiler/Disasm/Register.h"
 #include "BasicBlocks.h"
 #include "CfgVtx.h"
 #include "common/type_system/TypeSpec.h"
@@ -80,6 +82,8 @@ class Function {
   bool run_type_analysis(const TypeSpec& my_type,
                          DecompilerTypeSystem& dts,
                          LinkedObjectFile& file);
+  void run_reg_usage();
+  bool build_expression(LinkedObjectFile& file);
   BlockTopologicalSort bb_topo_sort();
 
   TypeSpec type;

--- a/decompiler/Function/Function.h
+++ b/decompiler/Function/Function.h
@@ -13,6 +13,7 @@
 #include "BasicBlocks.h"
 #include "CfgVtx.h"
 #include "common/type_system/TypeSpec.h"
+#include "decompiler/config.h"
 
 class DecompilerTypeSystem;
 class IR_Atomic;
@@ -81,7 +82,8 @@ class Function {
   int get_reginfo_basic_op_count();
   bool run_type_analysis(const TypeSpec& my_type,
                          DecompilerTypeSystem& dts,
-                         LinkedObjectFile& file);
+                         LinkedObjectFile& file,
+                         const std::unordered_map<int, std::vector<TypeHint>>& hints);
   void run_reg_usage();
   bool build_expression(LinkedObjectFile& file);
   BlockTopologicalSort bb_topo_sort();

--- a/decompiler/Function/RegUsage.cpp
+++ b/decompiler/Function/RegUsage.cpp
@@ -1,0 +1,165 @@
+#include "Function.h"
+#include "decompiler/IR/IR.h"
+
+namespace {
+bool in_set(RegSet& set, const Register& obj) {
+  return set.find(obj) != set.end();
+}
+
+void phase1(Function& f, BasicBlock& block) {
+  for (int i = block.end_basic_op; i-- > block.start_basic_op;) {
+    auto& instr = f.basic_ops.at(i);
+    auto& lv = block.live.at(i - block.start_basic_op);
+    auto& dd = block.dead.at(i - block.start_basic_op);
+
+    // make all read live out
+    auto read = instr->read_regs;
+    lv.clear();
+    for (auto& x : read) {
+      lv.insert(x);
+    }
+
+    // kill things which are overwritten
+    dd.clear();
+    auto write = instr->write_regs;
+    for (auto& x : write) {
+      if (!in_set(lv, x)) {
+        dd.insert(x);
+      }
+    }
+
+    // b.use = i.liveout
+    RegSet use_old = block.use;
+    block.use.clear();
+    for (auto& x : lv) {
+      block.use.insert(x);
+    }
+    // | (bu.use & !i.dead)
+    for (auto& x : use_old) {
+      if (!in_set(dd, x)) {
+        block.use.insert(x);
+      }
+    }
+
+    // b.defs = i.dead
+    RegSet defs_old = block.defs;
+    block.defs.clear();
+    for (auto& x : dd) {
+      block.defs.insert(x);
+    }
+    // | b.defs & !i.lv
+    for (auto& x : defs_old) {
+      if (!in_set(lv, x)) {
+        block.defs.insert(x);
+      }
+    }
+  }
+}
+
+bool phase2(std::vector<BasicBlock>& blocks, BasicBlock& block) {
+  bool changed = false;
+  auto out = block.defs;
+
+  for (auto s : {block.succ_branch, block.succ_ft}) {
+    if (s == -1) {
+      continue;
+    }
+    for (auto in : blocks.at(s).input) {
+      out.insert(in);
+    }
+  }
+
+  RegSet in = block.use;
+  for (auto x : out) {
+    if (!in_set(block.defs, x)) {
+      in.insert(x);
+    }
+  }
+
+  if (in != block.input || out != block.output) {
+    changed = true;
+    block.input = in;
+    block.output = out;
+  }
+
+  return changed;
+}
+
+void phase3(std::vector<BasicBlock>& blocks, BasicBlock& block) {
+  RegSet live_local;
+  for (auto s : {block.succ_branch, block.succ_ft}) {
+    if (s == -1) {
+      continue;
+    }
+    for (auto i : blocks.at(s).input) {
+      live_local.insert(i);
+    }
+  }
+
+  for (int i = block.end_basic_op; i-- > block.start_basic_op;) {
+    auto& lv = block.live.at(i - block.start_basic_op);
+    auto& dd = block.dead.at(i - block.start_basic_op);
+
+    RegSet new_live = lv;
+    for (auto x : live_local) {
+      if (!in_set(dd, x)) {
+        new_live.insert(x);
+      }
+    }
+    lv = live_local;
+    live_local = new_live;
+  }
+}
+
+}  // namespace
+/*!
+ * Analyze the function use of registers to determine which are live where.
+ */
+void Function::run_reg_usage() {
+  // phase 1
+  for (auto& block : basic_blocks) {
+    block.live.resize(block.basic_op_size());
+    block.dead.resize(block.basic_op_size());
+    phase1(*this, block);
+  }
+
+  // phase 2
+  bool changed = false;
+  do {
+    changed = false;
+    for (auto& block : basic_blocks) {
+      if (phase2(basic_blocks, block)) {
+        changed = true;
+      }
+    }
+  } while (changed);
+
+  // phase 3
+  for (auto& block : basic_blocks) {
+    phase3(basic_blocks, block);
+  }
+
+  // we want to know if an op "consumes" a register.
+  // this means that the value of the register coming in to the operation is:
+  // A. read by the operation.
+  // B. no longer read after the operation.
+  for (auto& block : basic_blocks) {
+    for (int i = block.start_basic_op; i < block.end_basic_op; i++) {
+      auto& op = basic_ops.at(i);
+      // look at each register that we read
+      for (auto reg : op->read_regs) {
+        if (!block.op_has_reg_live_out(i, reg)) {
+          // if the register is not live out, we definitely consume it.
+          op->consumed.insert(reg);
+        } else {
+          // it's live out... but it could be a new value.
+          for (auto wr : op->write_regs) {
+            if (wr == reg) {
+              op->consumed.insert(reg);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/decompiler/Function/TypeAnalysis.cpp
+++ b/decompiler/Function/TypeAnalysis.cpp
@@ -65,7 +65,7 @@ bool Function::run_type_analysis(const TypeSpec& my_type,
         try {
           op->propagate_types(*init_types, file, dts);
         } catch (std::runtime_error& e) {
-          fmt::print("Type prop fail: {}\n\n\n", e.what());
+          fmt::print("Type prop fail on {}: {}\n", guessed_name.to_string(), e.what());
           warnings += "Type prop attempted and failed.  ";
           return false;
         }

--- a/decompiler/Function/TypeAnalysis.cpp
+++ b/decompiler/Function/TypeAnalysis.cpp
@@ -20,7 +20,12 @@ TypeState construct_initial_typestate(const TypeSpec& f_ts) {
 
 void apply_hints(const std::vector<TypeHint>& hints, TypeState* state, DecompilerTypeSystem& dts) {
   for (auto& hint : hints) {
-    state->get(hint.reg) = TP_Type::make_from_typespec(dts.parse_type_spec(hint.type_name));
+    try {
+      state->get(hint.reg) = TP_Type::make_from_typespec(dts.parse_type_spec(hint.type_name));
+    } catch (std::exception& e) {
+      printf("failed to parse hint: %s\n", e.what());
+      assert(false);
+    }
   }
 }
 

--- a/decompiler/Function/TypeAnalysis.cpp
+++ b/decompiler/Function/TypeAnalysis.cpp
@@ -66,7 +66,7 @@ bool Function::run_type_analysis(const TypeSpec& my_type,
           op->propagate_types(*init_types, file, dts);
         } catch (std::runtime_error& e) {
           fmt::print("Type prop fail on {}: {}\n", guessed_name.to_string(), e.what());
-          warnings += "Type prop attempted and failed.  ";
+          warnings += ";; Type prop attempted and failed.\n";
           return false;
         }
 
@@ -93,7 +93,7 @@ bool Function::run_type_analysis(const TypeSpec& my_type,
   auto last_op = basic_ops.back();
   auto last_type = last_op->end_types.get(Register(Reg::GPR, Reg::V0)).as_typespec();
   if (last_type != my_type.last_arg()) {
-    warnings += fmt::format("return type mismatch {} vs {}.  ", last_type.print(),
+    warnings += fmt::format(";; return type mismatch {} vs {}.  ", last_type.print(),
                             my_type.last_arg().print());
   }
 

--- a/decompiler/Function/TypeAnalysis.cpp
+++ b/decompiler/Function/TypeAnalysis.cpp
@@ -13,15 +13,14 @@ TypeState construct_initial_typestate(const TypeSpec& f_ts) {
   for (int i = 0; i < int(f_ts.arg_count()) - 1; i++) {
     auto reg_id = goal_args[i];
     auto reg_type = f_ts.get_arg(i);
-    result.gpr_types[reg_id].ts = reg_type;
-    result.gpr_types[reg_id].kind = TP_Type::OBJECT_OF_TYPE;
+    result.gpr_types[reg_id] = TP_Type::make_from_typespec(reg_type);
   }
   return result;
 }
 
 void apply_hints(const std::vector<TypeHint>& hints, TypeState* state, DecompilerTypeSystem& dts) {
   for (auto& hint : hints) {
-    state->get(hint.reg) = TP_Type(dts.parse_type_spec(hint.type_name));
+    state->get(hint.reg) = TP_Type::make_from_typespec(dts.parse_type_spec(hint.type_name));
   }
 }
 
@@ -118,7 +117,7 @@ bool Function::run_type_analysis(const TypeSpec& my_type,
   }
 
   auto last_op = basic_ops.back();
-  auto last_type = last_op->end_types.get(Register(Reg::GPR, Reg::V0)).as_typespec();
+  auto last_type = last_op->end_types.get(Register(Reg::GPR, Reg::V0)).typespec();
   if (last_type != my_type.last_arg()) {
     warnings += fmt::format(";; return type mismatch {} vs {}.  ", last_type.print(),
                             my_type.last_arg().print());

--- a/decompiler/Function/TypeAnalysis.cpp
+++ b/decompiler/Function/TypeAnalysis.cpp
@@ -9,7 +9,7 @@ TypeState construct_initial_typestate(const TypeSpec& f_ts) {
   int goal_args[] = {Reg::A0, Reg::A1, Reg::A2, Reg::A3, Reg::T0, Reg::T1, Reg::T2, Reg::T3};
   assert(f_ts.base_type() == "function");
   assert(f_ts.arg_count() >= 1);
-  assert(f_ts.arg_count() <= 8);
+  assert(f_ts.arg_count() <= 8 + 1);  // 8 args + 1 return.
   for (int i = 0; i < int(f_ts.arg_count()) - 1; i++) {
     auto reg_id = goal_args[i];
     auto reg_type = f_ts.get_arg(i);

--- a/decompiler/IR/BasicOpBuilder.cpp
+++ b/decompiler/IR/BasicOpBuilder.cpp
@@ -1403,6 +1403,12 @@ std::shared_ptr<IR_Atomic> try_beq(Instruction& instr, Instruction& next_instr, 
         instr.get_src(2).get_label(), get_branch_delay(next_instr, idx), false);
     op->update_reginfo_self(0, 1, 0);
     return op;
+  } else if (instr.kind == InstructionKind::BEQ && instr.get_src(1).is_reg(make_gpr(Reg::R0))) {
+    auto op = std::make_shared<IR_Branch_Atomic>(
+        Condition(Condition::ZERO, make_reg(instr.get_src(0).get_reg(), idx), nullptr, nullptr),
+        instr.get_src(2).get_label(), get_branch_delay(next_instr, idx), false);
+    op->update_reginfo_self(0, 1, 0);
+    return op;
   } else if (instr.kind == InstructionKind::BEQ) {
     auto op = std::make_shared<IR_Branch_Atomic>(
         Condition(Condition::EQUAL, make_reg(instr.get_src(0).get_reg(), idx),
@@ -1646,12 +1652,22 @@ std::shared_ptr<IR_Atomic> try_slt(Instruction& i0, Instruction& i1, Instruction
     if (i2.get_src(1).get_reg() != clobber_reg) {
       return nullptr;  // TODO!
     }
-    auto op = make_set_atomic(IR_Set_Atomic::REG_64, make_reg(dst_reg, idx),
-                              std::make_shared<IR_Compare>(
-                                  Condition(Condition::LESS_THAN_SIGNED, make_reg(src0_reg, idx),
-                                            make_reg(src1_reg, idx), make_reg(clobber_reg, idx))));
-    op->update_reginfo_self<IR_Compare>(1, 2, 1);
-    return op;
+    if (src1_reg == make_gpr(Reg::R0)) {
+      auto op = make_set_atomic(
+          IR_Set_Atomic::REG_64, make_reg(dst_reg, idx),
+          std::make_shared<IR_Compare>(Condition(Condition::LESS_THAN_ZERO, make_reg(src0_reg, idx),
+                                                 nullptr, make_reg(clobber_reg, idx))));
+      op->update_reginfo_self<IR_Compare>(1, 1, 1);
+      return op;
+    } else {
+      auto op = make_set_atomic(IR_Set_Atomic::REG_64, make_reg(dst_reg, idx),
+                                std::make_shared<IR_Compare>(Condition(
+                                    Condition::LESS_THAN_SIGNED, make_reg(src0_reg, idx),
+                                    make_reg(src1_reg, idx), make_reg(clobber_reg, idx))));
+      op->update_reginfo_self<IR_Compare>(1, 2, 1);
+      return op;
+    }
+
   } else if (i0.kind == InstructionKind::SLT && i1.kind == InstructionKind::BEQ) {
     auto clobber_reg = i0.get_dst(0).get_reg();
     auto src0_reg = i0.get_src(0).get_reg();

--- a/decompiler/IR/BasicOpBuilder.cpp
+++ b/decompiler/IR/BasicOpBuilder.cpp
@@ -1532,7 +1532,7 @@ std::shared_ptr<IR_Atomic> try_slt(Instruction& i0, Instruction& i1, int idx) {
       result->clobber_regs.push_back(temp);
       result->write_regs.push_back(left);
       result->read_regs.push_back(right);
-      result->read_regs.push_back(right);
+      result->read_regs.push_back(left);
       result->reg_info_set = true;
       return result;
     }
@@ -1547,7 +1547,7 @@ std::shared_ptr<IR_Atomic> try_slt(Instruction& i0, Instruction& i1, int idx) {
       result->clobber_regs.push_back(temp);
       result->write_regs.push_back(left);
       result->read_regs.push_back(right);
-      result->read_regs.push_back(right);
+      result->read_regs.push_back(left);
       result->reg_info_set = true;
       return result;
     }

--- a/decompiler/IR/BasicOpBuilder.cpp
+++ b/decompiler/IR/BasicOpBuilder.cpp
@@ -2435,7 +2435,7 @@ void add_basic_ops_to_block(Function* func, const BasicBlock& block, LinkedObjec
       func->add_basic_op(std::make_shared<IR_Failed_Atomic>(), instr, instr + 1);
     } else {
       if (!func->contains_asm_ops && dynamic_cast<IR_AsmOp*>(result.get())) {
-        func->warnings += "Function contains asm op";
+        func->warnings += ";; Function contains asm op\n";
         func->contains_asm_ops = true;
       }
 

--- a/decompiler/IR/CfgBuilder.cpp
+++ b/decompiler/IR/CfgBuilder.cpp
@@ -1145,7 +1145,6 @@ std::shared_ptr<IR> build_cfg_ir(Function& function,
     auto all_children = ir->get_all_ir(file);
     all_children.push_back(ir);
     for (auto& child : all_children) {
-      //      printf("child is %s\n", child->print(file).c_str());
       auto as_begin = dynamic_cast<IR_Begin*>(child.get());
       if (as_begin) {
         clean_up_while_loops(as_begin, file);

--- a/decompiler/IR/CfgBuilder.cpp
+++ b/decompiler/IR/CfgBuilder.cpp
@@ -623,7 +623,8 @@ std::shared_ptr<IR> try_sc_as_abs(Function& f, LinkedObjectFile& file, ShortCirc
   auto b0_ptr = cfg_to_ir(f, file, b0);
   auto b0_ir = dynamic_cast<IR_Begin*>(b0_ptr.get());
 
-  auto branch = dynamic_cast<IR_Branch*>(b0_ir->forms.back().get());
+  auto branch_sp = b0_ir->forms.back();
+  auto branch = dynamic_cast<IR_Branch*>(branch_sp.get());
   if (!branch) {
     return nullptr;
   }
@@ -647,7 +648,10 @@ std::shared_ptr<IR> try_sc_as_abs(Function& f, LinkedObjectFile& file, ShortCirc
     b0_ir->forms.pop_back();
     // add the ash
     b0_ir->forms.push_back(std::make_shared<IR_Set>(
-        IR_Set::REG_64, output, std::make_shared<IR_IntMath1>(IR_IntMath1::ABS, input)));
+        IR_Set::REG_64, output,
+        std::make_shared<IR_IntMath1>(IR_IntMath1::ABS, input,
+                                      std::dynamic_pointer_cast<IR_Atomic>(branch_sp))));
+
     return b0_ptr;
   }
 
@@ -682,7 +686,8 @@ std::shared_ptr<IR> try_sc_as_ash(Function& f, LinkedObjectFile& file, ShortCirc
     return nullptr;
   }
 
-  auto branch = dynamic_cast<IR_Branch*>(b0_ir->forms.back().get());
+  auto branch_sp = b0_ir->forms.back();
+  auto branch = dynamic_cast<IR_Branch*>(branch_sp.get());
   if (!branch || b1_ir->forms.size() != 2) {
     return nullptr;
   }
@@ -752,7 +757,10 @@ std::shared_ptr<IR> try_sc_as_ash(Function& f, LinkedObjectFile& file, ShortCirc
     // add the ash
     b0_ir->forms.push_back(std::make_shared<IR_Set>(
         IR_Set::REG_64, dest_ir,
-        std::make_shared<IR_Ash>(shift_ir, value_ir, clobber_ir, is_arith)));
+        std::make_shared<IR_Ash>(shift_ir, value_ir, clobber_ir,
+                                 std::dynamic_pointer_cast<IR_Branch_Atomic>(branch_sp),
+                                 std::dynamic_pointer_cast<IR_Atomic>(dsubu_candidate),
+                                 std::dynamic_pointer_cast<IR_Atomic>(dsrav_candidate), is_arith)));
     return b0_ptr;
   }
 

--- a/decompiler/IR/IR.cpp
+++ b/decompiler/IR/IR.cpp
@@ -94,6 +94,14 @@ std::string IR_Atomic::print_with_types(const TypeState& init_types,
 
   result += fmt::format("[{}] -> [{}]", init_types.print_gpr_masked(read_mask),
                         end_types.print_gpr_masked(write_mask));
+
+  if (!consumed.empty()) {
+    result += "c:";
+    for (auto x : consumed) {
+      result += " ";
+      result += x.to_charp();
+    }
+  }
   return result;
 }
 

--- a/decompiler/IR/IR.cpp
+++ b/decompiler/IR/IR.cpp
@@ -3,6 +3,9 @@
 #include "common/goos/PrettyPrinter.h"
 #include "third-party/fmt/core.h"
 
+// hack to print out reverse deref paths on loads to help with debugging load stuff.
+bool enable_hack_load_path_print = false;
+
 std::vector<std::shared_ptr<IR>> IR::get_all_ir(LinkedObjectFile& file) const {
   (void)file;
   std::vector<std::shared_ptr<IR>> result;
@@ -404,6 +407,19 @@ void IR_StaticAddress::get_children(std::vector<std::shared_ptr<IR>>* output) co
 }
 
 goos::Object IR_Load::to_form(const LinkedObjectFile& file) const {
+  if (load_path_set && enable_hack_load_path_print) {
+    std::vector<goos::Object> list;
+    if (load_path_addr_of) {
+      list.push_back(pretty_print::to_symbol("&->"));
+    } else {
+      list.push_back(pretty_print::to_symbol("->"));
+    }
+    list.push_back(load_path_base->to_form(file));
+    for (auto& x : load_path) {
+      list.push_back(pretty_print::to_symbol(x));
+    }
+    return pretty_print::build_list(list);
+  }
   std::string load_operator;
   switch (kind) {
     case FLOAT:
@@ -609,6 +625,12 @@ goos::Object IR_Call::to_form(const LinkedObjectFile& file) const {
   (void)file;
   std::vector<goos::Object> result;
   result.push_back(pretty_print::to_symbol("call!"));
+
+  if (call_type_set) {
+    result.push_back(pretty_print::to_symbol(":arg-count"));
+    result.push_back(pretty_print::to_symbol(std::to_string(call_type.arg_count() - 1)));
+  }
+
   for (auto& x : args) {
     result.push_back(x->to_form(file));
   }

--- a/decompiler/IR/IR.cpp
+++ b/decompiler/IR/IR.cpp
@@ -94,6 +94,7 @@ std::string IR_Atomic::print_with_types(const TypeState& init_types,
 
   auto read_mask = regs_to_gpr_mask(read_regs);
   auto write_mask = regs_to_gpr_mask(write_regs);
+  write_mask |= regs_to_gpr_mask({Register(Reg::GPR, Reg::A0)});
 
   result += fmt::format("[{}] -> [{}]", init_types.print_gpr_masked(read_mask),
                         end_types.print_gpr_masked(write_mask));

--- a/decompiler/IR/IR.cpp
+++ b/decompiler/IR/IR.cpp
@@ -94,7 +94,6 @@ std::string IR_Atomic::print_with_types(const TypeState& init_types,
 
   auto read_mask = regs_to_gpr_mask(read_regs);
   auto write_mask = regs_to_gpr_mask(write_regs);
-  write_mask |= regs_to_gpr_mask({Register(Reg::GPR, Reg::A0)});
 
   result += fmt::format("[{}] -> [{}]", init_types.print_gpr_masked(read_mask),
                         end_types.print_gpr_masked(write_mask));
@@ -387,15 +386,6 @@ goos::Object IR_EmptyPair::to_form(const LinkedObjectFile& file) const {
 
 void IR_EmptyPair::get_children(std::vector<std::shared_ptr<IR>>* output) const {
   (void)output;
-}
-
-TP_Type IR_EmptyPair::get_expression_type(const TypeState& input,
-                                          const LinkedObjectFile& file,
-                                          DecompilerTypeSystem& dts) {
-  (void)input;
-  (void)file;
-  (void)dts;
-  return TP_Type(TypeSpec("pair"));
 }
 
 goos::Object IR_StaticAddress::to_form(const LinkedObjectFile& file) const {

--- a/decompiler/IR/IR.cpp
+++ b/decompiler/IR/IR.cpp
@@ -607,7 +607,12 @@ goos::Object IR_FloatMath1::to_form(const LinkedObjectFile& file) const {
 
 goos::Object IR_Call::to_form(const LinkedObjectFile& file) const {
   (void)file;
-  return pretty_print::build_list("call!");
+  std::vector<goos::Object> result;
+  result.push_back(pretty_print::to_symbol("call!"));
+  for (auto& x : args) {
+    result.push_back(x->to_form(file));
+  }
+  return pretty_print::build_list(result);
 }
 
 void IR_Call::get_children(std::vector<std::shared_ptr<IR>>* output) const {

--- a/decompiler/IR/IR.h
+++ b/decompiler/IR/IR.h
@@ -278,9 +278,9 @@ class IR_FloatMath1 : public virtual IR {
   std::shared_ptr<IR> arg;
   goos::Object to_form(const LinkedObjectFile& file) const override;
   void get_children(std::vector<std::shared_ptr<IR>>* output) const override;
-  TP_Type get_expression_type(const TypeState& input,
-                              const LinkedObjectFile& file,
-                              DecompilerTypeSystem& dts) override;
+  //  TP_Type get_expression_type(const TypeState& input,
+  //                              const LinkedObjectFile& file,
+  //                              DecompilerTypeSystem& dts) override;
 };
 
 class IR_IntMath2 : public virtual IR {
@@ -517,9 +517,9 @@ class IR_Breakpoint_Atomic : public virtual IR_Atomic {
   IR_Breakpoint_Atomic() = default;
   goos::Object to_form(const LinkedObjectFile& file) const override;
   void get_children(std::vector<std::shared_ptr<IR>>* output) const override;
-  void propagate_types(const TypeState& input,
-                       const LinkedObjectFile& file,
-                       DecompilerTypeSystem& dts) override;
+  //  void propagate_types(const TypeState& input,
+  //                       const LinkedObjectFile& file,
+  //                       DecompilerTypeSystem& dts) override;
 };
 
 class IR_Begin : public virtual IR {
@@ -655,9 +655,9 @@ class IR_AsmOp_Atomic : public virtual IR_AsmOp, public IR_Atomic {
  public:
   IR_AsmOp_Atomic(std::string _name) : IR_AsmOp(std::move(_name)) {}
   void set_reg_info();
-  void propagate_types(const TypeState& input,
-                       const LinkedObjectFile& file,
-                       DecompilerTypeSystem& dts) override;
+  //  void propagate_types(const TypeState& input,
+  //                       const LinkedObjectFile& file,
+  //                       DecompilerTypeSystem& dts) override;
 };
 
 class IR_CMoveF : public virtual IR {

--- a/decompiler/IR/IR.h
+++ b/decompiler/IR/IR.h
@@ -240,6 +240,19 @@ class IR_Load : public virtual IR {
   bool update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
                          ExpressionStack& stack,
                          LinkedObjectFile& file) override;
+
+  // this load_path stuff is just for debugging and shouldn't be used as part of the real
+  // decompilation.
+  void clear_load_path() {
+    load_path_set = false;
+    load_path_addr_of = false;
+    load_path.clear();
+    load_path_base = nullptr;
+  }
+  std::shared_ptr<IR> load_path_base = nullptr;
+  bool load_path_set = false;
+  bool load_path_addr_of = false;
+  std::vector<std::string> load_path;
 };
 
 class IR_FloatMath2 : public virtual IR {
@@ -331,6 +344,8 @@ class IR_Call : public virtual IR {
   goos::Object to_form(const LinkedObjectFile& file) const override;
   void get_children(std::vector<std::shared_ptr<IR>>* output) const override;
   std::vector<std::shared_ptr<IR>> args;
+  TypeSpec call_type;
+  bool call_type_set = false;
 };
 
 // todo
@@ -341,8 +356,6 @@ class IR_Call_Atomic : public virtual IR_Call, public IR_Atomic {
                        const LinkedObjectFile& file,
                        DecompilerTypeSystem& dts) override;
   bool expression_stack(ExpressionStack& stack, LinkedObjectFile& file) override;
-  TypeSpec call_type;
-  bool call_type_set = false;
 };
 
 class IR_IntegerConstant : public virtual IR {

--- a/decompiler/IR/IR_ExpressionStack.cpp
+++ b/decompiler/IR/IR_ExpressionStack.cpp
@@ -73,6 +73,7 @@ bool IR_Set::expression_stack(ExpressionStack& stack, LinkedObjectFile& file) {
 }
 
 bool IR_Call_Atomic::expression_stack(ExpressionStack& stack, LinkedObjectFile& file) {
+  (void)file;
   if (!call_type_set) {
     throw std::runtime_error("Call type is unknown on an IR_Call_Atomic");
   }

--- a/decompiler/IR/IR_ExpressionStack.cpp
+++ b/decompiler/IR/IR_ExpressionStack.cpp
@@ -1,0 +1,82 @@
+#include "IR.h"
+#include "decompiler/Function/ExpressionStack.h"
+
+bool IR_Set_Atomic::expression_stack(ExpressionStack& stack, LinkedObjectFile& file) {
+  // first determine the type of the set.
+  switch (kind) {
+    case IR_Set::REG_64:
+    case IR_Set::LOAD:
+    case IR_Set::GPR_TO_FPR:  // TODO - this should probably not be invisible.
+    case IR_Set::FPR_TO_GPR64:
+    case IR_Set::REG_FLT: {
+      // normal 64-bit GPR set!
+      // first, we update our source to substitute in more complicated expressions.
+      auto src_as_reg = dynamic_cast<IR_Register*>(src.get());
+      if (src_as_reg) {
+        // an annoying special case.
+        if (consumed.find(src_as_reg->reg) != consumed.end()) {
+          // we consume it.
+          src = stack.get(src_as_reg->reg);
+        }
+      } else {
+        src->update_from_stack(consumed, stack, file);
+      }
+
+      // next, we tell the stack the value of the register we just set
+      auto dest_reg = dynamic_cast<IR_Register*>(dst.get());
+      assert(dest_reg);
+      stack.set(dest_reg->reg, src);
+      return true;
+    }
+
+    break;
+    default:
+      throw std::runtime_error("IR_Set_Atomic::expression_stack NYI for " + print(file));
+  }
+}
+
+bool IR_Load::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
+                                ExpressionStack& stack,
+                                LinkedObjectFile& file) {
+  return location->update_from_stack(consume, stack, file);
+}
+
+bool IR_StaticAddress::update_from_stack(
+    const std::unordered_set<Register, Register::hash>& consume,
+    ExpressionStack& stack,
+    LinkedObjectFile& file) {
+  (void)consume;
+  (void)stack;
+  (void)file;
+  return true;
+}
+
+bool IR_FloatMath2::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
+                                      ExpressionStack& stack,
+                                      LinkedObjectFile& file) {
+  if (kind == DIV) {
+    for (auto reg : {&arg1, &arg0}) {
+      auto as_reg = dynamic_cast<IR_Register*>(reg->get());
+      if (as_reg) {
+        if (consume.find(as_reg->reg) != consume.end()) {
+          *reg = stack.get(as_reg->reg);
+        }
+      } else {
+        (*reg)->update_from_stack(consume, stack, file);
+      }
+    }
+  } else {
+    for (auto reg : {&arg0, &arg1}) {
+      auto as_reg = dynamic_cast<IR_Register*>(reg->get());
+      if (as_reg) {
+        if (consume.find(as_reg->reg) != consume.end()) {
+          *reg = stack.get(as_reg->reg);
+        }
+      } else {
+        (*reg)->update_from_stack(consume, stack, file);
+      }
+    }
+  }
+
+  return true;
+}

--- a/decompiler/IR/IR_ExpressionStack.cpp
+++ b/decompiler/IR/IR_ExpressionStack.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "IR.h"
 #include "decompiler/Function/ExpressionStack.h"
 
@@ -8,7 +9,8 @@ bool IR_Set_Atomic::expression_stack(ExpressionStack& stack, LinkedObjectFile& f
     case IR_Set::LOAD:
     case IR_Set::GPR_TO_FPR:  // TODO - this should probably not be invisible.
     case IR_Set::FPR_TO_GPR64:
-    case IR_Set::REG_FLT: {
+    case IR_Set::REG_FLT:
+    case IR_Set::SYM_LOAD: {
       // normal 64-bit GPR set!
       // first, we update our source to substitute in more complicated expressions.
       auto src_as_reg = dynamic_cast<IR_Register*>(src.get());
@@ -35,10 +37,84 @@ bool IR_Set_Atomic::expression_stack(ExpressionStack& stack, LinkedObjectFile& f
   }
 }
 
+bool IR_Set::expression_stack(ExpressionStack& stack, LinkedObjectFile& file) {
+  // first determine the type of the set.
+  switch (kind) {
+    case IR_Set::REG_64:
+    case IR_Set::LOAD:
+    case IR_Set::GPR_TO_FPR:  // TODO - this should probably not be invisible.
+    case IR_Set::FPR_TO_GPR64:
+    case IR_Set::REG_FLT: {
+      // normal 64-bit GPR set!
+      // first, we update our source to substitute in more complicated expressions.
+      auto consumed = src->get_consumed(file);
+      auto src_as_reg = dynamic_cast<IR_Register*>(src.get());
+      if (src_as_reg) {
+        // an annoying special case.
+        if (consumed.find(src_as_reg->reg) != consumed.end()) {
+          // we consume it.
+          src = stack.get(src_as_reg->reg);
+        }
+      } else {
+        src->update_from_stack(consumed, stack, file);
+      }
+
+      // next, we tell the stack the value of the register we just set
+      auto dest_reg = dynamic_cast<IR_Register*>(dst.get());
+      assert(dest_reg);
+      stack.set(dest_reg->reg, src);
+      return true;
+    }
+
+    break;
+    default:
+      throw std::runtime_error("IR_Set_Atomic::expression_stack NYI for " + print(file));
+  }
+}
+
+bool IR_Call_Atomic::expression_stack(ExpressionStack& stack, LinkedObjectFile& file) {
+  if (!call_type_set) {
+    throw std::runtime_error("Call type is unknown on an IR_Call_Atomic");
+  }
+
+  const Reg::Gpr arg_regs[8] = {Reg::A0, Reg::A1, Reg::A2, Reg::A3,
+                                Reg::T0, Reg::T1, Reg::T2, Reg::T3};
+  int nargs = int(call_type.arg_count()) - 1;
+  // get all arguments.
+  for (int i = nargs; i-- > 0;) {
+    args.push_back(stack.get(Register(Reg::GPR, arg_regs[i])));
+  }
+  args.push_back(stack.get(Register(Reg::GPR, Reg::T9)));
+  std::reverse(args.begin(), args.end());
+
+  auto return_type = call_type.get_arg(call_type.arg_count() - 1);
+  // bleh...
+  stack.set(Register(Reg::GPR, Reg::V0), std::make_shared<IR_Call_Atomic>(*this));
+
+  return true;
+}
+
+namespace {
+void update_from_stack_helper(std::shared_ptr<IR>* ir,
+                              const std::unordered_set<Register, Register::hash>& consume,
+                              ExpressionStack& stack,
+                              LinkedObjectFile& file) {
+  auto as_reg = dynamic_cast<IR_Register*>(ir->get());
+  if (as_reg) {
+    if (consume.find(as_reg->reg) != consume.end()) {
+      *ir = stack.get(as_reg->reg);
+    }
+  } else {
+    (*ir)->update_from_stack(consume, stack, file);
+  }
+}
+}  // namespace
+
 bool IR_Load::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
                                 ExpressionStack& stack,
                                 LinkedObjectFile& file) {
-  return location->update_from_stack(consume, stack, file);
+  update_from_stack_helper(&location, consume, stack, file);
+  return true;
 }
 
 bool IR_StaticAddress::update_from_stack(
@@ -78,5 +154,70 @@ bool IR_FloatMath2::update_from_stack(const std::unordered_set<Register, Registe
     }
   }
 
+  return true;
+}
+
+bool IR_IntMath2::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
+                                    ExpressionStack& stack,
+                                    LinkedObjectFile& file) {
+  for (auto reg : {&arg1, &arg0}) {
+    auto as_reg = dynamic_cast<IR_Register*>(reg->get());
+    if (as_reg) {
+      if (consume.find(as_reg->reg) != consume.end()) {
+        *reg = stack.get(as_reg->reg);
+      }
+    } else {
+      (*reg)->update_from_stack(consume, stack, file);
+    }
+  }
+  return true;
+}
+
+std::unordered_set<Register, Register::hash> IR_Ash::get_consumed(LinkedObjectFile& file) {
+  (void)file;
+  // first get the set of read registers...
+  auto value_as_reg = dynamic_cast<IR_Register*>(value.get());
+  auto sa_as_reg = dynamic_cast<IR_Register*>(shift_amount.get());
+  if (!sa_as_reg || !value_as_reg) {
+    // consume nobody.
+    // todo - is this actually right? If not, this is "safe", but might lead to ugly code.
+    return {};
+  }
+
+  std::unordered_set<Register, Register::hash> result;
+
+  for (auto& op : {branch_op, sub_op, shift_op}) {
+    for (auto& reg : {value_as_reg->reg, sa_as_reg->reg}) {
+      if (op->consumed.find(reg) != op->consumed.end()) {
+        result.insert(reg);
+      }
+    }
+  }
+
+  return result;
+}
+
+bool IR_Ash::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
+                               ExpressionStack& stack,
+                               LinkedObjectFile& file) {
+  for (auto x : {&value, &shift_amount}) {
+    update_from_stack_helper(x, consume, stack, file);
+  }
+  return true;
+}
+
+std::unordered_set<Register, Register::hash> IR_IntMath1::get_consumed(LinkedObjectFile& file) {
+  if (kind == ABS) {
+    assert(abs_op);
+    return abs_op->consumed;
+  } else {
+    throw std::runtime_error("IR_IntMath1::get_consumed NYI for " + print(file));
+  }
+}
+
+bool IR_IntMath1::update_from_stack(const std::unordered_set<Register, Register::hash>& consume,
+                                    ExpressionStack& stack,
+                                    LinkedObjectFile& file) {
+  update_from_stack_helper(&arg, consume, stack, file);
   return true;
 }

--- a/decompiler/IR/IR_TypeAnalysis.cpp
+++ b/decompiler/IR/IR_TypeAnalysis.cpp
@@ -444,9 +444,28 @@ TP_Type IR_IntMath2::get_expression_type(const TypeState& input,
     return TP_Type(TypeSpec("int"));
   }
 
-  if (dts.ts.typecheck(TypeSpec("pointer"), arg0_type.as_typespec(), "", false, false) &&
+  if (kind == ADD &&
+      dts.ts.typecheck(TypeSpec("pointer"), arg0_type.as_typespec(), "", false, false) &&
       is_integer_type(arg1_type)) {
     return arg0_type;
+  }
+
+  if ((kind == ADD || kind == AND) &&
+      dts.ts.typecheck(TypeSpec("pointer"), arg1_type.as_typespec(), "", false, false) &&
+      is_integer_type(arg0_type)) {
+    return arg1_type;
+  }
+
+  if (kind == ADD &&
+      dts.ts.typecheck(TypeSpec("binteger"), arg0_type.as_typespec(), "", false, false) &&
+      is_integer_type(arg1_type)) {
+    return arg0_type;
+  }
+
+  if (kind == SUB &&
+      dts.ts.typecheck(TypeSpec("pointer"), arg0_type.as_typespec(), "", false, false) &&
+      dts.ts.typecheck(TypeSpec("pointer"), arg1_type.as_typespec(), "", false, false)) {
+    return TP_Type(TypeSpec("int"));
   }
 
   throw std::runtime_error(

--- a/decompiler/IR/IR_TypeAnalysis.cpp
+++ b/decompiler/IR/IR_TypeAnalysis.cpp
@@ -602,9 +602,12 @@ void IR_Call_Atomic::propagate_types(const TypeState& input,
       !dts.type_prop_settings.current_method_type.empty()) {
     end_types.get(Register(Reg::GPR, Reg::V0)) =
         TP_Type(dts.type_prop_settings.current_method_type);
+    // todo, set my call type here
     return;
   }
+
   auto in_type = in_tp.as_typespec();
+
   if (in_type.base_type() != "function") {
     throw std::runtime_error("Called something that wasn't a function: " + in_type.print());
   }
@@ -612,6 +615,10 @@ void IR_Call_Atomic::propagate_types(const TypeState& input,
   if (in_type.arg_count() < 1) {
     throw std::runtime_error("Called a function, but we don't know its type");
   }
+
+  // set the call type!
+  call_type = in_type;
+  call_type_set = true;
 
   end_types.get(Register(Reg::GPR, Reg::V0)) = TP_Type(in_type.last_arg());
 

--- a/decompiler/IR/IR_TypeAnalysis.cpp
+++ b/decompiler/IR/IR_TypeAnalysis.cpp
@@ -614,6 +614,15 @@ void IR_Call_Atomic::propagate_types(const TypeState& input,
   }
 
   end_types.get(Register(Reg::GPR, Reg::V0)) = TP_Type(in_type.last_arg());
+
+  // we can also update register usage here.
+  read_regs.clear();
+  read_regs.emplace_back(Reg::GPR, Reg::T9);
+  const Reg::Gpr arg_regs[8] = {Reg::A0, Reg::A1, Reg::A2, Reg::A3,
+                                Reg::T0, Reg::T1, Reg::T2, Reg::T3};
+  for (uint32_t i = 0; i < in_type.arg_count() - 1; i++) {
+    read_regs.emplace_back(Reg::GPR, arg_regs[i]);
+  }
 }
 
 void IR_Store_Atomic::propagate_types(const TypeState& input,

--- a/decompiler/IR/IR_TypeAnalysis.cpp
+++ b/decompiler/IR/IR_TypeAnalysis.cpp
@@ -772,18 +772,15 @@ void IR_Call_Atomic::propagate_types(const TypeState& input,
     // we're calling a varags function, which is format. We can determine the argument count
     // by looking at the format string, if we can get it.
     auto arg_type = input.get(Register(Reg::GPR, Reg::A1));
-    if (arg_type.is_constant_string()) {
-      auto& str = arg_type.get_string();
-      int arg_count = 0;
-      for (size_t i = 0; i < str.length(); i++) {
-        if (str.at(i) == '~') {
-          i++;  // also eat the next character.
-          if (i < str.length() && (str.at(i) == '%' || str.at(i) == 'T')) {
-            // newline (~%) or tab (~T) don't take an argument.
-            continue;
-          }
-          arg_count++;
-        }
+    if (arg_type.is_constant_string() || arg_type.is_format_string()) {
+      int arg_count = -1;
+
+      if (arg_type.is_constant_string()) {
+        auto& str = arg_type.get_string();
+        arg_count = dts.get_format_arg_count(str);
+      } else {
+        // is format string.
+        arg_count = arg_type.get_format_string_arg_count();
       }
 
       TypeSpec format_call_type("function");

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -586,7 +586,7 @@ std::string LinkedObjectFile::print_function_disassembly(Function& func,
   result += ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
   result += func.prologue.to_string(2) + "\n";
   if (!func.warnings.empty()) {
-    result += "Warnings: " + func.warnings + "\n";
+    result += ";;Warnings:\n" + func.warnings + "\n";
   }
 
   // print each instruction in the function.
@@ -784,7 +784,7 @@ std::string LinkedObjectFile::print_type_analysis_debug() {
       result += "; .function " + func.guessed_name.to_string() + "\n";
       result += ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
       if (!func.warnings.empty()) {
-        result += ";; WARNING: " + func.warnings + "\n";
+        result += ";; WARNING:\n" + func.warnings + "\n";
       }
 
       for (auto& block : func.basic_blocks) {

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -817,7 +817,7 @@ std::string LinkedObjectFile::print_type_analysis_debug() {
 /*!
  * Hacky way to get a GOAL string object
  */
-std::string LinkedObjectFile::get_goal_string(int seg, int word_idx, bool with_quotes) {
+std::string LinkedObjectFile::get_goal_string(int seg, int word_idx, bool with_quotes) const {
   std::string result;
   if (with_quotes) {
     result += "\"";
@@ -826,7 +826,7 @@ std::string LinkedObjectFile::get_goal_string(int seg, int word_idx, bool with_q
   if (word_idx + 1 >= int(words_by_seg[seg].size())) {
     return "invalid string!\n";
   }
-  LinkedWord& size_word = words_by_seg[seg].at(word_idx + 1);
+  const LinkedWord& size_word = words_by_seg[seg].at(word_idx + 1);
   if (size_word.kind != LinkedWord::PLAIN_DATA) {
     // sometimes an array of string pointer triggers this!
     return "invalid string!\n";
@@ -1036,7 +1036,7 @@ u32 LinkedObjectFile::read_data_word(const Label& label) {
   return word.data;
 }
 
-std::string LinkedObjectFile::get_goal_string_by_label(const Label& label) {
+std::string LinkedObjectFile::get_goal_string_by_label(const Label& label) const {
   assert(0 == (label.offset % 4));
   return get_goal_string(label.target_segment, (label.offset / 4) - 1, false);
 }

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -799,10 +799,12 @@ std::string LinkedObjectFile::print_type_analysis_debug() {
           // result += func.basic_ops.at(i)->print_with_reguse(*this);
           // result += func.basic_ops.at(i)->print(*this);
           if (func.attempted_type_analysis) {
+            result += fmt::format("[{:3d}] ", i);
             result += func.basic_ops.at(i)->print_with_types(*init_types, *this);
             result += "\n";
             init_types = &func.basic_ops.at(i)->end_types;
           } else {
+            result += fmt::format("[{:3d}] ", i);
             result += func.basic_ops.at(i)->print(*this);
             result += "\n";
           }

--- a/decompiler/ObjectFile/LinkedObjectFile.h
+++ b/decompiler/ObjectFile/LinkedObjectFile.h
@@ -70,7 +70,7 @@ class LinkedObjectFile {
   std::string print_asm_function_disassembly(const std::string& my_name);
 
   u32 read_data_word(const Label& label);
-  std::string get_goal_string_by_label(const Label& label);
+  std::string get_goal_string_by_label(const Label& label) const;
 
   struct Stats {
     uint32_t total_code_bytes = 0;
@@ -138,7 +138,7 @@ class LinkedObjectFile {
   goos::Object to_form_script_object(int seg, int byte_idx, std::vector<bool>& seen);
   bool is_empty_list(int seg, int byte_idx);
   bool is_string(int seg, int byte_idx);
-  std::string get_goal_string(int seg, int word_idx, bool with_quotes = true);
+  std::string get_goal_string(int seg, int word_idx, bool with_quotes = true) const;
 
   std::vector<std::unordered_map<int, int>> label_per_seg_by_offset;
 };

--- a/decompiler/ObjectFile/ObjectFileDB.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB.cpp
@@ -921,6 +921,7 @@ void ObjectFileDB::analyze_functions() {
 
       // type analysis
       if (get_config().function_type_prop) {
+        auto hints = get_config().type_hints_by_function_by_idx[func.guessed_name.to_string()];
         if (get_config().no_type_analysis_functions_by_name.find(func.guessed_name.to_string()) ==
             get_config().no_type_analysis_functions_by_name.end()) {
           if (func.guessed_name.kind == FunctionName::FunctionKind::GLOBAL) {
@@ -938,7 +939,7 @@ void ObjectFileDB::analyze_functions() {
               attempted_type_analysis++;
               //            spdlog::info("Type Analysis on {} {}", func.guessed_name.to_string(),
               //                         kv->second.print());
-              if (func.run_type_analysis(kv->second, dts, data.linked_data)) {
+              if (func.run_type_analysis(kv->second, dts, data.linked_data, hints)) {
                 successful_type_analysis++;
               }
             }
@@ -960,7 +961,7 @@ void ObjectFileDB::analyze_functions() {
                 //              spdlog::info("Type Analysis on {} {}",
                 //              func.guessed_name.to_string(),
                 //                           func.type.print());
-                if (func.run_type_analysis(func.type, dts, data.linked_data)) {
+                if (func.run_type_analysis(func.type, dts, data.linked_data, hints)) {
                   successful_type_analysis++;
                 }
               }
@@ -997,6 +998,10 @@ void ObjectFileDB::analyze_functions() {
     if (!func.guessed_name.empty()) {
       total_named_functions++;
     }
+
+    //    if (func.guessed_name.to_string() == "reset-and-call") {
+    //      assert(false);
+    //    }
   });
 
   spdlog::info("Found {} functions ({} with no control flow)", total_functions,

--- a/decompiler/ObjectFile/ObjectFileDB.h
+++ b/decompiler/ObjectFile/ObjectFileDB.h
@@ -60,11 +60,13 @@ class ObjectFileDB {
   void write_object_file_words(const std::string& output_dir, bool dump_v3_only);
   void write_disassembly(const std::string& output_dir,
                          bool disassemble_objects_without_functions,
-                         bool write_json);
+                         bool write_json,
+                         const std::string& file_suffix = "");
 
   void write_debug_type_analysis(const std::string& output_dir);
   void analyze_functions();
   void process_tpages();
+  void analyze_expressions();
   std::string process_game_count();
   std::string process_game_text();
 

--- a/decompiler/ObjectFile/ObjectFileDB.h
+++ b/decompiler/ObjectFile/ObjectFileDB.h
@@ -63,7 +63,7 @@ class ObjectFileDB {
                          bool write_json,
                          const std::string& file_suffix = "");
 
-  void write_debug_type_analysis(const std::string& output_dir);
+  void write_debug_type_analysis(const std::string& output_dir, const std::string& suffix = "");
   void analyze_functions();
   void process_tpages();
   void analyze_expressions();

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -34,6 +34,7 @@ void set_config(const std::string& path_to_config_file) {
   gConfig.dump_objs = cfg.at("dump_objs").get<bool>();
   gConfig.write_func_json = cfg.at("write_func_json").get<bool>();
   gConfig.function_type_prop = cfg.at("function_type_prop").get<bool>();
+  gConfig.analyze_expressions = cfg.at("analyze_expressions").get<bool>();
 
   std::vector<std::string> asm_functions_by_name =
       cfg.at("asm_functions_by_name").get<std::vector<std::string>>();

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -48,6 +48,12 @@ void set_config(const std::string& path_to_config_file) {
     gConfig.pair_functions_by_name.insert(x);
   }
 
+  std::vector<std::string> no_type_analysis_functions_by_name =
+      cfg.at("no_type_analysis_functions_by_name").get<std::vector<std::string>>();
+  for (const auto& x : no_type_analysis_functions_by_name) {
+    gConfig.no_type_analysis_functions_by_name.insert(x);
+  }
+
   auto bad_inspect = cfg.at("types_with_bad_inspect_methods").get<std::vector<std::string>>();
   for (const auto& x : bad_inspect) {
     gConfig.bad_inspect_types.insert(x);

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -58,4 +58,23 @@ void set_config(const std::string& path_to_config_file) {
   for (const auto& x : bad_inspect) {
     gConfig.bad_inspect_types.insert(x);
   }
+
+  auto type_hints_file_name = cfg.at("type_hints_file").get<std::string>();
+  auto type_hints_txt = file_util::read_text_file(file_util::get_file_path({type_hints_file_name}));
+  auto type_hints_json = nlohmann::json::parse(type_hints_txt, nullptr, true, true);
+
+  for (auto& kv : type_hints_json.items()) {
+    auto& function_name = kv.key();
+    auto& hints = kv.value();
+    for (auto& hint : hints) {
+      auto idx = hint.at(0).get<int>();
+      for (size_t i = 1; i < hint.size(); i++) {
+        auto& assignment = hint.at(i);
+        TypeHint type_hint;
+        type_hint.reg = Register(assignment.at(0).get<std::string>());
+        type_hint.type_name = assignment.at(1).get<std::string>();
+        gConfig.type_hints_by_function_by_idx[function_name][idx].push_back(type_hint);
+      }
+    }
+  }
 }

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -27,6 +27,7 @@ struct Config {
   bool dump_objs = false;
   bool write_func_json = false;
   bool function_type_prop = false;
+  bool analyze_expressions = false;
   std::unordered_set<std::string> asm_functions_by_name;
   std::unordered_set<std::string> pair_functions_by_name;
   // ...

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -30,6 +30,7 @@ struct Config {
   bool analyze_expressions = false;
   std::unordered_set<std::string> asm_functions_by_name;
   std::unordered_set<std::string> pair_functions_by_name;
+  std::unordered_set<std::string> no_type_analysis_functions_by_name;
   // ...
 };
 

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -6,6 +6,13 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
+#include <unordered_map>
+#include "decompiler/Disasm/Register.h"
+
+struct TypeHint {
+  Register reg;
+  std::string type_name;
+};
 
 struct Config {
   int game_version = -1;
@@ -31,6 +38,8 @@ struct Config {
   std::unordered_set<std::string> asm_functions_by_name;
   std::unordered_set<std::string> pair_functions_by_name;
   std::unordered_set<std::string> no_type_analysis_functions_by_name;
+  std::unordered_map<std::string, std::unordered_map<int, std::vector<TypeHint>>>
+      type_hints_by_function_by_idx;
   // ...
 };
 

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -398,14 +398,13 @@
   )
 
 ;; gkernel-h
-;; todo
-; (deftype handle (uint64)
-;   ()
-;   :method-count-assert 9
-;   :size-assert         #x8
-;   :flag-assert         #x900000008
-;   ;; likely a bitfield type
-;   )
+(deftype handle (uint64)
+  ((process (pointer process) :offset 0)
+   (pid int32 :offset 32)
+   (u64 uint64 :offset 0)
+   )
+  :flag-assert #x900000008
+  )
 
 ;; gkernel-h
 (deftype state (protect-frame)

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -144,6 +144,27 @@
 ;   ;;  too many basic blocks
 ;   )
 
+;; todo, remove me!!
+(deftype __array-uint64 (basic)
+  ((data uint64 :dynamic :offset 16))
+  )
+
+(deftype __array-int8 (basic)
+  ((data int8 :dynamic :offset 16))
+  )
+
+(deftype __array-int16 (basic)
+  ((data int16 :dynamic :offset 16))
+  )
+
+(deftype __array-uint16 (basic)
+  ((data uint16 :dynamic :offset 16))
+  )
+
+(deftype __array-int32 (basic)
+  ((data int32 :dynamic :offset 16))
+  )
+
 ; ;; gcommon
 ; (deftype vec4s (uint128)
 ;   ()

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -144,27 +144,6 @@
 ;   ;;  too many basic blocks
 ;   )
 
-;; todo, remove me!!
-(deftype __array-uint64 (basic)
-  ((data uint64 :dynamic :offset 16))
-  )
-
-(deftype __array-int8 (basic)
-  ((data int8 :dynamic :offset 16))
-  )
-
-(deftype __array-int16 (basic)
-  ((data int16 :dynamic :offset 16))
-  )
-
-(deftype __array-uint16 (basic)
-  ((data uint16 :dynamic :offset 16))
-  )
-
-(deftype __array-int32 (basic)
-  ((data int32 :dynamic :offset 16))
-  )
-
 ; ;; gcommon
 ; (deftype vec4s (uint128)
 ;   ()

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -3,7 +3,7 @@
 {
   "game_version":1,
   // the order here matters (not sure that this is true any more...). KERNEL and GAME should go first
-  "dgo_names":["CGO/KERNEL.CGO","CGO/GAME.CGO",
+  "dgo_names_":["CGO/KERNEL.CGO","CGO/GAME.CGO",
      "CGO/ENGINE.CGO"
      , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
      "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
@@ -11,12 +11,12 @@
      "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
      "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
  ],
-  "dgo_names_":["CGO/KERNEL.CGO"],
+  "dgo_names":["CGO/KERNEL.CGO"],
 
   "object_file_names":["TEXT/0COMMON.TXT", "TEXT/1COMMON.TXT", "TEXT/2COMMON.TXT", "TEXT/3COMMON.TXT", "TEXT/4COMMON.TXT",
       "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
 
-  "str_file_names":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
+  "str_file_names_":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
       "STR/SNRBSBFC.STR", "STR/SNRBIPFC.STR", "STR/SNRBICFC.STR", "STR/ORR3.STR", "STR/ORR2.STR", "STR/MICANNON.STR",
       "STR/BECANNON.STR", "STR/SWTS4.STR", "STR/SWTS3.STR", "STR/SWTS2.STR", "STR/SW4.STR", "STR/SW3.STR", "STR/SW2.STR",
       "STR/SWTS1.STR", "STR/ORREYE.STR", "STR/ORLEYE.STR", "STR/SW1.STR", "STR/MAGFCELL.STR", "STR/GNFCELL.STR",
@@ -50,12 +50,13 @@
       "STR/SAISA.STR","STR/SIHISC.STR","STR/MIIORBS.STR","STR/WAINTROD.STR","STR/SAISD2.STR","STR/GRSOPREB.STR",
       "STR/GRSOBBB.STR","STR/SA3INTRO.STR"
   ],
-  "str_file_names_":[],
+  "str_file_names":[],
 
+  "type_hints_file":"decompiler/config/jak1_ntsc_black_label/type_hints.jsonc",
 
   "analyze_functions":true,
   "analyze_expressions":false,
-  "function_type_prop":false,
+  "function_type_prop":true,
   "write_disassembly":true,
   "write_hex_near_instructions":false,
 
@@ -87,10 +88,10 @@
     "part-tracker"],
 
   "no_type_analysis_functions_by_name":[
-    "(method 2 vec4s)", // 128-bit bitfield.
-    "(method 3 vec4s)",
-    "(method 2 handle)", // handle is a bitfield type
-    "(method 3 handle)"  // handle is a bitfield type
+    "(method 2 vec4s)",       // 128-bit bitfield.
+    "(method 3 vec4s)",       // 128-bit bitfield
+    "reset-and-call",         // stack manipulation
+    "(method 10 cpu-thread)"  // loading saved regs off of the stack.
   ],
 
 

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -3,7 +3,7 @@
 {
   "game_version":1,
   // the order here matters (not sure that this is true any more...). KERNEL and GAME should go first
-  "dgo_names":["CGO/KERNEL.CGO","CGO/GAME.CGO",
+  "dgo_names_":["CGO/KERNEL.CGO","CGO/GAME.CGO",
    "CGO/ENGINE.CGO"
   , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
                "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
@@ -11,12 +11,12 @@
                "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
                "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
                ],
-  //"dgo_names":["CGO/KERNEL.CGO"],
+  "dgo_names":["CGO/KERNEL.CGO"],
 
   "object_file_names":["TEXT/0COMMON.TXT", "TEXT/1COMMON.TXT", "TEXT/2COMMON.TXT", "TEXT/3COMMON.TXT", "TEXT/4COMMON.TXT",
                   "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
 
-  "str_file_names":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
+  "str_file_names_":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
       "STR/SNRBSBFC.STR", "STR/SNRBIPFC.STR", "STR/SNRBICFC.STR", "STR/ORR3.STR", "STR/ORR2.STR", "STR/MICANNON.STR",
       "STR/BECANNON.STR", "STR/SWTS4.STR", "STR/SWTS3.STR", "STR/SWTS2.STR", "STR/SW4.STR", "STR/SW3.STR", "STR/SW2.STR",
       "STR/SWTS1.STR", "STR/ORREYE.STR", "STR/ORLEYE.STR", "STR/SW1.STR", "STR/MAGFCELL.STR", "STR/GNFCELL.STR",
@@ -50,11 +50,12 @@
       "STR/SAISA.STR","STR/SIHISC.STR","STR/MIIORBS.STR","STR/WAINTROD.STR","STR/SAISD2.STR","STR/GRSOPREB.STR",
       "STR/GRSOBBB.STR","STR/SA3INTRO.STR"
   ],
-  //"str_file_names":[],
+  "str_file_names":[],
 
 
   "analyze_functions":true,
-  "function_type_prop":false,
+  "analyze_expressions":true,
+  "function_type_prop":true,
   "write_disassembly":true,
   "write_hex_near_instructions":false,
 

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -3,7 +3,7 @@
 {
   "game_version":1,
   // the order here matters (not sure that this is true any more...). KERNEL and GAME should go first
-  "dgo_names_":["CGO/KERNEL.CGO","CGO/GAME.CGO",
+  "dgo_names":["CGO/KERNEL.CGO","CGO/GAME.CGO",
      "CGO/ENGINE.CGO"
      , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
      "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
@@ -11,12 +11,12 @@
      "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
      "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
  ],
-  "dgo_names":["CGO/KERNEL.CGO"],
+  "dgo_names_":["CGO/KERNEL.CGO"],
 
   "object_file_names":["TEXT/0COMMON.TXT", "TEXT/1COMMON.TXT", "TEXT/2COMMON.TXT", "TEXT/3COMMON.TXT", "TEXT/4COMMON.TXT",
       "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
 
-  "str_file_names_":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
+  "str_file_names":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
       "STR/SNRBSBFC.STR", "STR/SNRBIPFC.STR", "STR/SNRBICFC.STR", "STR/ORR3.STR", "STR/ORR2.STR", "STR/MICANNON.STR",
       "STR/BECANNON.STR", "STR/SWTS4.STR", "STR/SWTS3.STR", "STR/SWTS2.STR", "STR/SW4.STR", "STR/SW3.STR", "STR/SW2.STR",
       "STR/SWTS1.STR", "STR/ORREYE.STR", "STR/ORLEYE.STR", "STR/SW1.STR", "STR/MAGFCELL.STR", "STR/GNFCELL.STR",
@@ -50,13 +50,13 @@
       "STR/SAISA.STR","STR/SIHISC.STR","STR/MIIORBS.STR","STR/WAINTROD.STR","STR/SAISD2.STR","STR/GRSOPREB.STR",
       "STR/GRSOBBB.STR","STR/SA3INTRO.STR"
   ],
-  "str_file_names":[],
+  "str_file_names_":[],
 
   "type_hints_file":"decompiler/config/jak1_ntsc_black_label/type_hints.jsonc",
 
   "analyze_functions":true,
   "analyze_expressions":false,
-  "function_type_prop":true,
+  "function_type_prop":false,
   "write_disassembly":true,
   "write_hex_near_instructions":false,
 

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -3,7 +3,7 @@
 {
   "game_version":1,
   // the order here matters (not sure that this is true any more...). KERNEL and GAME should go first
-  "dgo_names_":["CGO/KERNEL.CGO","CGO/GAME.CGO",
+  "dgo_names":["CGO/KERNEL.CGO","CGO/GAME.CGO",
      "CGO/ENGINE.CGO"
      , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
      "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
@@ -11,12 +11,12 @@
      "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
      "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
  ],
-  "dgo_names":["CGO/KERNEL.CGO"],
+  "dgo_names_":["CGO/KERNEL.CGO"],
 
   "object_file_names":["TEXT/0COMMON.TXT", "TEXT/1COMMON.TXT", "TEXT/2COMMON.TXT", "TEXT/3COMMON.TXT", "TEXT/4COMMON.TXT",
       "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
 
-  "str_file_names_":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
+  "str_file_names":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
       "STR/SNRBSBFC.STR", "STR/SNRBIPFC.STR", "STR/SNRBICFC.STR", "STR/ORR3.STR", "STR/ORR2.STR", "STR/MICANNON.STR",
       "STR/BECANNON.STR", "STR/SWTS4.STR", "STR/SWTS3.STR", "STR/SWTS2.STR", "STR/SW4.STR", "STR/SW3.STR", "STR/SW2.STR",
       "STR/SWTS1.STR", "STR/ORREYE.STR", "STR/ORLEYE.STR", "STR/SW1.STR", "STR/MAGFCELL.STR", "STR/GNFCELL.STR",
@@ -50,12 +50,12 @@
       "STR/SAISA.STR","STR/SIHISC.STR","STR/MIIORBS.STR","STR/WAINTROD.STR","STR/SAISD2.STR","STR/GRSOPREB.STR",
       "STR/GRSOBBB.STR","STR/SA3INTRO.STR"
   ],
-  "str_file_names":[],
+  "str_file_names_":[],
 
 
   "analyze_functions":true,
   "analyze_expressions":false,
-  "function_type_prop":true,
+  "function_type_prop":false,
   "write_disassembly":true,
   "write_hex_near_instructions":false,
 
@@ -87,8 +87,12 @@
     "part-tracker"],
 
   "no_type_analysis_functions_by_name":[
-    "(method 2 vec4s)" // 128-bit bitfield.
+    "(method 2 vec4s)", // 128-bit bitfield.
+    "(method 3 vec4s)",
+    "(method 2 handle)", // handle is a bitfield type
+    "(method 3 handle)"  // handle is a bitfield type
   ],
+
 
   "asm_functions_by_name":[
         // gcommon

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -4,17 +4,17 @@
   "game_version":1,
   // the order here matters (not sure that this is true any more...). KERNEL and GAME should go first
   "dgo_names_":["CGO/KERNEL.CGO","CGO/GAME.CGO",
-   "CGO/ENGINE.CGO"
-  , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
-               "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
-               "DGO/LAV.DGO", "DGO/MAI.DGO", "CGO/MAINCAVE.CGO", "DGO/MIS.DGO", "DGO/OGR.DGO", "CGO/RACERP.CGO", "DGO/ROB.DGO", "DGO/ROL.DGO",
-               "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
-               "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
-               ],
+     "CGO/ENGINE.CGO"
+     , "CGO/ART.CGO", "DGO/BEA.DGO", "DGO/CIT.DGO", "CGO/COMMON.CGO", "DGO/DAR.DGO", "DGO/DEM.DGO",
+     "DGO/FIN.DGO", "DGO/INT.DGO", "DGO/JUB.DGO", "DGO/JUN.DGO", "CGO/JUNGLE.CGO", "CGO/L1.CGO", "DGO/FIC.DGO",
+     "DGO/LAV.DGO", "DGO/MAI.DGO", "CGO/MAINCAVE.CGO", "DGO/MIS.DGO", "DGO/OGR.DGO", "CGO/RACERP.CGO", "DGO/ROB.DGO", "DGO/ROL.DGO",
+     "DGO/SNO.DGO", "DGO/SUB.DGO", "DGO/SUN.DGO", "CGO/SUNKEN.CGO", "DGO/SWA.DGO", "DGO/TIT.DGO", "DGO/TRA.DGO", "DGO/VI1.DGO",
+     "DGO/VI2.DGO", "DGO/VI3.DGO", "CGO/VILLAGEP.CGO", "CGO/WATER-AN.CGO"
+ ],
   "dgo_names":["CGO/KERNEL.CGO"],
 
   "object_file_names":["TEXT/0COMMON.TXT", "TEXT/1COMMON.TXT", "TEXT/2COMMON.TXT", "TEXT/3COMMON.TXT", "TEXT/4COMMON.TXT",
-                  "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
+      "TEXT/5COMMON.TXT", "TEXT/6COMMON.TXT"],
 
   "str_file_names_":["STR/BAFCELL.STR", "STR/SWTE4.STR", "STR/SWTE3.STR", "STR/SWTE2.STR", "STR/SWTE1.STR",
       "STR/SNRBSBFC.STR", "STR/SNRBIPFC.STR", "STR/SNRBICFC.STR", "STR/ORR3.STR", "STR/ORR2.STR", "STR/MICANNON.STR",
@@ -54,7 +54,7 @@
 
 
   "analyze_functions":true,
-  "analyze_expressions":true,
+  "analyze_expressions":false,
   "function_type_prop":true,
   "write_disassembly":true,
   "write_hex_near_instructions":false,
@@ -84,10 +84,13 @@
     "engine",
     "bsp-header",
     "joint-anim-matrix",
-    "part-tracker"
+    "part-tracker"],
+
+  "no_type_analysis_functions_by_name":[
+    "(method 2 vec4s)" // 128-bit bitfield.
   ],
 
-    "asm_functions_by_name":[
+  "asm_functions_by_name":[
         // gcommon
         "quad-copy!",
 
@@ -483,6 +486,6 @@
         "(anon-function 2 ogreboss)"
     ],
 
-    "pair_functions_by_name":["ref", "last", "member", "nmember", "assoc", "assoce", "append!", "delete!", "delete-car!",
+"pair_functions_by_name":["ref", "last", "member", "nmember", "assoc", "assoce", "append!", "delete!", "delete-car!",
     "insert-cons!", "sort", "unload-package", "(method 4 pair)", "nassoc", "nassoce"]
 }

--- a/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
@@ -1,0 +1,39 @@
+{
+	"(method 2 handle)":[
+		[10, ["a3", "process"]],
+		[11, ["v1", "int"]],
+		[15, ["gp", "int"]]
+	],
+
+	"(method 3 handle)":[
+		[10, ["gp", "int"]]
+	],
+
+	"(method 0 cpu-thread)":[
+		[13, ["v0", "cpu-thread"]]
+	],
+
+	"remove-exit":[
+		[0, ["s6", "process"]]
+	],
+
+	"(method 0 process)":[
+		[12, ["a0", "int"]],
+		[13, ["v0", "process"]]
+	],
+
+	"inspect-process-heap":[
+		[4, ["s5", "basic"]],
+		[17, ["s5", "int"]]
+	],
+
+	"return-from-thread-dead":[
+		[0, ["s6", "process"]]
+	],
+
+	"(method 14 dead-pool)":[
+		[23, ["v1", "process"]], // bad visit order with #f?
+		[28, ["s4", "(pointer process-tree)"]] // bug in real game, see gkernel.gc
+	]
+
+}

--- a/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
@@ -1,20 +1,4 @@
 {
-
-	"(method 2 array)":[
-		[24, ["v1", "(pointer int32)"]],
-		[44, ["v1", "(pointer uint32)"]],
-		[64, ["v1", "__array-uint64"]],
-		[84, ["v1", "__array-uint64"]],
-		[102, ["gp", "__array-int8"]],
-		[142, ["v1", "__array-int16"]],
-		[162, ["v1", "__array-uint16"]],
-		[204, ["v1", "__array-int32"]],
-		[223, ["v1", "__array-int32"]],
-		[232, ["v1", "__array-int32"]],
-		[249, ["v1", "__array-int32"]],
-		[258, ["v1", "__array-int32"]]
-	],
-
 	"(method 2 handle)":[
 		[10, ["a3", "process"]],
 		[11, ["v1", "int"]],

--- a/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
@@ -1,4 +1,20 @@
 {
+
+	"(method 2 array)":[
+		[24, ["v1", "(pointer int32)"]],
+		[44, ["v1", "(pointer uint32)"]],
+		[64, ["v1", "__array-uint64"]],
+		[84, ["v1", "__array-uint64"]],
+		[102, ["gp", "__array-int8"]],
+		[142, ["v1", "__array-int16"]],
+		[162, ["v1", "__array-uint16"]],
+		[204, ["v1", "__array-int32"]],
+		[223, ["v1", "__array-int32"]],
+		[232, ["v1", "__array-int32"]],
+		[249, ["v1", "__array-int32"]],
+		[258, ["v1", "__array-int32"]]
+	],
+
 	"(method 2 handle)":[
 		[10, ["a3", "process"]],
 		[11, ["v1", "int"]],

--- a/decompiler/main.cpp
+++ b/decompiler/main.cpp
@@ -88,6 +88,11 @@ int main(int argc, char** argv) {
     db.write_debug_type_analysis(out_folder);
   }
 
+  if (get_config().analyze_expressions) {
+    db.analyze_expressions();
+    db.write_disassembly(out_folder, false, false, "_expr");
+  }
+
   // todo print type summary
   // printf("%s\n", get_type_info().get_summary().c_str());
 

--- a/decompiler/main.cpp
+++ b/decompiler/main.cpp
@@ -91,6 +91,7 @@ int main(int argc, char** argv) {
   if (get_config().analyze_expressions) {
     db.analyze_expressions();
     db.write_disassembly(out_folder, false, false, "_expr");
+    db.write_debug_type_analysis(out_folder, "_expr");
   }
 
   // todo print type summary

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -271,7 +271,27 @@ TP_Type DecompilerTypeSystem::tp_lca_no_simplify(const TP_Type& existing,
 }
 
 TP_Type DecompilerTypeSystem::tp_lca(const TP_Type& existing, const TP_Type& add, bool* changed) {
-  return tp_lca_no_simplify(existing.simplify(), add.simplify(), changed);
+  // we should handle existing == add without simplifying anything.
+  if (existing == add) {
+    *changed = false;
+    return existing;
+  }
+
+  // we should handle the case of tp_lca(complex, none) or tp_lca(none, complex) correctly,
+  // without simplifying.
+  if (add.kind == TP_Type::NONE) {
+    *changed = false;
+    return existing;
+  }
+
+  if (existing.kind == TP_Type::NONE) {
+    *changed = true;  // existing != none because of previous check.
+    return add;
+  }
+  auto result = tp_lca_no_simplify(existing.simplify(), add.simplify(), changed);
+  //  printf("%s --- %s ---> %s\n", existing.print().c_str(), add.print().c_str(),
+  //  result.print().c_str());
+  return result;
 }
 
 bool DecompilerTypeSystem::tp_lca(TypeState* combined, const TypeState& add) {

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -83,7 +83,7 @@ void DecompilerTypeSystem::parse_type_defs(const std::vector<std::string>& file_
 TypeSpec DecompilerTypeSystem::parse_type_spec(const std::string& str) {
   auto read = m_reader.read_from_string(str);
   auto data = cdr(read);
-  return parse_typespec(&ts, data);
+  return parse_typespec(&ts, car(data));
 }
 
 std::string DecompilerTypeSystem::dump_symbol_types() {

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -43,8 +43,7 @@ void for_each_in_list(goos::Object& list, T f) {
 }  // namespace
 
 void DecompilerTypeSystem::parse_type_defs(const std::vector<std::string>& file_path) {
-  goos::Reader reader;
-  auto read = reader.read_from_file(file_path);
+  auto read = m_reader.read_from_file(file_path);
   auto data = cdr(read);
 
   for_each_in_list(data, [&](goos::Object& o) {
@@ -79,6 +78,12 @@ void DecompilerTypeSystem::parse_type_defs(const std::vector<std::string>& file_
       throw std::runtime_error("Decompiler cannot parse " + car(o).print());
     }
   });
+}
+
+TypeSpec DecompilerTypeSystem::parse_type_spec(const std::string& str) {
+  auto read = m_reader.read_from_string(str);
+  auto data = cdr(read);
+  return parse_typespec(&ts, data);
 }
 
 std::string DecompilerTypeSystem::dump_symbol_types() {

--- a/decompiler/util/DecompilerTypeSystem.h
+++ b/decompiler/util/DecompilerTypeSystem.h
@@ -3,6 +3,7 @@
 
 #include "common/type_system/TypeSystem.h"
 #include "decompiler/Disasm/Register.h"
+#include "common/goos/Reader.h"
 
 struct TP_Type;
 struct TypeState;
@@ -30,6 +31,7 @@ class DecompilerTypeSystem {
 
   void add_symbol(const std::string& name, const TypeSpec& type_spec);
   void parse_type_defs(const std::vector<std::string>& file_path);
+  TypeSpec parse_type_spec(const std::string& str);
   void add_type_flags(const std::string& name, u64 flags);
   void add_type_parent(const std::string& child, const std::string& parent);
   std::string dump_symbol_types();
@@ -46,6 +48,9 @@ class DecompilerTypeSystem {
       current_method_type.clear();
     }
   } type_prop_settings;
+
+ private:
+  goos::Reader m_reader;
 };
 
 #endif  // JAK_DECOMPILERTYPESYSTEM_H

--- a/decompiler/util/DecompilerTypeSystem.h
+++ b/decompiler/util/DecompilerTypeSystem.h
@@ -40,6 +40,8 @@ class DecompilerTypeSystem {
   TP_Type tp_lca(const TP_Type& existing, const TP_Type& add, bool* changed);
   TP_Type tp_lca_no_simplify(const TP_Type& existing, const TP_Type& add, bool* changed);
   bool tp_lca(TypeState* combined, const TypeState& add);
+  int get_format_arg_count(const std::string& str);
+  int get_format_arg_count(const TP_Type& type);
   struct {
     bool allow_pair;
     std::string current_method_type;

--- a/decompiler/util/TP_Type.cpp
+++ b/decompiler/util/TP_Type.cpp
@@ -13,6 +13,8 @@ TP_Type TP_Type::simplify() const {
       return TP_Type(ts);
     case OBJ_PLUS_PRODUCT:
       return TP_Type(TypeSpec("none"));
+    case STRING:
+      return TP_Type(TypeSpec("string"));
     default:
       return *this;
   }
@@ -31,11 +33,13 @@ std::string TP_Type::print() const {
     case PRODUCT:
       return fmt::format("[{} x {}]", ts.print(), multiplier);
     case PARTIAL_METHOD_TABLE_ACCESS:
-      return fmt::format("[[vtable-access]]");
+      return fmt::format("[[vtable-access of {}]]", ts.print());
     case METHOD_NEW_OF_OBJECT:
-      return fmt::format("[(method object new)]");
+      return fmt::format("[(method object new) -> {}]", ts.print());
     case OBJ_PLUS_PRODUCT:
       return fmt::format("[{} + int x {}]", ts.print(), multiplier);
+    case STRING:
+      return fmt::format("[\"{}\"]", str_data);
     default:
       assert(false);
   }
@@ -52,4 +56,33 @@ std::string TypeState::print_gpr_masked(u32 mask) const {
     }
   }
   return result;
+}
+
+bool TP_Type::operator==(const TP_Type& other) const {
+  if (kind != other.kind) {
+    return false;
+  }
+
+  switch (kind) {
+    case OBJECT_OF_TYPE:
+      return ts == other.ts;
+    case TYPE_OBJECT:
+      return ts == other.ts;
+    case FALSE:
+      return true;
+    case NONE:
+      return true;
+    case PRODUCT:
+      return (ts == other.ts) && (multiplier == other.multiplier);
+    case PARTIAL_METHOD_TABLE_ACCESS:
+      return (ts == other.ts);
+    case METHOD_NEW_OF_OBJECT:
+      return (ts == other.ts);
+    case OBJ_PLUS_PRODUCT:
+      return (ts == other.ts) && (multiplier == other.multiplier);
+    case STRING:
+      return str_data == other.str_data && ts == other.ts;
+    default:
+      assert(false);
+  }
 }

--- a/decompiler/util/TP_Type.cpp
+++ b/decompiler/util/TP_Type.cpp
@@ -1,50 +1,6 @@
 #include "TP_Type.h"
 #include "third-party/fmt/core.h"
 
-/*!
- * Takes the weird TP_Types and converts them to one of the main 4.
- * This is supposed to be used if the fancy type analysis steps are attempted but fail.
- */
-TP_Type TP_Type::simplify() const {
-  switch (kind) {
-    case PRODUCT:
-      return TP_Type(ts);
-    case METHOD_NEW_OF_OBJECT:
-      return TP_Type(ts);
-    case OBJ_PLUS_PRODUCT:
-      return TP_Type(TypeSpec("none"));
-    case STRING:
-      return TP_Type(TypeSpec("string"));
-    default:
-      return *this;
-  }
-}
-
-std::string TP_Type::print() const {
-  switch (kind) {
-    case OBJECT_OF_TYPE:
-      return ts.print();
-    case TYPE_OBJECT:
-      return fmt::format("[{}]", ts.print());
-    case FALSE:
-      return fmt::format("[#f]");
-    case NONE:
-      return fmt::format("[none]");
-    case PRODUCT:
-      return fmt::format("[{} x {}]", ts.print(), multiplier);
-    case PARTIAL_METHOD_TABLE_ACCESS:
-      return fmt::format("[[vtable-access of {}]]", ts.print());
-    case METHOD_NEW_OF_OBJECT:
-      return fmt::format("[(method object new) -> {}]", ts.print());
-    case OBJ_PLUS_PRODUCT:
-      return fmt::format("[{} + int x {}]", ts.print(), multiplier);
-    case STRING:
-      return fmt::format("[\"{}\"]", str_data);
-    default:
-      assert(false);
-  }
-}
-
 std::string TypeState::print_gpr_masked(u32 mask) const {
   std::string result;
   for (int i = 0; i < 32; i++) {
@@ -58,30 +14,99 @@ std::string TypeState::print_gpr_masked(u32 mask) const {
   return result;
 }
 
+std::string TP_Type::print() const {
+  switch (kind) {
+    case Kind::TYPESPEC:
+      return m_ts.print();
+    case Kind::TYPE_OF_TYPE_OR_CHILD:
+      return fmt::format("<the type {}>", m_ts.print());
+    case Kind::FALSE_AS_NULL:
+      return fmt::format("'#f");
+    case Kind::UNINITIALIZED:
+      return fmt::format("<uninitialized>");
+    case Kind::PRODUCT_WITH_CONSTANT:
+      return fmt::format("<value x {}>", m_int);
+    case Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT:
+      return fmt::format("<{} + (value x {})>", m_ts.print(), m_int);
+    case Kind::OBJECT_NEW_METHOD:
+      return fmt::format("<(object-new) for {}>", m_ts.print());
+    case Kind::STRING_CONSTANT:
+      return fmt::format("<string \"{}\">", m_str);
+    case Kind::INTEGER_CONSTANT:
+      return fmt::format("<integer {}>", m_int);
+    case Kind::DYNAMIC_METHOD_ACCESS:
+      return fmt::format("<dynamic-method-access>");
+    case Kind::INVALID:
+    default:
+      assert(false);
+  }
+}
+
 bool TP_Type::operator==(const TP_Type& other) const {
   if (kind != other.kind) {
     return false;
   }
 
   switch (kind) {
-    case OBJECT_OF_TYPE:
-      return ts == other.ts;
-    case TYPE_OBJECT:
-      return ts == other.ts;
-    case FALSE:
+    case Kind::TYPESPEC:
+      return m_ts == other.m_ts;
+    case Kind::TYPE_OF_TYPE_OR_CHILD:
+      return m_ts == other.m_ts;
+    case Kind::FALSE_AS_NULL:
       return true;
-    case NONE:
+    case Kind::UNINITIALIZED:
       return true;
-    case PRODUCT:
-      return (ts == other.ts) && (multiplier == other.multiplier);
-    case PARTIAL_METHOD_TABLE_ACCESS:
-      return (ts == other.ts);
-    case METHOD_NEW_OF_OBJECT:
-      return (ts == other.ts);
-    case OBJ_PLUS_PRODUCT:
-      return (ts == other.ts) && (multiplier == other.multiplier);
-    case STRING:
-      return str_data == other.str_data && ts == other.ts;
+    case Kind::PRODUCT_WITH_CONSTANT:
+      return m_int == other.m_int;
+    case Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT:
+      return m_ts == other.m_ts && m_int == other.m_int;
+    case Kind::OBJECT_NEW_METHOD:
+      return m_ts == other.m_ts;
+    case Kind::STRING_CONSTANT:
+      return m_str == other.m_str;
+    case Kind::INTEGER_CONSTANT:
+      return m_int == other.m_int;
+    case Kind::DYNAMIC_METHOD_ACCESS:
+      return true;
+    case Kind::INVALID:
+    default:
+      assert(false);
+  }
+}
+
+bool TP_Type::operator!=(const TP_Type& other) const {
+  return !((*this) == other);
+}
+
+TypeSpec TP_Type::typespec() const {
+  switch (kind) {
+    case Kind::TYPESPEC:
+      return m_ts;
+    case Kind::TYPE_OF_TYPE_OR_CHILD:
+      return TypeSpec("type");
+    case Kind::FALSE_AS_NULL:
+      return TypeSpec("symbol");
+    case Kind::UNINITIALIZED:
+      return TypeSpec("none");
+    case Kind::PRODUCT_WITH_CONSTANT:
+      return TypeSpec("int");
+    case Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT:
+      // this can be part of an array access, so we don't really know the type.
+      // probably not a good idea to try to do anything with this as a typespec
+      // so let's be very vague
+      return TypeSpec("object");
+    case Kind::OBJECT_NEW_METHOD:
+      // similar to previous case, being more vague than we need to be because we don't
+      // want to assume the return type incorrectly and you shouldn't try to do anything with
+      // this as a typespec.
+      return TypeSpec("function");
+    case Kind::STRING_CONSTANT:
+      return TypeSpec("string");
+    case Kind::INTEGER_CONSTANT:
+      return TypeSpec("int");
+    case Kind::DYNAMIC_METHOD_ACCESS:
+      return TypeSpec("object");
+    case Kind::INVALID:
     default:
       assert(false);
   }

--- a/decompiler/util/TP_Type.cpp
+++ b/decompiler/util/TP_Type.cpp
@@ -32,6 +32,8 @@ std::string TP_Type::print() const {
       return fmt::format("<(object-new) for {}>", m_ts.print());
     case Kind::STRING_CONSTANT:
       return fmt::format("<string \"{}\">", m_str);
+    case Kind::FORMAT_STRING:
+      return fmt::format("<string with {} args>", m_int);
     case Kind::INTEGER_CONSTANT:
       return fmt::format("<integer {}>", m_int);
     case Kind::DYNAMIC_METHOD_ACCESS:
@@ -65,6 +67,8 @@ bool TP_Type::operator==(const TP_Type& other) const {
     case Kind::STRING_CONSTANT:
       return m_str == other.m_str;
     case Kind::INTEGER_CONSTANT:
+      return m_int == other.m_int;
+    case Kind::FORMAT_STRING:
       return m_int == other.m_int;
     case Kind::DYNAMIC_METHOD_ACCESS:
       return true;
@@ -106,6 +110,8 @@ TypeSpec TP_Type::typespec() const {
       return TypeSpec("int");
     case Kind::DYNAMIC_METHOD_ACCESS:
       return TypeSpec("object");
+    case Kind::FORMAT_STRING:
+      return TypeSpec("string");
     case Kind::INVALID:
     default:
       assert(false);

--- a/decompiler/util/TP_Type.h
+++ b/decompiler/util/TP_Type.h
@@ -111,7 +111,7 @@ class TP_Type {
   bool is_constant_string() const { return kind == Kind::STRING_CONSTANT; }
   bool is_integer_constant() const { return kind == Kind::INTEGER_CONSTANT; }
   bool is_integer_constant(int64_t value) const { return is_integer_constant() && m_int == value; }
-
+  bool is_product() const { return kind == Kind::PRODUCT_WITH_CONSTANT; }
   bool is_product_with(int64_t value) const {
     return kind == Kind::PRODUCT_WITH_CONSTANT && m_int == value;
   }
@@ -181,6 +181,14 @@ class TP_Type {
     return result;
   }
 
+  static TP_Type make_object_plus_product(const TypeSpec& ts, int64_t multiplier) {
+    TP_Type result;
+    result.kind = Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT;
+    result.m_ts = ts;
+    result.m_int = multiplier;
+    return result;
+  }
+
   const TypeSpec& get_objects_typespec() const {
     assert(kind == Kind::TYPESPEC);
     return m_ts;
@@ -193,6 +201,11 @@ class TP_Type {
 
   const TypeSpec& get_method_new_object_typespec() const {
     assert(kind == Kind::OBJECT_NEW_METHOD);
+    return m_ts;
+  }
+
+  const TypeSpec& get_obj_plus_const_mult_typespec() const {
+    assert(kind == Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT);
     return m_ts;
   }
 

--- a/decompiler/util/TP_Type.h
+++ b/decompiler/util/TP_Type.h
@@ -98,6 +98,7 @@ class TP_Type {
     OBJECT_PLUS_PRODUCT_WITH_CONSTANT,  // address: obj + (val * multiplier)
     OBJECT_NEW_METHOD,      // the method new of object, as used in an (object-new) or similar.
     STRING_CONSTANT,        // a string that's part of the string pool
+    FORMAT_STRING,          // a string with a given number of format arguments
     INTEGER_CONSTANT,       // a constant integer.
     DYNAMIC_METHOD_ACCESS,  // partial access into a
     INVALID
@@ -115,10 +116,24 @@ class TP_Type {
   bool is_product_with(int64_t value) const {
     return kind == Kind::PRODUCT_WITH_CONSTANT && m_int == value;
   }
+  bool is_format_string() const { return kind == Kind::FORMAT_STRING; }
+  bool can_be_format_string() const { return is_format_string() || is_constant_string(); }
+
+  int get_format_string_arg_count() const {
+    assert(is_format_string());
+    return m_int;
+  }
 
   const std::string& get_string() const {
     assert(is_constant_string());
     return m_str;
+  }
+
+  static TP_Type make_from_format_string(int n_args) {
+    TP_Type result;
+    result.kind = Kind::FORMAT_STRING;
+    result.m_int = n_args;
+    return result;
   }
 
   static TP_Type make_from_typespec(const TypeSpec& ts) {

--- a/decompiler/util/TP_Type.h
+++ b/decompiler/util/TP_Type.h
@@ -5,81 +5,206 @@
 #include "common/common_types.h"
 #include "decompiler/Disasm/Register.h"
 
-struct TP_Type {
-  enum Kind {
-    OBJECT_OF_TYPE,
-    TYPE_OBJECT,
-    FALSE,
-    NONE,
-    PRODUCT,
-    OBJ_PLUS_PRODUCT,
-    PARTIAL_METHOD_TABLE_ACCESS,  // type + method_number * 4
-    METHOD_NEW_OF_OBJECT,
-    STRING
-  } kind = NONE;
-  // in the case that we are type_object, just store the type name in a single arg ts.
-  TypeSpec ts;
-  int multiplier;
-  std::string str_data;
+// struct TP_Type {
+//  enum Kind {
+//    OBJECT_OF_TYPE,
+//    TYPE_OBJECT,
+//    FALSE,
+//    NONE,
+//    PRODUCT,
+//    OBJ_PLUS_PRODUCT,
+//    PARTIAL_METHOD_TABLE_ACCESS,  // type + method_number * 4
+//    METHOD_NEW_OF_OBJECT,
+//    STRING
+//  } kind = NONE;
+//  // in the case that we are type_object, just store the type name in a single arg ts.
+//  TypeSpec ts;
+//  int multiplier;
+//  std::string str_data;
+//
+//  TP_Type() = default;
+//  explicit TP_Type(const TypeSpec& _ts) {
+//    kind = OBJECT_OF_TYPE;
+//    ts = _ts;
+//  }
+//
+//  TP_Type simplify() const;
+//  std::string print() const;
+//
+//  bool is_object_of_type() const { return kind == TYPE_OBJECT || ts == TypeSpec("type"); }
+//
+//  TypeSpec as_typespec() const {
+//    switch (kind) {
+//      case OBJECT_OF_TYPE:
+//        return ts;
+//      case TYPE_OBJECT:
+//        return TypeSpec("type");
+//      case FALSE:
+//        return TypeSpec("symbol");
+//      case NONE:
+//        return TypeSpec("none");
+//      case PRODUCT:
+//      case METHOD_NEW_OF_OBJECT:
+//        return ts;
+//      default:
+//        assert(false);
+//    }
+//  }
+//
+//  static TP_Type make_partial_method_table_access(TypeSpec ts) {
+//    TP_Type result;
+//    result.kind = PARTIAL_METHOD_TABLE_ACCESS;
+//    result.ts = std::move(ts);
+//    return result;
+//  }
+//
+//  static TP_Type make_type_object(const std::string& name) {
+//    TP_Type result;
+//    result.kind = TYPE_OBJECT;
+//    result.ts = TypeSpec(name);
+//    return result;
+//  }
+//
+//  static TP_Type make_string_object(const std::string& str) {
+//    TP_Type result;
+//    result.kind = STRING;
+//    result.ts = TypeSpec("string");
+//    result.str_data = str;
+//    return result;
+//  }
+//
+//  static TP_Type make_none() {
+//    TP_Type result;
+//    result.kind = NONE;
+//    return result;
+//  }
+//
+//  bool operator==(const TP_Type& other) const;
+//};
 
+/*!
+ * A TP_Type is a specialized typespec used in the type propagation algorithm.
+ * It is basically a normal typespec plus some optional information.
+ * It should always use register types.
+ */
+class TP_Type {
+ public:
+  enum class Kind {
+    TYPESPEC,                           // just a normal typespec
+    TYPE_OF_TYPE_OR_CHILD,              // a type object, of the given type of a child type.
+    FALSE_AS_NULL,                      // the GOAL "false" object, possibly used as a null.
+    UNINITIALIZED,                      // representing data which is uninitialized.
+    PRODUCT_WITH_CONSTANT,              // representing: (val * multiplier)
+    OBJECT_PLUS_PRODUCT_WITH_CONSTANT,  // address: obj + (val * multiplier)
+    OBJECT_NEW_METHOD,      // the method new of object, as used in an (object-new) or similar.
+    STRING_CONSTANT,        // a string that's part of the string pool
+    INTEGER_CONSTANT,       // a constant integer.
+    DYNAMIC_METHOD_ACCESS,  // partial access into a
+    INVALID
+  } kind = Kind::UNINITIALIZED;
   TP_Type() = default;
-  explicit TP_Type(const TypeSpec& _ts) {
-    kind = OBJECT_OF_TYPE;
-    ts = _ts;
-  }
-
-  TP_Type simplify() const;
   std::string print() const;
-
-  bool is_object_of_type() const { return kind == TYPE_OBJECT || ts == TypeSpec("type"); }
-
-  TypeSpec as_typespec() const {
-    switch (kind) {
-      case OBJECT_OF_TYPE:
-        return ts;
-      case TYPE_OBJECT:
-        return TypeSpec("type");
-      case FALSE:
-        return TypeSpec("symbol");
-      case NONE:
-        return TypeSpec("none");
-      case PRODUCT:
-      case METHOD_NEW_OF_OBJECT:
-        return ts;
-      default:
-        assert(false);
-    }
-  }
-
-  static TP_Type make_partial_method_table_access(TypeSpec ts) {
-    TP_Type result;
-    result.kind = PARTIAL_METHOD_TABLE_ACCESS;
-    result.ts = std::move(ts);
-    return result;
-  }
-
-  static TP_Type make_type_object(const std::string& name) {
-    TP_Type result;
-    result.kind = TYPE_OBJECT;
-    result.ts = TypeSpec(name);
-    return result;
-  }
-
-  static TP_Type make_string_object(const std::string& str) {
-    TP_Type result;
-    result.kind = STRING;
-    result.ts = TypeSpec("string");
-    result.str_data = str;
-    return result;
-  }
-
-  static TP_Type make_none() {
-    TP_Type result;
-    result.kind = NONE;
-    return result;
-  }
-
   bool operator==(const TP_Type& other) const;
+  bool operator!=(const TP_Type& other) const;
+  TypeSpec typespec() const;
+
+  bool is_constant_string() const { return kind == Kind::STRING_CONSTANT; }
+  bool is_integer_constant() const { return kind == Kind::INTEGER_CONSTANT; }
+  bool is_integer_constant(int64_t value) const { return is_integer_constant() && m_int == value; }
+
+  bool is_product_with(int64_t value) const {
+    return kind == Kind::PRODUCT_WITH_CONSTANT && m_int == value;
+  }
+
+  const std::string& get_string() const {
+    assert(is_constant_string());
+    return m_str;
+  }
+
+  static TP_Type make_from_typespec(const TypeSpec& ts) {
+    TP_Type result;
+    result.kind = Kind::TYPESPEC;
+    result.m_ts = ts;
+    return result;
+  }
+
+  static TP_Type make_from_string(const std::string& str) {
+    TP_Type result;
+    result.kind = Kind::STRING_CONSTANT;
+    result.m_str = str;
+    return result;
+  }
+
+  static TP_Type make_type_object(const TypeSpec& type) {
+    TP_Type result;
+    result.kind = Kind::TYPE_OF_TYPE_OR_CHILD;
+    result.m_ts = type;
+    return result;
+  }
+
+  static TP_Type make_false() {
+    TP_Type result;
+    result.kind = Kind::FALSE_AS_NULL;
+    return result;
+  }
+
+  static TP_Type make_uninitialized() {
+    TP_Type result;
+    result.kind = Kind::UNINITIALIZED;
+    return result;
+  }
+
+  static TP_Type make_from_integer(int64_t value) {
+    TP_Type result;
+    result.kind = Kind::INTEGER_CONSTANT;
+    result.m_int = value;
+    return result;
+  }
+
+  static TP_Type make_from_product(int64_t multiplier) {
+    TP_Type result;
+    result.kind = Kind::PRODUCT_WITH_CONSTANT;
+    result.m_int = multiplier;
+    return result;
+  }
+
+  static TP_Type make_partial_dyanmic_vtable_access() {
+    TP_Type result;
+    result.kind = Kind::DYNAMIC_METHOD_ACCESS;
+    return result;
+  }
+
+  static TP_Type make_object_new(const TypeSpec& ts) {
+    TP_Type result;
+    result.kind = Kind::OBJECT_NEW_METHOD;
+    result.m_ts = ts;
+    return result;
+  }
+
+  const TypeSpec& get_objects_typespec() const {
+    assert(kind == Kind::TYPESPEC);
+    return m_ts;
+  }
+
+  const TypeSpec& get_type_objects_typespec() const {
+    assert(kind == Kind::TYPE_OF_TYPE_OR_CHILD);
+    return m_ts;
+  }
+
+  const TypeSpec& get_method_new_object_typespec() const {
+    assert(kind == Kind::OBJECT_NEW_METHOD);
+    return m_ts;
+  }
+
+  uint64_t get_multiplier() const {
+    assert(kind == Kind::PRODUCT_WITH_CONSTANT || kind == Kind::OBJECT_PLUS_PRODUCT_WITH_CONSTANT);
+    return m_int;
+  }
+
+ private:
+  TypeSpec m_ts;
+  std::string m_str;
+  int64_t m_int = 0;
 };
 
 struct TypeState {

--- a/decompiler/util/TP_Type.h
+++ b/decompiler/util/TP_Type.h
@@ -14,11 +14,13 @@ struct TP_Type {
     PRODUCT,
     OBJ_PLUS_PRODUCT,
     PARTIAL_METHOD_TABLE_ACCESS,  // type + method_number * 4
-    METHOD_NEW_OF_OBJECT
+    METHOD_NEW_OF_OBJECT,
+    STRING
   } kind = NONE;
   // in the case that we are type_object, just store the type name in a single arg ts.
   TypeSpec ts;
   int multiplier;
+  std::string str_data;
 
   TP_Type() = default;
   explicit TP_Type(const TypeSpec& _ts) {
@@ -49,9 +51,10 @@ struct TP_Type {
     }
   }
 
-  static TP_Type make_partial_method_table_access() {
+  static TP_Type make_partial_method_table_access(TypeSpec ts) {
     TP_Type result;
     result.kind = PARTIAL_METHOD_TABLE_ACCESS;
+    result.ts = std::move(ts);
     return result;
   }
 
@@ -61,6 +64,22 @@ struct TP_Type {
     result.ts = TypeSpec(name);
     return result;
   }
+
+  static TP_Type make_string_object(const std::string& str) {
+    TP_Type result;
+    result.kind = STRING;
+    result.ts = TypeSpec("string");
+    result.str_data = str;
+    return result;
+  }
+
+  static TP_Type make_none() {
+    TP_Type result;
+    result.kind = NONE;
+    return result;
+  }
+
+  bool operator==(const TP_Type& other) const;
 };
 
 struct TypeState {

--- a/doc/expressions_todo.txt
+++ b/doc/expressions_todo.txt
@@ -1,0 +1,2 @@
+order of floating point argument evaluation is different
+GPR -> FPR conversions should not happen silently

--- a/goal_src/kernel/gkernel-h.gc
+++ b/goal_src/kernel/gkernel-h.gc
@@ -373,7 +373,7 @@
   )
 
 (deftype handle (uint64)
-  ((process (pointer process) :offset 0) ;; todo, more specific type
+  ((process (pointer process) :offset 0)
    (pid int32 :offset 32)
    (u64 uint64 :offset 0)
    )


### PR DESCRIPTION
Adds a very experimental expression stack algorithm as a totally separate compile pass from function analysis, and fix up some small issues with type propagation.

There are some implementation issues, so it will probably be mostly rewritten at some point.

Most of the important information, like `consumes`, types, and register use are in terms of `IR_Atomic` operations. But we want to support the expression stack operation on non-atomic IR. So it is probably worth making a better interface for the information the expression stack needs and make sure it can be done on all IR.

Currently the expression building goes in an inside -> outside order, but this will have issues depending on where things are split for stuff like computing the condition of `if`s.  So going in the "compile order" of outside -> in might be a better approach?

The expression logic is the perfect place to convert multi-op loads into a single large expression. This means we'll need type information in the expression stack, and some way to detect and simplify these load expressions.
