### PR TITLE
[Compiler] Better array indexing

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -104,3 +104,6 @@
 - Fixed an off-by-one in move eliminator (previous version was correct, but did not generate as good code). Complicated functions are 2 to 10% smaller.
 - Improved getting a stack address.
 - Improved getting the value of `#f`, `#t`, and `()`.
+- Accessing a constant field of an array now constant propagates the memory offset like field access and avoids a runtime multiply.
+- Fixed a bug where loading or storing a `vf` register from a memory location + constant offset would cause the compiler to throw an error.
+- Accessing array elements uses more efficient indexing for power-of-two element sizes.

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -237,6 +237,7 @@ class Compiler {
                                        StaticStructure* structure,
                                        int offset,
                                        Env* env);
+  void compile_constant_product(RegVal* dest, RegVal* src, int stride, Env* env);
 
   template <typename... Args>
   void throw_compiler_error(const goos::Object& code, const std::string& str, Args&&... args) {

--- a/goalc/compiler/compilation/Asm.cpp
+++ b/goalc/compiler/compilation/Asm.cpp
@@ -304,7 +304,6 @@ Val* Compiler::compile_asm_svf(const goos::Object& form, const goos::Object& res
   info.reg = RegClass::VECTOR_FLOAT;
   if (as_co) {
     // can do a clever offset here
-    assert(false);
     env->emit_ir<IR_StoreConstOffset>(src, as_co->offset, as_co->base->to_gpr(env), 16, color);
   } else {
     env->emit_ir<IR_StoreConstOffset>(src, 0, dest->to_gpr(env), 16, color);

--- a/test/goalc/source_templates/with_game/test-boxed-array-index.gc
+++ b/test/goalc/source_templates/with_game/test-boxed-array-index.gc
@@ -1,0 +1,5 @@
+(let ((arr (new 'global 'boxed-array int16 12))
+      (x 3))
+  ;; 12 + 3 * 2 = 18
+  (format #t "~D~%" (&- (&-> arr 3) arr))
+  )

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -361,6 +361,10 @@ TEST_F(WithGameTests, XMMSpill) {
   runner.run_static_test(env, testCategory, "test-xmm-spill.gc", {"253.0000\n0\n"});
 }
 
+TEST_F(WithGameTests, BoxedArrayIndex) {
+  runner.run_static_test(env, testCategory, "test-boxed-array-index.gc", {"18\n0\n"});
+}
+
 TEST(TypeConsistency, TypeConsistency) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();


### PR DESCRIPTION
The given case of `(-> x 3)` is now a single instruction instead of 6! (where `x` is an array of `int32`)
Old:
```
  [0x1000d] mov ecx, 0x03                          mov-ic igpr-3, 3
  [0x10012] mov edx, 0x04                          mov-ic igpr-4, 4
  [0x10017] imul edx, ecx                          imul igpr-4, igpr-3
  [0x1001a] movsxd rdx, edx
  [0x1001d] add rdx, rax                           addi igpr-6, igpr-2
  [0x10020] movsxd rax, dword ptr [r15+rdx*1]      mov igpr-5, [igpr-6 + 0]
```
New:
```
  [0x1000a] movsxd rax, dword ptr [r15+rax*1+0x0C] mov igpr-3, [igpr-2 + 12]
```
Also, `(-> x <var>)` is now
```
  [0x1000f] shl rcx, 0x02                          shl igpr-5, 2
  [0x10013] add rcx, rax                           addi igpr-7, igpr-3
  [0x10016] movsxd rax, dword ptr [r15+rcx*1]      mov igpr-6, [igpr-7 + 0]

```
instead of 
```
  [0x10012] mov edx, 0x04                          mov-ic igpr-4, 4
  [0x10017] imul edx, ecx                          imul igpr-4, igpr-3
  [0x1001a] movsxd rdx, edx
  [0x1001d] add rdx, rax                           addi igpr-6, igpr-2
  [0x10020] movsxd rax, dword ptr [r15+rdx*1]      mov igpr-5, [igpr-6 + 0]
```

Stacked memory constant offsets now propagate.

This will close https://github.com/water111/jak-project/issues/173