### PR TITLE
[Compiler] Implement and/or in the compiler instead of a macro

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -112,3 +112,4 @@
 - Fixed bug where `(-> obj type)` caused a compiler error when `obj` had compile time type of `array` (the fancy boxed array)
 - Fixed use-after-free if the top-level form fails to compile and you continue trying to compile stuff.
 - `and` and `or` are more efficient and the type of the result is more specific: `LCA(symbol, cases...)`
+- `print-type` now fully compiles the argument and returns the result instead of `none`

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -111,3 +111,4 @@
 - Split `method` into `method-of-type` and `method-of-object` to avoid ambiguity
 - Fixed bug where `(-> obj type)` caused a compiler error when `obj` had compile time type of `array` (the fancy boxed array)
 - Fixed use-after-free if the top-level form fails to compile and you continue trying to compile stuff.
+- `and` and `or` are more efficient and the type of the result is more specific: `LCA(symbol, cases...)`

--- a/doc/goal_doc.md
+++ b/doc/goal_doc.md
@@ -1094,7 +1094,7 @@ Print the type of some GOAL expression at compile time.
 ```lisp
 (print-type form)
 ```
-This is mainly used to debug the compiler or figure out why some code is failing a type check. The thing inside is actually executed at runtime. Example:
+This is mainly used to debug the compiler or figure out why some code is failing a type check. The thing inside is compiled fully and used as the result of `print-type`. Example:
 ```lisp
 (print-type "apples")        ;; [TYPE] string
 (print-type (+ 12 1.2))      ;; [TYPE] int

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -304,47 +304,6 @@
 
 ;; TODO - these work but aren't very efficient.
 
-(defmacro and (&rest args)
-  (with-gensyms (result end)
-    `(begin
-       (let ((,result (the object #f)))
-         ,@(apply (lambda (x)
-                    `(begin
-                      (set! ,result ,x)
-                      (if (eq? ,result #f)
-                        (goto ,end)
-                        )
-                      )
-                    )
-                  args
-                  )
-         (label ,end)
-         ,result
-         )
-       )
-    )
-  )
-
-(defmacro or (&rest args)
-  (with-gensyms (result end)
-    `(begin
-       (let ((,result (the object #f)))
-         ,@(apply (lambda (x)
-                    `(begin
-                       (set! ,result ,x)
-                       (if (not (eq? ,result #f))
-                         (goto ,end)
-                         )
-                       )
-                    )
-                  args
-                  )
-         (label ,end)
-         ,result
-         )
-       )
-    )
-  )
 
 ;;;;;;;;;;;;;;;;;;;
 ;; Math Macros

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -322,6 +322,7 @@ class Compiler {
   Val* compile_condition_as_bool(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_when_goto(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_cond(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_and_or(const goos::Object& form, const goos::Object& rest, Env* env);
 
   // Define
   Val* compile_define(const goos::Object& form, const goos::Object& rest, Env* env);

--- a/goalc/compiler/IR.h
+++ b/goalc/compiler/IR.h
@@ -116,22 +116,6 @@ class IR_RegSet : public IR {
   const RegVal* m_src = nullptr;
 };
 
-class IR_GotoLabel : public IR {
- public:
-  IR_GotoLabel();
-  void resolve(const Label* dest);
-  explicit IR_GotoLabel(const Label* dest);
-  std::string print() override;
-  RegAllocInstr to_rai() override;
-  void do_codegen(emitter::ObjectGenerator* gen,
-                  const AllocationResult& allocs,
-                  emitter::IR_Record irec) override;
-
- protected:
-  const Label* m_dest = nullptr;
-  bool m_resolved = false;
-};
-
 class IR_FunctionCall : public IR {
  public:
   IR_FunctionCall(const RegVal* func, const RegVal* ret, std::vector<RegVal*> args);
@@ -255,6 +239,22 @@ struct Condition {
   bool is_float = false;
   RegAllocInstr to_rai();
   std::string print() const;
+};
+
+class IR_GotoLabel : public IR {
+ public:
+  IR_GotoLabel();
+  void resolve(const Label* dest);
+  explicit IR_GotoLabel(const Label* dest);
+  std::string print() override;
+  RegAllocInstr to_rai() override;
+  void do_codegen(emitter::ObjectGenerator* gen,
+                  const AllocationResult& allocs,
+                  emitter::IR_Record irec) override;
+
+ protected:
+  const Label* m_dest = nullptr;
+  bool m_resolved = false;
 };
 
 class IR_ConditionalBranch : public IR {

--- a/goalc/compiler/compilation/Atoms.cpp
+++ b/goalc/compiler/compilation/Atoms.cpp
@@ -56,6 +56,8 @@ static const std::unordered_map<
         // CONTROL FLOW
         {"cond", &Compiler::compile_cond},
         {"when-goto", &Compiler::compile_when_goto},
+        {"and", &Compiler::compile_and_or},
+        {"or", &Compiler::compile_and_or},
 
         // DEFINITION
         {"define", &Compiler::compile_define},

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -655,8 +655,9 @@ Val* Compiler::compile_the(const goos::Object& form, const goos::Object& rest, E
 Val* Compiler::compile_print_type(const goos::Object& form, const goos::Object& rest, Env* env) {
   auto args = get_va(form, rest);
   va_check(form, args, {{}}, {});
-  fmt::print("[TYPE] {}\n", compile(args.unnamed.at(0), env)->type().print());
-  return get_none();
+  auto result = compile(args.unnamed.at(0), env)->to_reg(env);
+  fmt::print("[TYPE] {}\n", result->type().print());
+  return result;
 }
 
 /*!

--- a/test/goalc/source_templates/with_game/test-short-circuit.gc
+++ b/test/goalc/source_templates/with_game/test-short-circuit.gc
@@ -1,0 +1,33 @@
+(start-test "short-circuit")
+
+(defun dont-call-me ()
+  (segfault)
+  )
+
+(expect-true (= 1 (and 1)))
+(expect-true (= #f (and #f)))
+(expect-true (= 1 (and 2 1)))
+(expect-true (= #f (and 2 #f 1)))
+(expect-true (= #f (and #f 1 1)))
+(expect-true (= #f (and 2 1 #f)))
+
+(expect-true (= 1 (or 1)))
+(expect-true (= #f (or #f)))
+(expect-true (= 2 (or 2 1)))
+(expect-true (= 2 (or 2 #f 1)))
+(expect-true (= 3 (or #f 3 1)))
+(expect-true (= 2 (or 2 1 #f)))
+(expect-true (= 2 (or #f #f #f 2 3 #f)))
+
+(or #f #f 1 (segfault) 2)
+
+(and 1 #f 1 (segfault) 2)
+
+(let ((x (the symbol #f)))
+  ;; type system should allow this because and will return a symbol
+  (set! x (and #t #f))
+  (set! x (or #t #f))
+  ;; (set! x (or 1 #f)) ;; not allowed.
+  )
+
+(finish-test)

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -370,6 +370,11 @@ TEST_F(WithGameTests, LocalVars) {
                          {"y is \"test\", x is 12, z is 3.2000\n0\n"});
 }
 
+TEST_F(WithGameTests, ShortCircuit) {
+  runner.run_static_test(env, testCategory, "test-short-circuit.gc",
+                         get_test_pass_string("short-circuit", 13));
+}
+
 TEST(TypeConsistency, TypeConsistency) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();


### PR DESCRIPTION
The code is more efficient and it gives a more specific compile time type as a result, fixing https://github.com/water111/jak-project/issues/223

Also adds tests for `and` and `or` which I guess I never wrote???