### PR TITLE
Add logs folder to root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-build-debug/*
 .idea/*
 build/*
 decompiler_out/*
+logs/*

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Certain configurations may use the root directory to create the ``logs`` folder.