### PR TITLE
[Compiler] Add `reset-here` option to colored and constrained rlet vars

### DIFF
--- a/decompiler/Function/ExpressionBuilder.cpp
+++ b/decompiler/Function/ExpressionBuilder.cpp
@@ -25,17 +25,18 @@ bool Function::build_expression(LinkedObjectFile& file) {
     // or more complicated analysis to do as good as possible on outer begins.
     auto all_children = ir->get_all_ir(file);
     std::vector<IR_Begin*> all_begins;
-    for (auto i = all_children.size(); i-- > 0;) {
-      auto as_begin = dynamic_cast<IR_Begin*>(all_children.at(i).get());
-      if (as_begin) {
-        all_begins.push_back(as_begin);
-      }
-    }
 
     // the top level may also be a begin
     auto as_begin = dynamic_cast<IR_Begin*>(ir.get());
     if (as_begin) {
       all_begins.push_back(as_begin);
+    }
+
+    for (auto& i : all_children) {
+      auto child_as_begin = dynamic_cast<IR_Begin*>(i.get());
+      if (child_as_begin) {
+        all_begins.push_back(child_as_begin);
+      }
     }
 
     // turn each begin into an expression

--- a/decompiler/ObjectFile/ObjectFileDB.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB.cpp
@@ -1099,11 +1099,14 @@ void ObjectFileDB::analyze_expressions() {
     (void)segment_id;
     // register usage
     func.run_reg_usage();
-    attempts++;
-    if (func.build_expression(data.linked_data)) {
-      success++;
-    } else {
-      func.warnings.append(";; Expression analysis failed.\n");
+
+    if (func.attempted_type_analysis) {
+      attempts++;
+      if (func.build_expression(data.linked_data)) {
+        success++;
+      } else {
+        func.warnings.append(";; Expression analysis failed.\n");
+      }
     }
   });
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -89,3 +89,4 @@
 - Fixed a bug where accessing an inline basic field did not apply the 4-byte basic offset.
 - Made string/float constants go in the main segment when they are declared in the top-level segment, instead of the top-level segment. This is what GOAL seems to do (not 100% sure yet) and avoids issues where you set something to a string constant in the top-level. This avoids the possibility of memory bugs at the cost of more memory usage (likely very little additional memory).
 - Added support for boxed arrays. They can be created with `new` and indexed with `->`. The compound type `(array <elt-type>)` is used to describe an array with a given content type.
+- Added `reset-here` option for `rlet`.

--- a/goal_src/kernel/gkernel-h.gc
+++ b/goal_src/kernel/gkernel-h.gc
@@ -492,10 +492,16 @@
   )
 
 (defmacro suspend ()
-  `(rlet ((pp :reg r13))
+  `(rlet ((pp :reg r13 :reset-here #t))
          (.push pp)
          (set! pp (-> (the process pp) top-thread))
          ((-> (the cpu-thread pp) suspend-hook) (the cpu-thread 0))
          (.pop pp)
+         )
+  )
+
+(defmacro process-deactivate ()
+  `(rlet ((pp :reg r13 :reset-here #t :type process))
+         (deactivate pp)
          )
   )

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -857,15 +857,15 @@ void IR_Null::do_codegen(emitter::ObjectGenerator* gen,
 }
 
 ///////////////////////
-// FunctionStart
+// ValueReset
 ///////////////////////
-IR_FunctionStart::IR_FunctionStart(std::vector<RegVal*> args) : m_args(std::move(args)) {}
+IR_ValueReset::IR_ValueReset(std::vector<RegVal*> args) : m_args(std::move(args)) {}
 
-std::string IR_FunctionStart::print() {
-  return "function-start";
+std::string IR_ValueReset::print() {
+  return "value-reset";
 }
 
-RegAllocInstr IR_FunctionStart::to_rai() {
+RegAllocInstr IR_ValueReset::to_rai() {
   RegAllocInstr rai;
   for (auto& x : m_args) {
     rai.write.push_back(x->ireg());
@@ -873,9 +873,9 @@ RegAllocInstr IR_FunctionStart::to_rai() {
   return rai;
 }
 
-void IR_FunctionStart::do_codegen(emitter::ObjectGenerator* gen,
-                                  const AllocationResult& allocs,
-                                  emitter::IR_Record irec) {
+void IR_ValueReset::do_codegen(emitter::ObjectGenerator* gen,
+                               const AllocationResult& allocs,
+                               emitter::IR_Record irec) {
   (void)gen;
   (void)allocs;
   (void)irec;

--- a/goalc/compiler/IR.h
+++ b/goalc/compiler/IR.h
@@ -316,9 +316,9 @@ class IR_Null : public IR {
                   emitter::IR_Record irec) override;
 };
 
-class IR_FunctionStart : public IR {
+class IR_ValueReset : public IR {
  public:
-  IR_FunctionStart(std::vector<RegVal*> args);
+  IR_ValueReset(std::vector<RegVal*> args);
   std::string print() override;
   RegAllocInstr to_rai() override;
   void do_codegen(emitter::ObjectGenerator* gen,

--- a/goalc/compiler/compilation/Function.cpp
+++ b/goalc/compiler/compilation/Function.cpp
@@ -169,7 +169,7 @@ Val* Compiler::compile_lambda(const goos::Object& form, const goos::Object& rest
     auto func_block_env = new_func_env->alloc_env<BlockEnv>(new_func_env.get(), "#f");
     func_block_env->return_value = return_reg;
     func_block_env->end_label = Label(new_func_env.get());
-    func_block_env->emit(std::make_unique<IR_FunctionStart>(args_for_coloring));
+    func_block_env->emit(std::make_unique<IR_ValueReset>(args_for_coloring));
 
     // compile the function, iterating through the body.
     Val* result = nullptr;

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -182,7 +182,7 @@ Val* Compiler::generate_inspector_for_type(const goos::Object& form, Env* env, T
   constraint.desired_register = emitter::gRegInfo.get_arg_reg(0);  // to the first argument
   method_env->constrain(constraint);
   // Inform the compiler that `input`'s value will be written to `rdi` (first arg register)
-  method_env->emit(std::make_unique<IR_FunctionStart>(std::vector<RegVal*>{input}));
+  method_env->emit(std::make_unique<IR_ValueReset>(std::vector<RegVal*>{input}));
 
   RegVal* type_name = nullptr;
   if (dynamic_cast<BasicType*>(structured_type)) {
@@ -342,7 +342,7 @@ Val* Compiler::compile_defmethod(const goos::Object& form, const goos::Object& _
   auto func_block_env = new_func_env->alloc_env<BlockEnv>(new_func_env.get(), "#f");
   func_block_env->return_value = return_reg;
   func_block_env->end_label = Label(new_func_env.get());
-  func_block_env->emit(std::make_unique<IR_FunctionStart>(args_for_coloring));
+  func_block_env->emit(std::make_unique<IR_ValueReset>(args_for_coloring));
 
   // compile the function!
   Val* result = nullptr;

--- a/test/goalc/source_templates/kernel/kernel-test.gc
+++ b/test/goalc/source_templates/kernel/kernel-test.gc
@@ -1,41 +1,3 @@
-; (defun get-saved-regs ((dest (pointer uint64)))
-;   (rlet ((s0 :reg rbx :type uint)
-;          (s1 :reg rbp :type uint)
-;          (s2 :reg r10 :type uint)
-;          (s3 :reg r11 :type uint)
-;          (s4 :reg r12 :type uint))
-;         (set! (-> dest 0) s0)
-;         (set! (-> dest 1) s1)
-;         (set! (-> dest 2) s2)
-;         (set! (-> dest 3) s3)
-;         (set! (-> dest 4) s4)
-        
-;         )
-;   )
-
-(defmacro with-named-reg-vars-check (&rest body)
-  `(let ((one 1)
-         (two 2)
-         (three 3)
-         (four 4)
-         (five 5)
-         (six 6)
-         (seven 7)
-         (eight 8)
-         (nine 9))
-     ,@body
-     (format 0 "~d ~d ~d ~d ~d ~d " one two three four five six)
-     (format 0 "~d ~d ~d~%" seven eight nine)
-     )
-  
-  )
-
-(defun deactivate-myself ()
-  "Deactivate the current process. A workaround because rlet isn't working well."
-  (rlet ((pp :reg r13 :type process))
-        (deactivate pp)
-        )
-  )
 
 (defun target-function ((a0 uint) (a1 uint) (a2 uint) (a3 uint) (a4 uint) (a5 uint))
   (format #t "TARGET FUNCTION ~D ~D ~D~%" a0 a1 a2)
@@ -49,7 +11,7 @@
     (format #t "proc1: ~D~%" i)
     (when (> i 4)
       (format #t "DEACTIVATE PROC 1~%")
-      (deactivate-myself)
+      (process-deactivate)
       )
     (suspend)
     )
@@ -102,7 +64,7 @@
     (format #t "Stack Alignemnt ~D/16~%" (logand 15 (the uint stack-arr)))
     )
   (if (eq? a0 (the int 0))
-      (deactivate-myself)
+      (process-deactivate)
       )
   'init-child-proc-result
   )
@@ -117,7 +79,7 @@
       )
     )
   
-  (deactivate-myself)
+  (process-deactivate)
   )
 
 (defun kernel-test-2 ()


### PR DESCRIPTION
See updated documentation for details.

This allows you to have multiple `suspend` and `process-deactivate`s in the same function.