### PR TITLE
[Compiler] Add static data features

### DIFF
--- a/common/link_types.h
+++ b/common/link_types.h
@@ -14,6 +14,7 @@ enum LinkKind {
   LINK_TYPE_PTR = 2,                  //! link a pointer to a type.
   LINK_DISTANCE_TO_OTHER_SEG_64 = 3,  //! link to another segment
   LINK_DISTANCE_TO_OTHER_SEG_32 = 4,  //! link to another segment
+  LINK_PTR = 5,                       //! link a pointer within this segment
 };
 
 enum SegmentTypes { MAIN_SEGMENT = 0, DEBUG_SEGMENT = 1, TOP_LEVEL_SEGMENT = 2 };

--- a/common/versions.h
+++ b/common/versions.h
@@ -11,9 +11,11 @@
 #include "common/common_types.h"
 
 namespace versions {
-// language version
+// language version (OpenGOAL)
 constexpr s32 GOAL_VERSION_MAJOR = 0;
-constexpr s32 GOAL_VERSION_MINOR = 3;
+constexpr s32 GOAL_VERSION_MINOR = 4;
+
+// these versions are from the game
 constexpr u32 ART_FILE_VERSION = 6;
 constexpr u32 LEVEL_FILE_VERSION = 30;
 constexpr u32 DGO_FILE_VERSION = 1;
@@ -21,7 +23,7 @@ constexpr u32 RES_FILE_VERSION = 1;
 constexpr u32 TX_PAGE_VERSION = 7;
 }  // namespace versions
 
-// GOAL kernel version
+// GOAL kernel version (OpenGOAL changes this version from the game's version)
 constexpr int KERNEL_VERSION_MAJOR = 2;
 constexpr int KERNEL_VERSION_MINOR = 0;
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -81,3 +81,7 @@
 - Rearranged function stack frames so spilled register variable slots come after stack structures.
 - Added `stack` allocated and constructed basic/structure types.
 - Fixed a bug where functions with exactly 8 parameters created a compiler error.
+
+## V0.4
+- Breaking change: added new link kind to link table format. Code compiled with previous versions will still work, but code compiled in V0.4 that uses static pairs will cause a "unknown link table code 5" error.
+- Added support for static pairs and lists. Symbols, integers, and strings are supported.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -85,3 +85,5 @@
 ## V0.4
 - Breaking change: added new link kind to link table format. Code compiled with previous versions will still work, but code compiled in V0.4 that uses static pairs will cause a "unknown link table code 5" error.
 - Added support for static pairs and lists. Symbols, integers, and strings are supported.
+- Added much better support for setting fields of statics. Now you can set constants, symbols, strings, pairs, integers, floats, or other statics, including inlined structures/basics! Also uses the full type system for typechecking
+- Fixed a bug where accessing an inline basic field did not apply the 4-byte basic offset.

--- a/goal_src/kernel/gkernel.gc
+++ b/goal_src/kernel/gkernel.gc
@@ -2298,8 +2298,7 @@
 (define *default-dead-pool* (the dead-pool *nk-dead-pool*))
 (define *pickup-dead-pool* (the dead-pool *nk-dead-pool*))
 
-;; todo dead pool list
-
+(define *dead-pool-list* '(*4k-dead-pool* *8k-dead-pool* *16k-dead-pool* *nk-dead-pool* *target-dead-pool* *camera-dead-pool* *camera-master-dead-pool*))
 
 ;; main active pool
 (define *active-pool* (new 'global 'process-tree 'active-pool))

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -94,6 +94,9 @@ class Compiler {
   bool is_basic(const TypeSpec& ts);
   bool is_structure(const TypeSpec& ts);
   bool is_bitfield(const TypeSpec& ts);
+  std::vector<goos::Object> get_list_as_vector(const goos::Object& o,
+                                               goos::Object* rest_out = nullptr,
+                                               int max_length = -1);
   const goos::Object& pair_car(const goos::Object& o);
   const goos::Object& pair_cdr(const goos::Object& o);
   void expect_empty_list(const goos::Object& o);
@@ -212,7 +215,22 @@ class Compiler {
                                    Env* env);
   Val* compile_static_pair(const goos::Object& form, Env* env);
   StaticResult compile_static(const goos::Object& form, Env* env);
-  StaticResult compile_static_no_eval(const goos::Object& form, Env* env);
+  StaticResult compile_static_no_eval_for_pairs(const goos::Object& form, Env* env);
+  StaticResult compile_static_bitfield(const goos::Object& form,
+                                       const TypeSpec& type,
+                                       const goos::Object& _field_defs,
+                                       Env* env);
+  StaticResult compile_new_static_structure(const goos::Object& form,
+                                            const TypeSpec& type,
+                                            const goos::Object& _field_defs,
+                                            Env* env);
+
+  void compile_static_structure_inline(const goos::Object& form,
+                                       const TypeSpec& type,
+                                       const goos::Object& _field_defs,
+                                       StaticStructure* structure,
+                                       int offset,
+                                       Env* env);
 
   template <typename... Args>
   void throw_compiler_error(const goos::Object& code, const std::string& str, Args&&... args) {

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -210,6 +210,9 @@ class Compiler {
                                    const TypeSpec& type,
                                    const goos::Object& field_defs,
                                    Env* env);
+  Val* compile_static_pair(const goos::Object& form, Env* env);
+  StaticResult compile_static(const goos::Object& form, Env* env);
+  StaticResult compile_static_no_eval(const goos::Object& form, Env* env);
 
   template <typename... Args>
   void throw_compiler_error(const goos::Object& code, const std::string& str, Args&&... args) {

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -94,6 +94,7 @@ class Compiler {
   bool is_basic(const TypeSpec& ts);
   bool is_structure(const TypeSpec& ts);
   bool is_bitfield(const TypeSpec& ts);
+  bool is_pair(const TypeSpec& ts);
   std::vector<goos::Object> get_list_as_vector(const goos::Object& o,
                                                goos::Object* rest_out = nullptr,
                                                int max_length = -1);

--- a/goalc/compiler/StaticObject.cpp
+++ b/goalc/compiler/StaticObject.cpp
@@ -110,6 +110,10 @@ void StaticStructure::generate_structure(emitter::ObjectGenerator* gen) {
   for (auto& sym : symbols) {
     gen->link_static_symbol_ptr(rec, sym.offset, sym.name);
   }
+
+  for (auto& ptr : pointers) {
+    gen->link_static_pointer(rec, ptr.offset_in_this, ptr.dest->rec, ptr.offset_in_dest);
+  }
 }
 
 void StaticStructure::generate(emitter::ObjectGenerator* gen) {
@@ -121,6 +125,16 @@ void StaticStructure::add_symbol_record(std::string name, int offset) {
   srec.name = std::move(name);
   srec.offset = offset;
   symbols.push_back(srec);
+}
+
+void StaticStructure::add_pointer_record(int offset_in_this,
+                                         StaticStructure* dest,
+                                         int offset_in_dest) {
+  PointerRecord prec;
+  prec.offset_in_this = offset_in_this;
+  prec.dest = dest;
+  prec.offset_in_dest = offset_in_dest;
+  pointers.push_back(prec);
 }
 
 ///////////////////
@@ -137,4 +151,64 @@ int StaticBasic::get_addr_offset() const {
 void StaticBasic::generate(emitter::ObjectGenerator* gen) {
   generate_structure(gen);
   gen->link_static_type_ptr(rec, 0, type_name);
+}
+
+///////////////////
+// StaticPair
+///////////////////
+
+StaticPair::StaticPair(StaticResult car, StaticResult cdr, int _seg)
+    : StaticStructure(_seg), m_car(std::move(car)), m_cdr(std::move(cdr)) {}
+
+int StaticPair::get_addr_offset() const {
+  return PAIR_OFFSET;
+}
+
+void StaticPair::generate(emitter::ObjectGenerator* gen) {
+  data.resize(2 * POINTER_SIZE);  // size of pair
+  generate_item(m_car, 0);
+  generate_item(m_cdr, 4);
+  generate_structure(gen);
+}
+
+void StaticPair::generate_item(const StaticResult& item, int offset) {
+  if (item.is_reference()) {
+    add_pointer_record(offset, item.reference(), item.reference()->get_addr_offset());
+  } else if (item.is_symbol()) {
+    add_symbol_record(item.symbol_name(), offset);
+    u32 symbol_placeholder = 0xffffffff;
+    memcpy(data.data() + offset, &symbol_placeholder, POINTER_SIZE);
+  } else if (item.is_constant_data()) {
+    // if it's a constant data, it should always be a boxed integer for a pair.
+    // or I guess you could put a normal integer too. Either way, we assume signed here,
+    // though we may need to allow overflow so you can store either signed/unsigned things in pairs
+    s32 value = item.get_as_s32();
+    memcpy(data.data() + offset, &value, POINTER_SIZE);
+  }
+}
+
+///////////////////
+// StaticResult
+///////////////////
+
+StaticResult StaticResult::make_structure_reference(StaticStructure* structure, TypeSpec ts) {
+  StaticResult result;
+  result.m_kind = Kind::STRUCTURE_REFERENCE;
+  result.m_struct = structure;
+  result.m_ts = std::move(ts);
+  return result;
+}
+
+StaticResult StaticResult::make_constant_data(u64 value) {
+  StaticResult result;
+  result.m_kind = Kind::CONSTANT_DATA;
+  result.m_constant_data = value;
+  return result;
+}
+
+StaticResult StaticResult::make_symbol(const std::string& name) {
+  StaticResult result;
+  result.m_kind = Kind::SYMBOL;
+  result.m_symbol = name;
+  return result;
 }

--- a/goalc/compiler/StaticObject.cpp
+++ b/goalc/compiler/StaticObject.cpp
@@ -104,6 +104,10 @@ void StaticStructure::generate_structure(emitter::ObjectGenerator* gen) {
   for (auto& ptr : pointers) {
     gen->link_static_pointer(rec, ptr.offset_in_this, ptr.dest->rec, ptr.offset_in_dest);
   }
+
+  for (auto& type : types) {
+    gen->link_static_type_ptr(rec, type.offset, type.name);
+  }
 }
 
 void StaticStructure::generate(emitter::ObjectGenerator* gen) {
@@ -127,20 +131,24 @@ void StaticStructure::add_pointer_record(int offset_in_this,
   pointers.push_back(prec);
 }
 
+void StaticStructure::add_type_record(std::string name, int offset) {
+  SymbolRecord srec;
+  srec.name = std::move(name);
+  srec.offset = offset;
+  types.push_back(srec);
+}
+
 ///////////////////
 // StaticBasic
 ///////////////////
 
 StaticBasic::StaticBasic(int _seg, std::string _type_name)
-    : StaticStructure(_seg), type_name(std::move(_type_name)) {}
+    : StaticStructure(_seg), type_name(std::move(_type_name)) {
+  add_type_record(type_name, 0);
+}
 
 int StaticBasic::get_addr_offset() const {
   return BASIC_OFFSET;
-}
-
-void StaticBasic::generate(emitter::ObjectGenerator* gen) {
-  generate_structure(gen);
-  gen->link_static_type_ptr(rec, 0, type_name);
 }
 
 ///////////////////

--- a/goalc/compiler/StaticObject.cpp
+++ b/goalc/compiler/StaticObject.cpp
@@ -189,10 +189,11 @@ StaticResult StaticResult::make_structure_reference(StaticStructure* structure, 
   return result;
 }
 
-StaticResult StaticResult::make_constant_data(u64 value) {
+StaticResult StaticResult::make_constant_data(u64 value, TypeSpec ts) {
   StaticResult result;
   result.m_kind = Kind::CONSTANT_DATA;
   result.m_constant_data = value;
+  result.m_ts = std::move(ts);
   return result;
 }
 
@@ -200,5 +201,6 @@ StaticResult StaticResult::make_symbol(const std::string& name) {
   StaticResult result;
   result.m_kind = Kind::SYMBOL;
   result.m_symbol = name;
+  result.m_ts = TypeSpec("symbol");
   return result;
 }

--- a/goalc/compiler/StaticObject.cpp
+++ b/goalc/compiler/StaticObject.cpp
@@ -16,17 +16,11 @@ uint32_t push_data_to_byte_vector(T data, std::vector<uint8_t>& v) {
 ////////////////
 // StaticString
 ////////////////
-StaticString::StaticString(std::string data, int _seg) : text(std::move(data)), seg(_seg) {}
+StaticString::StaticString(std::string text_data, int _seg)
+    : StaticBasic(_seg, "string"), text(std::move(text_data)) {}
 
 std::string StaticString::print() const {
   return fmt::format("static-string \"{}\"", text);
-}
-
-StaticObject::LoadInfo StaticString::get_load_info() const {
-  LoadInfo info;
-  info.requires_load = false;
-  info.prefer_xmm = false;
-  return info;
 }
 
 void StaticString::generate(emitter::ObjectGenerator* gen) {
@@ -47,10 +41,6 @@ void StaticString::generate(emitter::ObjectGenerator* gen) {
     d.push_back(c);
   }
   d.push_back(0);
-}
-
-int StaticString::get_addr_offset() const {
-  return BASIC_OFFSET;
 }
 
 ////////////////

--- a/goalc/compiler/StaticObject.h
+++ b/goalc/compiler/StaticObject.h
@@ -93,7 +93,7 @@ class StaticResult {
   StaticResult() = default;
 
   static StaticResult make_structure_reference(StaticStructure* structure, TypeSpec ts);
-  static StaticResult make_constant_data(u64 value);
+  static StaticResult make_constant_data(u64 value, TypeSpec ts);
   static StaticResult make_symbol(const std::string& name);
 
   std::string print() const;
@@ -117,6 +117,11 @@ class StaticResult {
   const std::string& symbol_name() const {
     assert(is_symbol());
     return m_symbol;
+  }
+
+  u64 constant_data() const {
+    assert(is_constant_data());
+    return m_constant_data;
   }
 
  private:

--- a/goalc/compiler/StaticObject.h
+++ b/goalc/compiler/StaticObject.h
@@ -27,17 +27,6 @@ class StaticObject {
   emitter::StaticRecord rec;
 };
 
-class StaticString : public StaticObject {
- public:
-  explicit StaticString(std::string data, int _seg);
-  std::string text;
-  int seg = -1;
-  std::string print() const override;
-  LoadInfo get_load_info() const override;
-  void generate(emitter::ObjectGenerator* gen) override;
-  int get_addr_offset() const override;
-};
-
 class StaticFloat : public StaticObject {
  public:
   explicit StaticFloat(float _value, int _seg);
@@ -82,6 +71,14 @@ class StaticBasic : public StaticStructure {
   std::string type_name;
   StaticBasic(int _seg, std::string _type_name);
   int get_addr_offset() const override;
+  void generate(emitter::ObjectGenerator* gen) override;
+};
+
+class StaticString : public StaticBasic {
+ public:
+  explicit StaticString(std::string data, int _seg);
+  std::string text;
+  std::string print() const override;
   void generate(emitter::ObjectGenerator* gen) override;
 };
 

--- a/goalc/compiler/StaticObject.h
+++ b/goalc/compiler/StaticObject.h
@@ -59,11 +59,14 @@ class StaticStructure : public StaticObject {
     StaticStructure* dest = nullptr;
     int offset_in_dest = -1;
   };
+
+  std::vector<SymbolRecord> types;
   std::vector<SymbolRecord> symbols;
   std::vector<PointerRecord> pointers;
 
   void add_symbol_record(std::string name, int offset);
   void add_pointer_record(int offset_in_this, StaticStructure* dest, int offset_in_dest);
+  void add_type_record(std::string name, int offset);
 };
 
 class StaticBasic : public StaticStructure {
@@ -71,7 +74,6 @@ class StaticBasic : public StaticStructure {
   std::string type_name;
   StaticBasic(int _seg, std::string _type_name);
   int get_addr_offset() const override;
-  void generate(emitter::ObjectGenerator* gen) override;
 };
 
 class StaticString : public StaticBasic {

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -224,3 +224,31 @@ bool Compiler::get_true_or_false(const goos::Object& form, const goos::Object& b
   throw_compiler_error(form, "The value {} cannot be used as a boolean.", boolean.print());
   return false;
 }
+
+std::vector<goos::Object> Compiler::get_list_as_vector(const goos::Object& o,
+                                                       goos::Object* rest_out,
+                                                       int max_length) {
+  std::vector<goos::Object> result;
+
+  auto* cur = &o;
+  int n = 0;
+  while (true) {
+    if (max_length >= 0 && n >= max_length) {
+      if (rest_out) {
+        *rest_out = *cur;
+      }
+      return result;
+    }
+
+    if (cur->is_pair()) {
+      result.push_back(cur->as_pair()->car);
+      cur = &cur->as_pair()->cdr;
+      n++;
+    } else if (cur->is_empty_list()) {
+      if (rest_out) {
+        *rest_out = goos::EmptyListObject::make_new();
+      }
+      return result;
+    }
+  }
+}

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -163,6 +163,10 @@ bool Compiler::is_bitfield(const TypeSpec& ts) {
   return m_ts.is_bitfield_type(ts.base_type());
 }
 
+bool Compiler::is_pair(const TypeSpec& ts) {
+  return m_ts.typecheck(m_ts.make_typespec("pair"), ts, "", false, false);
+}
+
 bool Compiler::try_getting_constant_integer(const goos::Object& in, int64_t* out, Env* env) {
   (void)env;
   if (in.is_int()) {

--- a/goalc/compiler/compilation/Macro.cpp
+++ b/goalc/compiler/compilation/Macro.cpp
@@ -106,7 +106,8 @@ Val* Compiler::compile_quote(const goos::Object& form, const goos::Object& rest,
       empty_pair->set_type(m_ts.make_typespec("pair"));
       return empty_pair;
     }
-      // todo...
+    case goos::ObjectType::PAIR:
+      return compile_static_pair(thing, env);
     default:
       throw_compiler_error(form, "Quote is not yet implemented for {}.", thing.print());
   }

--- a/goalc/compiler/compilation/Static.cpp
+++ b/goalc/compiler/compilation/Static.cpp
@@ -144,6 +144,10 @@ void Compiler::compile_static_structure_inline(const goos::Object& form,
         }
 
         auto inlined_type = parse_typespec(unquote(new_form.at(2)));
+        if (inlined_type != field_info.type) {
+          throw_compiler_error(field_value, "Cannot store a {} in an inline {}",
+                               inlined_type.print(), field_info.type.print());
+        }
         compile_static_structure_inline(field_value, inlined_type, constructor_args, structure,
                                         field_offset, env);
 

--- a/goalc/compiler/compilation/Static.cpp
+++ b/goalc/compiler/compilation/Static.cpp
@@ -43,11 +43,147 @@ u32 float_as_u32(float x) {
 }
 }  // namespace
 
-Val* Compiler::compile_new_static_bitfield(const goos::Object& form,
-                                           const TypeSpec& type,
-                                           const goos::Object& _field_defs,
-                                           Env* env) {
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+/*!
+ * Compile the fields of a static structure into the given StaticStructure*, applying an offset.
+ * This can be used to generate an entire structure (set offset to 0), or to fill out an inline
+ * structure within an existing one (set the offset to the offset of the inline field)
+ */
+void Compiler::compile_static_structure_inline(const goos::Object& form,
+                                               const TypeSpec& type,
+                                               const goos::Object& _field_defs,
+                                               StaticStructure* structure,
+                                               int offset,
+                                               Env* env) {
+  auto type_info = dynamic_cast<StructureType*>(m_ts.lookup_type(type));
+  assert(type_info);
+
+  // make sure we have enough space
+  if (int(structure->data.size()) < offset + type_info->get_size_in_memory()) {
+    throw_compiler_error(form, "The structure does not fit in the type.");
+  }
+
+  auto* field_defs = &_field_defs;
+  while (!field_defs->is_empty_list()) {
+    auto field_name_def = symbol_string(pair_car(*field_defs));
+    field_defs = &pair_cdr(*field_defs);
+
+    auto field_value = pair_car(*field_defs);
+    field_defs = &pair_cdr(*field_defs);
+
+    if (field_name_def.at(0) != ':') {
+      throw_compiler_error(
+          form, "expected field def name to start with :, instead got " + field_name_def);
+    }
+
+    field_name_def = field_name_def.substr(1);
+    auto field_info = m_ts.lookup_field_info(type_info->get_name(), field_name_def);
+
+    if (field_info.field.is_dynamic() || field_info.field.is_inline() ||
+        field_info.field.is_array()) {
+      throw_compiler_error(form, "Static objects not yet implemented for dynamic/inline/array");
+    }
+
+    auto field_offset = field_info.field.offset() + offset;
+    assert(field_info.needs_deref);  // for now...
+    auto deref_info = m_ts.get_deref_info(m_ts.make_pointer_typespec(field_info.type));
+    auto field_size = deref_info.load_size;
+    assert(field_offset + field_size <= int(structure->data.size()));
+
+    if (is_integer(field_info.type)) {
+      s64 value = 0;
+      auto sr = compile_static(field_value, env);
+      if (!sr.is_constant_data()) {
+        throw_compiler_error(form, "Could not use {} for an integer field", field_value.print());
+      }
+      // we are not strict with the type checking here, as long as you give an "integer" and it
+      // ends up fitting, it's okay.
+      typecheck(form, TypeSpec("integer"), sr.typespec());
+      value = sr.constant_data();
+
+      if (!integer_fits(value, deref_info.load_size, deref_info.sign_extend)) {
+        throw_compiler_error(form,
+                             "Field {} is set to a compile time integer value of {} which would "
+                             "overflow (size {} signed {})",
+                             field_name_def, value, deref_info.load_size, deref_info.sign_extend);
+      }
+
+      if (field_size == 1 || field_size == 2 || field_size == 4 || field_size == 8) {
+        memcpy(structure->data.data() + field_offset, &value, field_size);
+      } else {
+        // not sure how we can create 128-bit integer constants at this point...
+        assert(false);
+      }
+    } else if (is_basic(field_info.type)) {
+      // todo - rewrite this to correctly handle structures within structures.
+      if (is_quoted_sym(field_value)) {
+        structure->add_symbol_record(quoted_sym_as_string(field_value), field_offset);
+        assert(deref_info.mem_deref);
+        assert(deref_info.can_deref);
+        assert(deref_info.load_size == 4);
+
+        // the linker needs to see a -1 in order to know to insert a symbol pointer
+        // instead of just the symbol table offset.
+        u32 linker_val = 0xffffffff;
+        memcpy(structure->data.data() + field_offset, &linker_val, 4);
+      } else if (field_value.is_symbol() &&
+                 (field_value.as_symbol()->name == "#t" || field_value.as_symbol()->name == "#f")) {
+        structure->add_symbol_record(symbol_string(field_value), field_offset);
+        assert(deref_info.mem_deref);
+        assert(deref_info.can_deref);
+        assert(deref_info.load_size == 4);
+
+        // the linker needs to see a -1 in order to know to insert a symbol pointer
+        // instead of just the symbol table offset.
+        u32 linker_val = 0xffffffff;
+        memcpy(structure->data.data() + field_offset, &linker_val, 4);
+      } else {
+        throw_compiler_error(
+            form, "Setting a basic field to anything other than a symbol is currently unsupported");
+      }
+    } else if (is_float(field_info.type)) {
+      auto sr = compile_static(field_value, env);
+      if (!sr.is_constant_data()) {
+        throw_compiler_error(form, "Could not use {} for a float field", field_value.print());
+      }
+      typecheck(form, TypeSpec("float"), sr.typespec());
+      u64 value = sr.constant_data();
+      memcpy(structure->data.data() + field_offset, &value, sizeof(float));
+    }
+
+    else {
+      assert(false);  // for now
+    }
+  }
+}
+
+StaticResult Compiler::compile_new_static_structure(const goos::Object& form,
+                                                    const TypeSpec& type,
+                                                    const goos::Object& _field_defs,
+                                                    Env* env) {
+  std::unique_ptr<StaticStructure> obj;
+  if (is_basic(type)) {
+    obj = std::make_unique<StaticBasic>(MAIN_SEGMENT, type.base_type());
+  } else {
+    // if we ever find this type of static data outside of MAIN_SEGMENT, we can create an option
+    // in the new form to pick the segment.
+    obj = std::make_unique<StaticStructure>(MAIN_SEGMENT);
+  }
+
+  auto type_info = dynamic_cast<StructureType*>(m_ts.lookup_type(type));
+  assert(type_info);
+
+  obj->data.resize(type_info->get_size_in_memory());
+  compile_static_structure_inline(form, type, _field_defs, obj.get(), 0, env);
+  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto result = StaticResult::make_structure_reference(obj.get(), type);
+  fie->add_static(std::move(obj));
+  return result;
+}
+
+StaticResult Compiler::compile_static_bitfield(const goos::Object& form,
+                                               const TypeSpec& type,
+                                               const goos::Object& _field_defs,
+                                               Env* env) {
   u64 as_int = 0;
 
   auto type_info = dynamic_cast<BitFieldType*>(m_ts.lookup_type(type));
@@ -118,134 +254,18 @@ Val* Compiler::compile_new_static_bitfield(const goos::Object& form,
     }
   }
 
-  return fe->alloc_val<IntegerConstantVal>(type, as_int);
+  return StaticResult::make_constant_data(as_int, type);
 }
 
-Val* Compiler::compile_new_static_structure_or_basic(const goos::Object& form,
-                                                     const TypeSpec& type,
-                                                     const goos::Object& _field_defs,
-                                                     Env* env) {
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
-  std::unique_ptr<StaticStructure> obj;
-  if (is_basic(type)) {
-    obj = std::make_unique<StaticBasic>(MAIN_SEGMENT, type.base_type());
-  } else {
-    // if we ever find this type of static data outside of MAIN_SEGMENT, we can create an option
-    // in the new form to pick the segment.
-    obj = std::make_unique<StaticStructure>(MAIN_SEGMENT);
-  }
-
-  auto type_info = dynamic_cast<StructureType*>(m_ts.lookup_type(type));
-  assert(type_info);  // should always be at least a structure.
-  obj->data.resize(type_info->get_size_in_memory());
-  // the file env will end up owning the obj.
-  auto result = fe->alloc_val<StaticVal>(obj.get(), type);
-
-  auto* field_defs = &_field_defs;
-  while (!field_defs->is_empty_list()) {
-    auto field_name_def = symbol_string(pair_car(*field_defs));
-    field_defs = &pair_cdr(*field_defs);
-
-    auto field_value = pair_car(*field_defs);
-    field_defs = &pair_cdr(*field_defs);
-
-    if (field_name_def.at(0) != ':') {
-      throw_compiler_error(
-          form, "expected field def name to start with :, instead got " + field_name_def);
-    }
-
-    field_name_def = field_name_def.substr(1);
-    auto field_info = m_ts.lookup_field_info(type_info->get_name(), field_name_def);
-
-    if (field_info.field.is_dynamic() || field_info.field.is_inline() ||
-        field_info.field.is_array()) {
-      throw_compiler_error(form, "Static objects not yet implemented for dynamic/inline/array");
-    }
-
-    auto field_offset = field_info.field.offset();
-    assert(field_info.needs_deref);  // for now...
-    auto deref_info = m_ts.get_deref_info(m_ts.make_pointer_typespec(field_info.type));
-    auto field_size = deref_info.load_size;
-    assert(field_offset + field_size <= int(obj->data.size()));
-
-    if (is_integer(field_info.type)) {
-      s64 value = 0;
-      if (!try_getting_constant_integer(field_value, &value, env)) {
-        throw_compiler_error(form,
-                             "Field {} is an integer, but the value given couldn't be "
-                             "converted to an integer at compile time.",
-                             field_name_def);
-      }
-
-      if (!integer_fits(value, deref_info.load_size, deref_info.sign_extend)) {
-        throw_compiler_error(form,
-                             "Field {} is set to a compile time integer value of {} which would "
-                             "overflow (size {} signed {})",
-                             field_name_def, value, deref_info.load_size, deref_info.sign_extend);
-      }
-
-      if (field_size == 1 || field_size == 2 || field_size == 4 || field_size == 8) {
-        memcpy(obj->data.data() + field_offset, &value, field_size);
-      } else {
-        // not sure how we can create 128-bit integer constants at this point...
-        assert(false);
-      }
-    } else if (is_basic(field_info.type)) {
-      if (is_quoted_sym(field_value)) {
-        obj->add_symbol_record(quoted_sym_as_string(field_value), field_offset);
-        assert(deref_info.mem_deref);
-        assert(deref_info.can_deref);
-        assert(deref_info.load_size == 4);
-
-        // the linker needs to see a -1 in order to know to insert a symbol pointer
-        // instead of just the symbol table offset.
-        u32 linker_val = 0xffffffff;
-        memcpy(obj->data.data() + field_offset, &linker_val, 4);
-      } else if (field_value.is_symbol() &&
-                 (field_value.as_symbol()->name == "#t" || field_value.as_symbol()->name == "#f")) {
-        obj->add_symbol_record(symbol_string(field_value), field_offset);
-        assert(deref_info.mem_deref);
-        assert(deref_info.can_deref);
-        assert(deref_info.load_size == 4);
-
-        // the linker needs to see a -1 in order to know to insert a symbol pointer
-        // instead of just the symbol table offset.
-        u32 linker_val = 0xffffffff;
-        memcpy(obj->data.data() + field_offset, &linker_val, 4);
-      } else {
-        throw_compiler_error(
-            form, "Setting a basic field to anything other than a symbol is currently unsupported");
-      }
-    } else if (is_float(field_info.type)) {
-      float value = 0.f;
-      if (!try_getting_constant_float(field_value, &value, env)) {
-        throw_compiler_error(form, fmt::format("Field {} is a float, but the value given couldn't "
-                                               "be converted to a float at compile time.",
-                                               field_name_def));
-      }
-      memcpy(obj->data.data() + field_offset, &value, sizeof(float));
-    }
-
-    else {
-      assert(false);  // for now
-    }
-  }
-
-  auto fie = get_parent_env_of_type<FileEnv>(env);
-  fie->add_static(std::move(obj));
-  return result;
-}
-
-Val* Compiler::compile_static_pair(const goos::Object& form, Env* env) {
-  assert(form.is_pair());  // (quote PAIR)
-  auto result = compile_static_no_eval(form, env);
-  assert(result.is_reference());
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
-  auto static_result = fe->alloc_val<StaticVal>(result.reference(), result.typespec());
-  return static_result;
-}
-
-StaticResult Compiler::compile_static_no_eval(const goos::Object& form, Env* env) {
+/*!
+ * Handles stuff in static pairs. Integers must be s32's.
+ * - Pairs
+ * - Empty Lists
+ * - Symbols
+ * - Integers
+ * - Strings
+ */
+StaticResult Compiler::compile_static_no_eval_for_pairs(const goos::Object& form, Env* env) {
   auto fie = get_parent_env_of_type<FileEnv>(env);
   auto fe = get_parent_env_of_type<FunctionEnv>(env);
   auto segment = fe->segment;
@@ -253,8 +273,8 @@ StaticResult Compiler::compile_static_no_eval(const goos::Object& form, Env* env
     segment = MAIN_SEGMENT;
   }
   if (form.is_pair()) {
-    auto car = compile_static_no_eval(form.as_pair()->car, env);
-    auto cdr = compile_static_no_eval(form.as_pair()->cdr, env);
+    auto car = compile_static_no_eval_for_pairs(form.as_pair()->car, env);
+    auto cdr = compile_static_no_eval_for_pairs(form.as_pair()->cdr, env);
     auto pair_structure = std::make_unique<StaticPair>(car, cdr, segment);
     auto result =
         StaticResult::make_structure_reference(pair_structure.get(), m_ts.make_typespec("pair"));
@@ -266,18 +286,165 @@ StaticResult Compiler::compile_static_no_eval(const goos::Object& form, Env* env
           form, "Cannot store {} (0x{:x}) in a pair because it overflows a signed 32-bit integer.",
           form.as_int(), form.as_int());
     }
-    return StaticResult::make_constant_data(form.as_int());
+    return StaticResult::make_constant_data(form.as_int(), TypeSpec("int32"));
   } else if (form.is_symbol()) {
     return StaticResult::make_symbol(form.as_symbol()->name);
   } else if (form.is_empty_list()) {
     return StaticResult::make_symbol("_empty_");
   } else if (form.is_string()) {
+    // todo - this should eventually work with a string pool
     auto obj = std::make_unique<StaticString>(form.as_string()->data, segment);
     auto result = StaticResult::make_structure_reference(obj.get(), m_ts.make_typespec("string"));
     fie->add_static(std::move(obj));
     return result;
-    assert(false);
   } else {
     assert(false);  // not yet implemented
   }
+}
+
+/*!
+ * Generic copmilation function to handle:
+ *  - (new 'static <structure-or-basic>), a reference
+ *
+ *  - (new 'static '<bitfield>), an integer constant
+ *  - (new 'static 'string), a string (not in the string pool, safe to modify)
+ *  - '(...) a quoted pair
+ *  - "a string" (goes in the string pool)
+ *  - 'a-symbol
+ *  - an integer
+ *  - a float
+ *  - a constant
+ *  - #t or #f
+ */
+StaticResult Compiler::compile_static(const goos::Object& form, Env* env) {
+  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto segment = fe->segment;
+  if (segment == TOP_LEVEL_SEGMENT) {
+    segment = MAIN_SEGMENT;
+  }
+
+  if (form.is_symbol()) {
+    // constant, #t, or #f
+    auto& name = form.as_symbol()->name;
+    if (name == "#t" || name == "#f") {
+      return StaticResult::make_symbol(name);
+    }
+
+    // as a constant
+    auto kv = m_global_constants.find(form.as_symbol());
+    if (kv != m_global_constants.end()) {
+      // expand constant and compile again.
+      return compile_static(kv->second, env);
+    } else {
+      throw_compiler_error(form, "The symbol {} could not be evaluated at compile time",
+                           form.print());
+    }
+  } else if (form.is_float()) {
+    u64 value = float_as_u32(form.as_float());
+    return StaticResult::make_constant_data(value, TypeSpec("float"));
+  } else if (form.is_int()) {
+    return StaticResult::make_constant_data(form.as_int(), TypeSpec("integer"));
+  } else if (is_quoted_sym(form)) {
+    return StaticResult::make_symbol(unquote(form).as_symbol()->name);
+  } else if (form.is_string()) {
+    // todo string pool
+    auto obj = std::make_unique<StaticString>(form.as_string()->data, segment);
+    auto result = StaticResult::make_structure_reference(obj.get(), m_ts.make_typespec("string"));
+    fie->add_static(std::move(obj));
+    return result;
+  } else if (form.is_pair()) {
+    auto first = form.as_pair()->car;
+    auto rest = form.as_pair()->cdr;
+    if (first.is_symbol() && first.as_symbol()->name == "quote") {
+      if (rest.is_pair()) {
+        auto second = rest.as_pair()->car;
+        if (!rest.as_pair()->cdr.is_empty_list()) {
+          throw_compiler_error(form, "The form {} is an invalid quoted form.", form.print());
+        }
+        if (second.is_pair()) {
+          return compile_static_no_eval_for_pairs(second, env);
+        } else {
+          throw_compiler_error(form, "Could not evaluate the quoted form {} at compile time.",
+                               second.print());
+        }
+      }
+      throw_compiler_error(form, "The quoted form {} has no argument.", form.print());
+    } else if (first.is_symbol() && first.as_symbol()->name == "new") {
+      goos::Object constructor_args;
+      auto args = get_list_as_vector(rest, &constructor_args, 2);
+      if (args.size() < 2) {
+        throw_compiler_error(form,
+                             "New form evaluated at compile must specify (new 'static <type> ...)");
+      }
+      if (!is_quoted_sym(args.at(0)) || unquote(args.at(0)).as_symbol()->name != "static") {
+        throw_compiler_error(form, "New form evaluated at compile time must use 'static. Got {}.",
+                             args.at(0).print());
+      }
+
+      if (!is_quoted_sym(args.at(1))) {
+        throw_compiler_error(form, "New form evaluated at compile got an invalid type: {}",
+                             args.at(1).print());
+      }
+
+      auto ts = parse_typespec(unquote(args.at(1)));
+      if (ts == TypeSpec("string")) {
+        // (new 'static 'string)
+        if (rest.is_pair() && rest.as_pair()->cdr.is_empty_list() &&
+            rest.as_pair()->car.is_string()) {
+          auto obj = std::make_unique<StaticString>(rest.as_pair()->car.as_string()->data, segment);
+          auto result =
+              StaticResult::make_structure_reference(obj.get(), m_ts.make_typespec("string"));
+          fie->add_static(std::move(obj));
+          return result;
+        } else {
+          throw_compiler_error(form, "Invalid new static string");
+        }
+      } else if (is_bitfield(ts)) {
+        return compile_static_bitfield(form, ts, constructor_args, env);
+      } else if (is_structure(ts)) {
+        return compile_new_static_structure(form, ts, constructor_args, env);
+      } else {
+        throw_compiler_error(form, "Cannot construct a static {}.", ts.print());
+      }
+    } else {
+      // maybe an enum
+      s64 int_out;
+      if (try_getting_constant_integer(form, &int_out, env)) {
+        return StaticResult::make_constant_data(int_out, TypeSpec("int"));
+      }
+    }
+  }
+
+  throw_compiler_error(form, "Could not evaluate {} at compile time.", form.print());
+  return {};
+}
+
+Val* Compiler::compile_new_static_bitfield(const goos::Object& form,
+                                           const TypeSpec& type,
+                                           const goos::Object& _field_defs,
+                                           Env* env) {
+  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto sr = compile_static_bitfield(form, type, _field_defs, env);
+  assert(sr.is_constant_data());
+  return fe->alloc_val<IntegerConstantVal>(sr.typespec(), sr.constant_data());
+}
+
+Val* Compiler::compile_static_pair(const goos::Object& form, Env* env) {
+  assert(form.is_pair());  // (quote PAIR)
+  auto result = compile_static_no_eval_for_pairs(form, env);
+  assert(result.is_reference());
+  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto static_result = fe->alloc_val<StaticVal>(result.reference(), result.typespec());
+  return static_result;
+}
+
+Val* Compiler::compile_new_static_structure_or_basic(const goos::Object& form,
+                                                     const TypeSpec& type,
+                                                     const goos::Object& field_defs,
+                                                     Env* env) {
+  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto sr = compile_new_static_structure(form, type, field_defs, env);
+  auto result = fe->alloc_val<StaticVal>(sr.reference(), type);
+  return result;
 }

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -412,8 +412,9 @@ Val* Compiler::get_field_of_structure(const StructureType* type,
     result = fe->alloc_val<MemoryDerefVal>(di.result_type, loc, MemLoadInfo(di));
     result->mark_as_settable();
   } else {
-    result =
-        fe->alloc_val<MemoryOffsetConstantVal>(field.type, object, field.field.offset() + offset);
+    auto field_type_info = m_ts.lookup_type(field.type);
+    result = fe->alloc_val<MemoryOffsetConstantVal>(
+        field.type, object, field.field.offset() + offset + field_type_info->get_offset());
     result->mark_as_settable();
   }
   return result;

--- a/goalc/emitter/ObjectGenerator.h
+++ b/goalc/emitter/ObjectGenerator.h
@@ -77,7 +77,10 @@ class ObjectGenerator {
   void link_instruction_symbol_mem(const InstructionRecord& rec, const std::string& name);
   void link_instruction_symbol_ptr(const InstructionRecord& rec, const std::string& name);
   void link_static_symbol_ptr(StaticRecord rec, int offset, const std::string& name);
-
+  void link_static_pointer(const StaticRecord& source,
+                           int source_offset,
+                           const StaticRecord& dest,
+                           int dest_offset);
   void link_instruction_static(const InstructionRecord& instr,
                                const StaticRecord& target_static,
                                int offset);
@@ -91,11 +94,13 @@ class ObjectGenerator {
   void handle_temp_static_sym_links(int seg);
   void handle_temp_rip_data_links(int seg);
   void handle_temp_rip_func_links(int seg);
+  void handle_temp_static_ptr_links(int seg);
 
   void emit_link_table(int seg);
   void emit_link_type_pointer(int seg);
   void emit_link_symbol(int seg);
   void emit_link_rip(int seg);
+  void emit_link_ptr(int seg);
   std::vector<u8> generate_header_v3();
 
   template <typename T>
@@ -139,6 +144,13 @@ class ObjectGenerator {
     int offset = -1;
   };
 
+  struct StaticPointerLink {
+    StaticRecord source;
+    int offset_in_source = -1;
+    StaticRecord dest;
+    int offset_in_dest = -1;
+  };
+
   struct SymbolInstrLink {
     InstructionRecord rec;
     bool is_mem_access = false;
@@ -166,6 +178,13 @@ class ObjectGenerator {
     IR_Record dest;
   };
 
+  struct PointerLink {
+    int segment = -1;
+    // both in bytes.
+    int source = -1;
+    int dest = -1;
+  };
+
   template <typename T>
   using seg_vector = std::array<std::vector<T>, N_SEG>;
 
@@ -185,6 +204,7 @@ class ObjectGenerator {
   seg_vector<JumpLink> m_jump_temp_links_by_seg;
   seg_map<SymbolInstrLink> m_symbol_instr_temp_links_by_seg;
   seg_map<StaticSymbolLink> m_static_sym_temp_links_by_seg;
+  seg_vector<StaticPointerLink> m_static_temp_ptr_links_by_seg;
   seg_vector<RipFuncLink> m_rip_func_temp_links_by_seg;
   seg_vector<RipDataLink> m_rip_data_temp_links_by_seg;
 
@@ -192,6 +212,7 @@ class ObjectGenerator {
   seg_map<int> m_type_ptr_links_by_seg;
   seg_map<int> m_sym_links_by_seg;
   seg_vector<RipLink> m_rip_links_by_seg;
+  seg_vector<PointerLink> m_pointer_links_by_seg;
 
   std::vector<FunctionRecord> m_all_function_records;
 };

--- a/test/goalc/source_templates/with_game/test-fancy-static-fields.gc
+++ b/test/goalc/source_templates/with_game/test-fancy-static-fields.gc
@@ -8,6 +8,7 @@
 (deftype basic-field-test-type (basic)
   ((name string)
    (kc kernel-context)
+   (kci kernel-context :inline)
    (pos float)
    (bf int32)
    (list pair))
@@ -19,6 +20,12 @@
                 :list '(a b c ) 
                 :name "name" 
                 :bf (new 'static 'basic-field-test-bitfield :f1 1 :f3 1) 
-                :kc (new 'static 'kernel-context :next-pid 12))))
-  (format #t "~A ~D ~f ~A ~D~%" (-> obj name) (-> obj kc next-pid) (-> obj pos) (-> obj list) (-> obj bf))
+                :kc (new 'static 'kernel-context :next-pid 12)
+                :kci (new 'static 'kernel-context :current-process 'asdf :relocating-min 33))))
+  (format #t "~A ~D ~f ~A ~D" (-> obj name) (-> obj kc next-pid) (-> obj pos) (-> obj list) (-> obj bf))
+  (format #t " ~D ~D ~A ~A~%" 
+          (-> obj kci relocating-min) 
+          (logand 15 (the int (-> obj kci))) 
+          (-> obj kci type) 
+          (-> obj kci current-process))
   )

--- a/test/goalc/source_templates/with_game/test-fancy-static-fields.gc
+++ b/test/goalc/source_templates/with_game/test-fancy-static-fields.gc
@@ -1,0 +1,24 @@
+(deftype basic-field-test-bitfield (int32)
+  ((f1 uint8 :offset 0 :size 1)
+   (f2 uint8 :offset 1 :size 1)
+   (f3 uint8 :offset 2 :size 1)
+   )
+  )
+
+(deftype basic-field-test-type (basic)
+  ((name string)
+   (kc kernel-context)
+   (pos float)
+   (bf int32)
+   (list pair))
+  )
+
+
+(let ((obj (new 'static 'basic-field-test-type 
+                :pos 12.34 
+                :list '(a b c ) 
+                :name "name" 
+                :bf (new 'static 'basic-field-test-bitfield :f1 1 :f3 1) 
+                :kc (new 'static 'kernel-context :next-pid 12))))
+  (format #t "~A ~D ~f ~A ~D~%" (-> obj name) (-> obj kc next-pid) (-> obj pos) (-> obj list) (-> obj bf))
+  )

--- a/test/goalc/source_templates/with_game/test-new-static-basic.gc
+++ b/test/goalc/source_templates/with_game/test-new-static-basic.gc
@@ -6,10 +6,11 @@
    (thing basic)
    (thing-2 basic)
    (thing-3 basic)
+   (thing-4 float)
    (u64 uint64))
   )
 
-(define test-static-basic (new 'static 'static-test-basic-type :s8 -122 :s16 -23123 :u64 434343 :thing 'bean :thing-2 #t :thing-3 #f))
+(define test-static-basic (new 'static 'static-test-basic-type :s8 -122 :s16 -23123 :thing-4 1.2 :u64 434343 :thing 'bean :thing-2 #t :thing-3 #f))
 
 (expect-true (< (the int test-static-basic) (-> debug current))) ;; should be in debug segment?
 (expect-true (> (the int test-static-basic) (-> debug base)))
@@ -23,5 +24,6 @@
 (expect-true (neq? (-> test-static-basic thing) 'not-bean))
 (expect-true (eq? (-> test-static-basic type symbol) 'static-test-basic-type))
 (expect-true (eq? (-> test-static-basic type) static-test-basic-type))
+(expect-true (eq? (-> test-static-basic thing-4) 1.2))
 
 (finish-test)

--- a/test/goalc/source_templates/with_game/test-static-pair-1.gc
+++ b/test/goalc/source_templates/with_game/test-static-pair-1.gc
@@ -1,0 +1,7 @@
+(defun test-static-pair-function ()
+  (format #t "~A~%" '(8 beans 16 twelve))
+  0
+)
+
+(test-static-pair-function)
+

--- a/test/goalc/source_templates/with_game/test-static-pair-1.gc
+++ b/test/goalc/source_templates/with_game/test-static-pair-1.gc
@@ -1,5 +1,5 @@
 (defun test-static-pair-function ()
-  (format #t "~A~%" '(8 beans 16 twelve))
+  (format #t "~A~%" '(8 ( w .  a ) beans 16 (-8 -16) twelve ( a  . "test")))
   0
 )
 

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -325,7 +325,8 @@ TEST_F(WithGameTests, Math) {
 }
 
 TEST_F(WithGameTests, StaticPairs) {
-  runner.run_static_test(env, testCategory, "test-static-pair-1.gc", {"(1 beans 2 twelve)\n0\n"});
+  runner.run_static_test(env, testCategory, "test-static-pair-1.gc",
+                         {"(1 (w . a) beans 2 (-1 -2) twelve (a . \"test\"))\n0\n"});
 }
 
 TEST(TypeConsistency, TypeConsistency) {

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -259,7 +259,7 @@ TEST_F(WithGameTests, NewStaticStructureIntegers) {
 
 TEST_F(WithGameTests, NewStaticBasic) {
   runner.run_static_test(env, testCategory, "test-new-static-basic.gc",
-                         get_test_pass_string("new-static-basic", 11));
+                         get_test_pass_string("new-static-basic", 12));
 }
 
 TEST_F(WithGameTests, VectorDot) {

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -324,6 +324,10 @@ TEST_F(WithGameTests, Math) {
   runner.run_static_test(env, testCategory, "test-math.gc", get_test_pass_string("math", 31));
 }
 
+TEST_F(WithGameTests, StaticPairs) {
+  runner.run_static_test(env, testCategory, "test-static-pair-1.gc", {"(1 beans 2 twelve)\n0\n"});
+}
+
 TEST(TypeConsistency, TypeConsistency) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -331,7 +331,7 @@ TEST_F(WithGameTests, StaticPairs) {
 
 TEST_F(WithGameTests, FancyStatic) {
   runner.run_static_test(env, testCategory, "test-fancy-static-fields.gc",
-                         {"\"name\" 12 12.3400 (a b c) 5\n0\n"});
+                         {"\"name\" 12 12.3400 (a b c) 5 33 4 kernel-context asdf\n0\n"});
 }
 
 TEST(TypeConsistency, TypeConsistency) {

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -329,6 +329,11 @@ TEST_F(WithGameTests, StaticPairs) {
                          {"(1 (w . a) beans 2 (-1 -2) twelve (a . \"test\"))\n0\n"});
 }
 
+TEST_F(WithGameTests, FancyStatic) {
+  runner.run_static_test(env, testCategory, "test-fancy-static-fields.gc",
+                         {"\"name\" 12 12.3400 (a b c) 5\n0\n"});
+}
+
 TEST(TypeConsistency, TypeConsistency) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();


### PR DESCRIPTION
Add support for pointers to other data in the same segment in the linker (`LINK_PTR`), in `ObjectGenerator` and in `StaticStructure`.

In the compiler, add static pairs, linked lists, etc. For now, it supports quoting only (no quasiquote), so you can't put in GOAL expressions. The only supported elements are: more pairs/lists, strings, symbols, and integers, which are signed 32-bit integers.

Make `StaticString` a child of `StaticBasic`, which makes including strings are pair elements, and eventually including strings a fields much easier.

Add the `StaticResult` class. It's kind of like a `RegVal`, but works with the static part of the compiler.  It would have been really cool if the static stuff could use `Val` like all the rest of the front end, but it seems like there would need to be too much special-casing. A `StaticResult` can be used to store an integer/float/bitfield-type-constant, reference, symbol, but not stuff like "the entire data of a type".