### PR TITLE
[Decompiler] Improve reverse field lookup

### DIFF
--- a/common/goal_constants.h
+++ b/common/goal_constants.h
@@ -10,6 +10,7 @@ constexpr s32 PAIR_OFFSET = 2;
 constexpr int POINTER_SIZE = 4;
 constexpr int BASIC_OFFSET = 4;
 constexpr int STRUCTURE_ALIGNMENT = 16;
+constexpr int ARRAY_DATA_OFFSET = 12;  // not including type tag
 
 constexpr s32 GOAL_MAX_SYMBOLS = 0x2000;
 constexpr s32 SYM_INFO_OFFSET = 0xff34;

--- a/common/type_system/CMakeLists.txt
+++ b/common/type_system/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(type_system
         TypeSystem.cpp
         Type.cpp
         TypeSpec.cpp
-        deftype.cpp)
+        deftype.cpp
+        TypeFieldLookup.cpp)
 
 target_link_libraries(type_system fmt goos)

--- a/common/type_system/TypeFieldLookup.cpp
+++ b/common/type_system/TypeFieldLookup.cpp
@@ -1,8 +1,33 @@
+/*!
+ * @file TypeFieldLookup.cpp
+ * Reverse field lookup used in the decompiler.
+ */
+
 #include "third-party/fmt/core.h"
 #include "TypeSystem.h"
 
-bool debug_reverse_lookup = true;
+namespace {
+// debug prints for the reverse lookup
+bool debug_reverse_lookup = false;
 
+/*!
+ * Is the actual dereference compatible with the expected?
+ */
+bool deref_matches(const DerefInfo& expected, const DerefKind& actual, bool is_integer) {
+  assert(expected.mem_deref);
+  assert(expected.can_deref);
+  if (actual.is_store || actual.size >= 8 || !is_integer) {
+    // don't check sign extension
+    return expected.load_size == actual.size;
+  } else {
+    return expected.load_size == actual.size && expected.sign_extend == actual.sign_extend;
+  }
+}
+}  // namespace
+
+/*!
+ * Convert a Token in a field path to a string for debugging.
+ */
 std::string FieldReverseLookupOutput::Token::print() const {
   switch (kind) {
     case Kind::FIELD:
@@ -16,37 +41,45 @@ std::string FieldReverseLookupOutput::Token::print() const {
   }
 }
 
+/*!
+ * Main reverse lookup. Check the success field of the result to see if it was successful.
+ * Will return the type of result as well as the path taken to get there.
+ * The path can be arbitrarily long because we could be looking through nested inline structures.
+ * The result is _always_ an actual dereference and there is no way for this to return "no deref".
+ * The "offset" should always be the actual memory offset in the load instruction.
+ * This is the "offset into memory" - "boxed offset"
+ */
 FieldReverseLookupOutput TypeSystem::reverse_field_lookup(
     const FieldReverseLookupInput& input) const {
+  if (debug_reverse_lookup) {
+    fmt::print("reverse_field_lookup on {} offset {} deref {} stride {}\n", input.base_type.print(),
+               input.offset, input.deref.has_value(), input.stride);
+  }
   FieldReverseLookupOutput result;
   result.success = try_reverse_lookup(input, &result.tokens, &result.addr_of, &result.result_type);
   // todo check for only one var lookup.
   return result;
 }
 
+/*!
+ * Reverse lookup helper. Returns true if successful. It's okay to call this an have it fail.
+ * Will set path/addr_of/result_type if successful.
+ */
 bool TypeSystem::try_reverse_lookup(const FieldReverseLookupInput& input,
                                     std::vector<FieldReverseLookupOutput::Token>* path,
                                     bool* addr_of,
                                     TypeSpec* result_type) const {
   if (debug_reverse_lookup) {
-    fmt::print("try_reverse_lookup on {} offset {} deref {} stride {}", input.base_type.print(),
+    fmt::print(" try_reverse_lookup on {} offset {} deref {} stride {}\n", input.base_type.print(),
                input.offset, input.deref.has_value(), input.stride);
   }
-
-  //  // base case:
-  //  if (input.offset == 0 && !input.deref.has_value() && input.stride == 0) {
-  //    // note, could also be getting the address of the first thing in the struct??
-  //    *addr_of = false;
-  //    *result_type = input.base_type;
-  //    return true;
-  //  }
 
   auto base_input_type = input.base_type.base_type();
   if (base_input_type == "pointer") {
     return try_reverse_lookup_pointer(input, path, addr_of, result_type);
   } else if (base_input_type == "inline-array") {
     return try_reverse_lookup_inline_array(input, path, addr_of, result_type);
-  } else if (base_input_type == "array") {
+  } else if (base_input_type == "array" && input.base_type.has_single_arg()) {
     return try_reverse_lookup_array(input, path, addr_of, result_type);
   } else {
     return try_reverse_lookup_other(input, path, addr_of, result_type);
@@ -54,23 +87,24 @@ bool TypeSystem::try_reverse_lookup(const FieldReverseLookupInput& input,
   return false;
 }
 
-bool deref_matches(const DerefInfo& expected, const DerefKind& actual) {
-  assert(expected.mem_deref);
-  assert(expected.can_deref);
-  if (actual.is_store) {
-    // don't check sign extension
-    return expected.load_size == actual.size && expected.reg == actual.reg_kind;
-  } else {
-    return expected.load_size == actual.size && expected.sign_extend == actual.sign_extend &&
-           expected.reg == actual.reg_kind;
-  }
-}
-
+/*!
+ * Handle a dereference of a pointer. This can be:
+ * - just dereferencing a pointer
+ * - accessing a variable element of a pointer-style array
+ * - getting the address of a variable element of a pointer-style array
+ * - accessing a constant element of a pointer-style array
+ * - getting the address of a constant element of a pointer-style array
+ */
 bool TypeSystem::try_reverse_lookup_pointer(const FieldReverseLookupInput& input,
                                             std::vector<FieldReverseLookupOutput::Token>* path,
                                             bool* addr_of,
                                             TypeSpec* result_type) const {
+  if (!input.base_type.has_single_arg()) {
+    return false;
+  }
   auto di = get_deref_info(input.base_type);
+  bool is_integer =
+      typecheck(TypeSpec("integer"), input.base_type.get_single_arg(), "", false, false);
   assert(di.mem_deref);  // it's accessing a pointer.
   auto elt_type = di.result_type;
   if (input.stride) {
@@ -89,7 +123,7 @@ bool TypeSystem::try_reverse_lookup_pointer(const FieldReverseLookupInput& input
     token.kind = FieldReverseLookupOutput::Token::Kind::VAR_IDX;
     path->push_back(token);
     if (input.deref.has_value()) {
-      if (deref_matches(di, input.deref.value())) {
+      if (deref_matches(di, input.deref.value(), is_integer)) {
         // access element of array
         *addr_of = false;
         *result_type = elt_type;
@@ -117,15 +151,14 @@ bool TypeSystem::try_reverse_lookup_pointer(const FieldReverseLookupInput& input
     token.kind = FieldReverseLookupOutput::Token::Kind::CONSTANT_IDX;
     token.idx = elt_idx;
     if (input.deref.has_value()) {
-      if (!deref_matches(di, input.deref.value())) {
+      if (!deref_matches(di, input.deref.value(), is_integer)) {
         // this isn't the right type of dereference
         return false;
       }
-      if (elt_idx != 0) {
-        // (-> thing) is probably better than (-> thing 0), in the case thing is just a pointer
-        // to a single thing that we're dereferencing.
-        path->push_back(token);
-      }
+
+      // always push back an index so we're never ambiguous.
+      path->push_back(token);
+
       // access constant idx element of array
       *addr_of = false;
       *result_type = elt_type;
@@ -141,23 +174,288 @@ bool TypeSystem::try_reverse_lookup_pointer(const FieldReverseLookupInput& input
   }
 }
 
+/*!
+ * Handle a dereference with an "array" type.
+ * This has two cases:
+ * - accessing a field of the array class, not including the array data. Like any other structure.
+ * - accessing the data array part of the array class, very similar to the pointer-style array.
+ */
 bool TypeSystem::try_reverse_lookup_array(const FieldReverseLookupInput& input,
                                           std::vector<FieldReverseLookupOutput::Token>* path,
                                           bool* addr_of,
                                           TypeSpec* result_type) const {
-  return false;
+  // type should be (array elt-type)
+  if (!input.base_type.has_single_arg()) {
+    return false;
+  }
+
+  if (input.offset < ARRAY_DATA_OFFSET) {
+    // we are accessing a field in an array so we can treat this like any other structure.
+    // this will add the basic offset, so we can pass in the input unchanged.
+    return try_reverse_lookup_other(input, path, addr_of, result_type);
+  }
+
+  // this is the data type - (pointer elt-type). this is stored at an offset of ARRAY_DATA_OFFSET.
+  auto array_data_type = make_pointer_typespec(input.base_type.get_single_arg());
+  auto di = get_deref_info(array_data_type);
+  bool is_integer =
+      typecheck(TypeSpec("integer"), input.base_type.get_single_arg(), "", false, false);
+  assert(di.mem_deref);  // it's accessing a pointer.
+  auto elt_type = di.result_type;
+  if (input.stride) {
+    if (input.offset != ARRAY_DATA_OFFSET) {
+      // might be constant propagated other offsets here?
+      return false;
+    }
+
+    // variable access to the array.
+    if (input.stride != di.stride) {
+      // mismatched array strides, fail!
+      return false;
+    }
+
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::VAR_IDX;
+    path->push_back(token);
+    if (input.deref.has_value()) {
+      if (deref_matches(di, input.deref.value(), is_integer)) {
+        // access element of array
+        *addr_of = false;
+        *result_type = elt_type;
+        return true;
+      } else {
+        // this isn't the right type of dereference.
+        return false;
+      }
+    } else {
+      // get the address of a variable indexed element of a pointer-style array
+      *addr_of = true;
+      *result_type = make_pointer_typespec(elt_type);
+      return true;
+    }
+  } else {
+    // either access array or just plain deref a pointer.
+    int elt_idx = (input.offset - ARRAY_DATA_OFFSET) / di.stride;
+    int offset_into_elt = (input.offset - ARRAY_DATA_OFFSET) - (elt_idx * di.stride);
+    if (offset_into_elt) {
+      // should line up correctly.
+      return false;
+    }
+
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::CONSTANT_IDX;
+    token.idx = elt_idx;
+    // always put array index, even if it's zero.
+    path->push_back(token);
+    if (input.deref.has_value()) {
+      if (!deref_matches(di, input.deref.value(), is_integer)) {
+        // this isn't the right type of dereference
+        return false;
+      }
+
+      // access constant idx element of array
+      *addr_of = false;
+      *result_type = elt_type;
+      return true;
+    } else {
+      // get address of constant idx element of array
+      *addr_of = true;
+      *result_type = make_pointer_typespec(elt_type);
+      return true;
+    }
+  }
 }
 
+/*!
+ * Handle a reverse deref of an inline-array.  This assumes that the array contains inlined
+ * reference type objects.  It can handle
+ * - get a reference object (variable idx)
+ * - get something inside an object (variable idx)
+ * - get a constant idx reference object (we pick this over just getting the array for idx = 0)
+ * - get something inside a constant idx reference object
+ */
 bool TypeSystem::try_reverse_lookup_inline_array(const FieldReverseLookupInput& input,
                                                  std::vector<FieldReverseLookupOutput::Token>* path,
                                                  bool* addr_of,
                                                  TypeSpec* result_type) const {
-  return false;
+  auto di = get_deref_info(input.base_type);
+  assert(di.can_deref);
+  assert(!di.mem_deref);  // if we make integer arrays allowed to be inline-array, this will break.
+
+  if (input.stride) {
+    if (input.stride != di.stride) {
+      return false;
+    }
+
+    if (input.offset >= di.stride) {
+      return false;
+    }
+
+    // variable lookup.
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::VAR_IDX;
+    path->push_back(token);
+
+    if (input.offset == 0 && !input.deref.has_value()) {
+      *addr_of = false;
+      *result_type = di.result_type;
+      return true;
+    }
+
+    FieldReverseLookupInput next_input;
+    next_input.deref = input.deref;
+    next_input.stride = 0;
+    next_input.offset = input.offset;
+    next_input.base_type = di.result_type;
+    return try_reverse_lookup(next_input, path, addr_of, result_type);
+  } else {
+    // constant lookup, or accessing within the first one
+    // which element we are in
+    int elt_idx = input.offset / di.stride;
+    // how many bytes into the element we look
+    int offset_into_elt = input.offset - (elt_idx * di.stride);
+    // the expected number of bytes into the element we would look to grab a ref to the elt.
+    int expected_offset_into_elt = lookup_type(di.result_type)->get_offset();
+
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::CONSTANT_IDX;
+    token.idx = elt_idx;
+
+    if (offset_into_elt == expected_offset_into_elt && !input.deref.has_value()) {
+      // just get an element (possibly zero, and we want to include the 0 if so)
+      // for the degenerate inline-array case, it seems more likely that we get the zeroth object
+      // rather than the array?  Either way, this code should be compatible with both approaches.
+      path->push_back(token);
+      *addr_of = false;
+      *result_type = di.result_type;
+      return true;
+    }
+
+    // otherwise access within the element
+    if (elt_idx != 0) {
+      path->push_back(token);
+    }
+    FieldReverseLookupInput next_input;
+    next_input.deref = input.deref;
+    next_input.stride = 0;
+    // try_reverse_lookup expects "offset_into_field - boxed_offset"
+    next_input.offset = offset_into_elt - expected_offset_into_elt;
+    next_input.base_type = di.result_type;
+    return try_reverse_lookup(next_input, path, addr_of, result_type);
+  }
 }
 
+/*!
+ * Handle a deref for fields of a structure.
+ * - Access a field which requires mem deref.
+ * - Get address of a field which requires mem deref.
+ */
 bool TypeSystem::try_reverse_lookup_other(const FieldReverseLookupInput& input,
                                           std::vector<FieldReverseLookupOutput::Token>* path,
                                           bool* addr_of,
                                           TypeSpec* result_type) const {
+  auto type_info = lookup_type(input.base_type);
+  auto structure_type = dynamic_cast<StructureType*>(type_info);
+  if (!structure_type) {
+    return false;
+  }
+
+  auto corrected_offset = input.offset + type_info->get_offset();
+  // loop over fields. We may need to try multiple fields.
+  for (auto& field : structure_type->fields()) {
+    auto field_deref = lookup_field_info(type_info->get_name(), field.name());
+
+    // how many bytes do we look at? In the case where we're just getting an address, we assume
+    // one byte, so we'll always pass the size check.
+    auto effective_load_size = 1;
+    if (input.deref.has_value()) {
+      effective_load_size = input.deref->size;
+    }
+
+    if (corrected_offset >= field.offset() &&
+        (corrected_offset + effective_load_size <= field.offset() + get_size_in_type(field) ||
+         field.is_dynamic())) {
+      // the field size looks okay.
+      int offset_into_field = corrected_offset - field.offset();
+
+      FieldReverseLookupOutput::Token token;
+      token.kind = FieldReverseLookupOutput::Token::Kind::FIELD;
+      token.name = field.name();
+
+      if (field_deref.needs_deref) {
+        if (offset_into_field == 0) {
+          if (input.deref.has_value()) {
+            // needs deref, offset is 0, did a deref.
+            // Check the deref is right...
+            // (pointer <field-type>)
+            TypeSpec loc_type = make_pointer_typespec(field_deref.type);
+            auto di = get_deref_info(loc_type);
+            bool is_integer = typecheck(TypeSpec("integer"), field_deref.type, "", false, false);
+            if (!deref_matches(di, input.deref.value(), is_integer)) {
+              continue;  // try another field!
+            }
+            // it's a match, just access the field like normal!
+            if (input.stride) {
+              continue;
+            }
+            path->push_back(token);
+            *addr_of = false;
+            *result_type = field_deref.type;
+            return true;
+          } else {
+            // needs a deref, offset is 0, didn't do a deref.
+            // we're taking the address
+            if (input.stride) {
+              continue;
+            }
+            path->push_back(token);
+            *addr_of = true;
+            *result_type = make_pointer_typespec(field_deref.type);
+            return true;
+          }
+        } else {
+          if (input.deref.has_value()) {
+            // needs deref, offset != 0, did a deref.
+            // try a different field.
+            continue;
+          } else {
+            // needs deref, offset != 0, didn't deref.
+            // try a different field
+            continue;
+          }
+        }
+      } else {
+        // no deref needed
+        int expected_offset_into_field = 0;
+        if (field.is_inline()) {
+          expected_offset_into_field = lookup_type(field.type())->get_offset();
+        }
+        if (offset_into_field == expected_offset_into_field && !input.deref.has_value()) {
+          // get the inline field.
+          if (input.stride) {
+            continue;
+          }
+          path->push_back(token);
+          *result_type = field_deref.type;
+          *addr_of = false;
+          return true;
+        } else {
+          FieldReverseLookupInput next_input;
+          next_input.deref = input.deref;
+          next_input.offset = offset_into_field - expected_offset_into_field;
+          next_input.stride = input.stride;
+          next_input.base_type = field_deref.type;
+          auto old_path = *path;
+          path->push_back(token);
+          if (try_reverse_lookup(next_input, path, addr_of, result_type)) {
+            return true;
+          } else {
+            *path = old_path;
+            continue;
+          }
+        }
+      }
+    }
+  }
   return false;
 }

--- a/common/type_system/TypeFieldLookup.cpp
+++ b/common/type_system/TypeFieldLookup.cpp
@@ -1,0 +1,163 @@
+#include "third-party/fmt/core.h"
+#include "TypeSystem.h"
+
+bool debug_reverse_lookup = true;
+
+std::string FieldReverseLookupOutput::Token::print() const {
+  switch (kind) {
+    case Kind::FIELD:
+      return name;
+    case Kind::CONSTANT_IDX:
+      return std::to_string(idx);
+    case Kind::VAR_IDX:
+      return "__VAR__";
+    default:
+      assert(false);
+  }
+}
+
+FieldReverseLookupOutput TypeSystem::reverse_field_lookup(
+    const FieldReverseLookupInput& input) const {
+  FieldReverseLookupOutput result;
+  result.success = try_reverse_lookup(input, &result.tokens, &result.addr_of, &result.result_type);
+  // todo check for only one var lookup.
+  return result;
+}
+
+bool TypeSystem::try_reverse_lookup(const FieldReverseLookupInput& input,
+                                    std::vector<FieldReverseLookupOutput::Token>* path,
+                                    bool* addr_of,
+                                    TypeSpec* result_type) const {
+  if (debug_reverse_lookup) {
+    fmt::print("try_reverse_lookup on {} offset {} deref {} stride {}", input.base_type.print(),
+               input.offset, input.deref.has_value(), input.stride);
+  }
+
+  //  // base case:
+  //  if (input.offset == 0 && !input.deref.has_value() && input.stride == 0) {
+  //    // note, could also be getting the address of the first thing in the struct??
+  //    *addr_of = false;
+  //    *result_type = input.base_type;
+  //    return true;
+  //  }
+
+  auto base_input_type = input.base_type.base_type();
+  if (base_input_type == "pointer") {
+    return try_reverse_lookup_pointer(input, path, addr_of, result_type);
+  } else if (base_input_type == "inline-array") {
+    return try_reverse_lookup_inline_array(input, path, addr_of, result_type);
+  } else if (base_input_type == "array") {
+    return try_reverse_lookup_array(input, path, addr_of, result_type);
+  } else {
+    return try_reverse_lookup_other(input, path, addr_of, result_type);
+  }
+  return false;
+}
+
+bool deref_matches(const DerefInfo& expected, const DerefKind& actual) {
+  assert(expected.mem_deref);
+  assert(expected.can_deref);
+  if (actual.is_store) {
+    // don't check sign extension
+    return expected.load_size == actual.size && expected.reg == actual.reg_kind;
+  } else {
+    return expected.load_size == actual.size && expected.sign_extend == actual.sign_extend &&
+           expected.reg == actual.reg_kind;
+  }
+}
+
+bool TypeSystem::try_reverse_lookup_pointer(const FieldReverseLookupInput& input,
+                                            std::vector<FieldReverseLookupOutput::Token>* path,
+                                            bool* addr_of,
+                                            TypeSpec* result_type) const {
+  auto di = get_deref_info(input.base_type);
+  assert(di.mem_deref);  // it's accessing a pointer.
+  auto elt_type = di.result_type;
+  if (input.stride) {
+    // variable access to the array.
+    if (input.stride != di.stride) {
+      // mismatched array strides, fail!
+      return false;
+    }
+    if (input.offset != 0) {
+      // can't access within an element of a pointer array.
+      // todo - this could be some sort of constant folding for the next operation.
+      return false;
+    }
+
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::VAR_IDX;
+    path->push_back(token);
+    if (input.deref.has_value()) {
+      if (deref_matches(di, input.deref.value())) {
+        // access element of array
+        *addr_of = false;
+        *result_type = elt_type;
+        return true;
+      } else {
+        // this isn't the right type of dereference.
+        return false;
+      }
+    } else {
+      // get the address of a variable indexed element of a pointer-style array
+      *addr_of = true;
+      *result_type = make_pointer_typespec(elt_type);
+      return true;
+    }
+  } else {
+    // either access array or just plain deref a pointer.
+    int elt_idx = input.offset / di.stride;
+    int offset_into_elt = input.offset - (elt_idx * di.stride);
+    if (offset_into_elt) {
+      // should line up correctly.
+      return false;
+    }
+
+    FieldReverseLookupOutput::Token token;
+    token.kind = FieldReverseLookupOutput::Token::Kind::CONSTANT_IDX;
+    token.idx = elt_idx;
+    if (input.deref.has_value()) {
+      if (!deref_matches(di, input.deref.value())) {
+        // this isn't the right type of dereference
+        return false;
+      }
+      if (elt_idx != 0) {
+        // (-> thing) is probably better than (-> thing 0), in the case thing is just a pointer
+        // to a single thing that we're dereferencing.
+        path->push_back(token);
+      }
+      // access constant idx element of array
+      *addr_of = false;
+      *result_type = elt_type;
+      return true;
+    } else {
+      // we want (&-> arr 0)
+      path->push_back(token);
+      // get address of constant idx element of array
+      *addr_of = true;
+      *result_type = make_pointer_typespec(elt_type);
+      return true;
+    }
+  }
+}
+
+bool TypeSystem::try_reverse_lookup_array(const FieldReverseLookupInput& input,
+                                          std::vector<FieldReverseLookupOutput::Token>* path,
+                                          bool* addr_of,
+                                          TypeSpec* result_type) const {
+  return false;
+}
+
+bool TypeSystem::try_reverse_lookup_inline_array(const FieldReverseLookupInput& input,
+                                                 std::vector<FieldReverseLookupOutput::Token>* path,
+                                                 bool* addr_of,
+                                                 TypeSpec* result_type) const {
+  return false;
+}
+
+bool TypeSystem::try_reverse_lookup_other(const FieldReverseLookupInput& input,
+                                          std::vector<FieldReverseLookupOutput::Token>* path,
+                                          bool* addr_of,
+                                          TypeSpec* result_type) const {
+  return false;
+}

--- a/common/type_system/TypeSystem.cpp
+++ b/common/type_system/TypeSystem.cpp
@@ -126,6 +126,10 @@ DerefInfo TypeSystem::get_deref_info(const TypeSpec& ts) const {
   info.reg = RegKind::GPR_64;
   info.mem_deref = true;
 
+  if (typecheck(TypeSpec("float"), ts, "", false, false)) {
+    info.reg = RegKind::FLOAT;
+  }
+
   if (ts.base_type() == "inline-array") {
     auto result_type = lookup_type(ts.get_single_arg());
     auto result_structure_type = dynamic_cast<StructureType*>(result_type);

--- a/decompiler/IR/BasicOpBuilder.cpp
+++ b/decompiler/IR/BasicOpBuilder.cpp
@@ -1005,14 +1005,26 @@ std::shared_ptr<IR_Atomic> try_sw(Instruction& instr, int idx) {
       op->update_reginfo_self(0, 2, 0);
       return op;
     } else {
-      auto op = std::make_shared<IR_Store_Atomic>(
-          IR_Store_Atomic::INTEGER,
-          std::make_shared<IR_IntMath2>(
-              IR_IntMath2::ADD, make_reg(instr.get_src(2).get_reg(), idx),
-              std::make_shared<IR_IntegerConstant>(instr.get_src(1).get_imm())),
-          make_reg(instr.get_src(0).get_reg(), idx), 4);
-      op->update_reginfo_self(0, 2, 0);
-      return op;
+      if (instr.get_src(0).is_reg(make_gpr(Reg::S7))) {
+        // store false
+        auto op = std::make_shared<IR_Store_Atomic>(
+            IR_Store_Atomic::Kind::INTEGER,
+            std::make_shared<IR_IntMath2>(
+                IR_IntMath2::ADD, make_reg(instr.get_src(2).get_reg(), idx),
+                std::make_shared<IR_IntegerConstant>(instr.get_src(1).get_imm())),
+            make_sym("#f"), 4);
+        op->update_reginfo_self(0, 1, 0);
+        return op;
+      } else {
+        auto op = std::make_shared<IR_Store_Atomic>(
+            IR_Store_Atomic::INTEGER,
+            std::make_shared<IR_IntMath2>(
+                IR_IntMath2::ADD, make_reg(instr.get_src(2).get_reg(), idx),
+                std::make_shared<IR_IntegerConstant>(instr.get_src(1).get_imm())),
+            make_reg(instr.get_src(0).get_reg(), idx), 4);
+        op->update_reginfo_self(0, 2, 0);
+        return op;
+      }
     }
   }
   return nullptr;

--- a/decompiler/IR/IR.h
+++ b/decompiler/IR/IR.h
@@ -517,9 +517,9 @@ class IR_Breakpoint_Atomic : public virtual IR_Atomic {
   IR_Breakpoint_Atomic() = default;
   goos::Object to_form(const LinkedObjectFile& file) const override;
   void get_children(std::vector<std::shared_ptr<IR>>* output) const override;
-  //  void propagate_types(const TypeState& input,
-  //                       const LinkedObjectFile& file,
-  //                       DecompilerTypeSystem& dts) override;
+  void propagate_types(const TypeState& input,
+                       const LinkedObjectFile& file,
+                       DecompilerTypeSystem& dts) override;
 };
 
 class IR_Begin : public virtual IR {
@@ -655,9 +655,9 @@ class IR_AsmOp_Atomic : public virtual IR_AsmOp, public IR_Atomic {
  public:
   IR_AsmOp_Atomic(std::string _name) : IR_AsmOp(std::move(_name)) {}
   void set_reg_info();
-  //  void propagate_types(const TypeState& input,
-  //                       const LinkedObjectFile& file,
-  //                       DecompilerTypeSystem& dts) override;
+  void propagate_types(const TypeState& input,
+                       const LinkedObjectFile& file,
+                       DecompilerTypeSystem& dts) override;
 };
 
 class IR_CMoveF : public virtual IR {

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -800,7 +800,29 @@ std::string LinkedObjectFile::print_type_analysis_debug() {
           // result += func.basic_ops.at(i)->print(*this);
           if (func.attempted_type_analysis) {
             result += fmt::format("[{:3d}] ", i);
-            result += func.basic_ops.at(i)->print_with_types(*init_types, *this);
+            auto& op = func.basic_ops.at(i);
+            result += op->print_with_types(*init_types, *this);
+
+            // temporary debug load path print
+            auto op_as_set = dynamic_cast<IR_Set_Atomic*>(op.get());
+            if (op_as_set) {
+              auto op_as_load = dynamic_cast<IR_Load*>(op_as_set->src.get());
+              if (op_as_load && op_as_load->load_path_set) {
+                if (op_as_load->load_path_addr_of) {
+                  result += " (&->";
+                } else {
+                  result += " (->";
+                }
+                result += ' ';
+                result += op_as_load->load_path_base->print(*this);
+                for (auto& tok : op_as_load->load_path) {
+                  result += ' ';
+                  result += tok;
+                }
+                result += ')';
+              }
+            }
+
             result += "\n";
             init_types = &func.basic_ops.at(i)->end_types;
           } else {

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -90,6 +90,8 @@
   "no_type_analysis_functions_by_name":[
     "(method 2 vec4s)",       // 128-bit bitfield.
     "(method 3 vec4s)",       // 128-bit bitfield
+    "qmem-copy<-!",           // 128-bit loads and stores
+    "qmem-copy->!",           // 128-bit loads and stores
     "reset-and-call",         // stack manipulation
     "(method 10 cpu-thread)"  // loading saved regs off of the stack.
   ],

--- a/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
@@ -1,4 +1,36 @@
 {
+	"(method 2 array)":[
+		[23, ["gp", "(array int32)"]],
+		[43, ["gp", "(array uint32)"]],
+		[63, ["gp", "(array int64)"]],
+		[83, ["gp", "(array uint64)"]],
+		[102, ["gp", "(array int8)"]],
+		[121, ["gp", "(array uint8)"]],
+		[141, ["gp", "(array int16)"]],
+		[161, ["gp", "(array uint16)"]],
+		[185, ["gp", "(array uint128)"]],
+		[203, ["gp", "(array int32)"]],
+		[222, ["gp", "(array float)"]],
+		[231, ["gp", "(array float)"]],
+		[248, ["gp", "(array basic)"]],
+		[257, ["gp", "(array basic)"]]
+	],
+
+	"(method 3 array)":[
+		[44, ["gp", "(array int32)"]],
+		[62, ["gp", "(array uint32)"]],
+		[80, ["gp", "(array int64)"]],
+		[98, ["gp", "(array uint64)"]],
+		[115, ["gp", "(array int8)"]],
+		[132, ["gp", "(array int8)"]], // bug in game
+		[150, ["gp", "(array int16)"]],
+		[168, ["gp", "(array uint16)"]],
+		[190, ["gp", "(array uint128)"]],
+		[203, ["gp", "(array int32)"]],
+		[225, ["gp", "(array float)"]],
+		[242, ["gp", "(array basic)"]]
+	],
+
 	"(method 2 handle)":[
 		[10, ["a3", "process"]],
 		[11, ["v1", "int"]],

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -262,7 +262,7 @@ TP_Type DecompilerTypeSystem::tp_lca(const TP_Type& existing, const TP_Type& add
         result_type = TP_Type::make_from_typespec(TypeSpec("string"));
       }
 
-      *changed = (result_type == existing);
+      *changed = (result_type != existing);
       return result_type;
     }
 

--- a/decompiler/util/TP_Type.h
+++ b/decompiler/util/TP_Type.h
@@ -229,6 +229,11 @@ class TP_Type {
     return m_int;
   }
 
+  uint64_t get_integer_constant() const {
+    assert(kind == Kind::INTEGER_CONSTANT);
+    return m_int;
+  }
+
  private:
   TypeSpec m_ts;
   std::string m_str;

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -538,7 +538,7 @@ Val* Compiler::compile_deref(const goos::Object& form, const goos::Object& _rest
       assert(di.mem_deref);
       assert(di.can_deref);
       // the total offset is 12 + stride * idx
-      auto offset = compile_integer(12, env)->to_gpr(env);
+      auto offset = compile_integer(ARRAY_DATA_OFFSET, env)->to_gpr(env);
       auto stride = compile_integer(di.stride, env)->to_gpr(env);
       env->emit(std::make_unique<IR_IntegerMath>(IntegerMathKind::IMUL_32, stride, index_value));
       env->emit_ir<IR_IntegerMath>(IntegerMathKind::ADD_64, offset, stride);


### PR DESCRIPTION
Improve the reverse field lookup.  Now we can correctly handle the cases described in https://github.com/water111/jak-project/issues/161.  We also should support inline basics, more types of nested field access, better "get pointer to thing in array", and support for fancy boxed arrays (print and inspect for array type now pass type propagation).

After this PR, KERNEL.CGO:
```
144/211 functions attempted type analysis (68.25%)
125/144 functions that attempted type analysis succeeded (86.81%)
125/211 functions passed type analysis (59.24%)
```