### PR TITLE
Fix asize bug, decompile a few files

### DIFF
--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -36,10 +36,10 @@ void ObjectFileDB::analyze_functions_ir2(const std::string& output_dir) {
   ir2_type_analysis_pass();
   lg::info("Register usage analysis...");
   ir2_register_usage_pass();
-  lg::info("Initial structuring..");
-  ir2_cfg_build_pass();
   lg::info("Variable analysis...");
   ir2_variable_pass();
+  lg::info("Initial structuring..");
+  ir2_cfg_build_pass();
   if (get_config().analyze_expressions) {
     lg::info("Storing temporary form result...");
     ir2_store_current_forms();

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -7690,7 +7690,7 @@
 ;; surface-h
 (deftype surface (basic)
   ((name              basic      :offset-assert 4)
-   ;(data              UNKNOWN 30 :offset-assert 8)
+   ;; data went here
    (turnv             float      :offset-assert 8)
    (turnvv            float      :offset-assert 12)
    (tiltv             float      :offset-assert 16)
@@ -7713,28 +7713,92 @@
    (alignv            float      :offset-assert 84)
    (slope-up-traction float      :offset-assert 88)
    (align-speed       float      :offset-assert 92)
-   ;(hook              UNKNOWN 4  :offset-assert 128)
+   ;; hook went here
    (active-hook       basic      :offset 128)
    (touch-hook        basic      :offset-assert 132)
    (impact-hook       basic      :offset-assert 136)
-   (mult-hook         basic      :offset-assert 140)
-   ;(dataw             UNKNOWN 2  :offset-assert 144)
+   (mult-hook         (function surface surface surface int none)     :offset-assert 140)
+   ;; dataw went here
    (mode              basic      :offset-assert 144)
    (flags             uint32     :offset-assert 148)
+   
+   (data              float 30 :offset 8)
+   (hook              basic 4  :offset 128)
+   (dataw             uint32 2  :offset 144)
    )
   :method-count-assert 9
   :size-assert         #x98
   :flag-assert         #x900000098
   )
 
-; ;; pat-h
-; (deftype pat-surface (uint32)
-;   ()
-;   :method-count-assert 9
-;   :size-assert         #x4
-;   :flag-assert         #x900000004
-;   ;; likely a bitfield type
-;   )
+(define-extern surface-interp! (function surface surface surface float surface))
+
+;;(define-extern standard object) ;; unknown type
+;;(define-extern *edge-surface* object) ;; unknown type
+;;(define-extern *uppercut-jump-mods* object) ;; unknown type
+;;(define-extern *forward-pole-jump-mods* object) ;; unknown type
+;;(define-extern *flip-jump-mods* object) ;; unknown type
+(define-extern surface-clamp-speed (function surface surface surface int none))
+;;(define-extern *flop-mods* object) ;; unknown type
+(define-extern surface type)
+;;(define-extern *smack-jump-mods* object) ;; unknown type
+;;(define-extern *dive-mods* object) ;; unknown type
+;;(define-extern *swim-surface* object) ;; unknown type
+(define-extern calc-terminal2-vel (function float float float float float))
+;;(define-extern *wade-surface* object) ;; unknown type
+;;(define-extern *jump-mods* object) ;; unknown type
+;;(define-extern *turn-around-mods* object) ;; unknown type
+;;(define-extern *jump-attack-mods* object) ;; unknown type
+;;(define-extern *grass-surface* object) ;; unknown type
+;;(define-extern *dive-bottom-mods* object) ;; unknown type
+;;(define-extern *tread-surface* object) ;; unknown type
+(define-extern surface-mult! (function surface surface surface surface))
+;;(define-extern *forward-high-jump-mods* object) ;; unknown type
+;;(define-extern *double-jump-mods* object) ;; unknown type
+;;(define-extern edge-grab object) ;; unknown type
+;;(define-extern *high-jump-mods* object) ;; unknown type
+;;(define-extern *ice-surface* object) ;; unknown type
+;;(define-extern *grab-mods* object) ;; unknown type
+;;(define-extern *run-attack-mods* object) ;; unknown type
+;;(define-extern *quicksand-surface* object) ;; unknown type
+;;(define-extern *walk-no-turn-mods* object) ;; unknown type
+(define-extern calc-terminal-vel (function float float float float))
+;;(define-extern *duck-mods* object) ;; unknown type
+;;(define-extern *duck-attack-mods* object) ;; unknown type
+;;(define-extern *slope-surface* object) ;; unknown type
+(define-extern calc-terminal4-vel (function float float float float))
+;;(define-extern *edge-grab-mods* object) ;; unknown type
+;;(define-extern *standard-ground-surface* object) ;; unknown type
+;;(define-extern *flop-land-mods* object) ;; unknown type
+;;(define-extern *wheel-mods* object) ;; unknown type
+;;(define-extern *swim-mods* object) ;; unknown type
+
+(define-extern *walk-mods* surface) ;; unknown type
+;;(define-extern *attack-mods* object) ;; unknown type
+;;(define-extern *neutral-mods* object) ;; unknown type
+;;(define-extern grab object) ;; unknown type
+;;(define-extern *wade-mods* object) ;; unknown type
+;;(define-extern *forward-jump-mods* object) ;; unknown type
+(define-extern *stone-surface* surface) ;; unknown type
+;;(define-extern *launch-jump-mods* object) ;; unknown type
+;;(define-extern *empty-mods* object) ;; unknown type
+;;(define-extern *tar-surface* object) ;; unknown type
+;;(define-extern *wheel-flip-mods* object) ;; unknown type
+;;(define-extern *pole-mods* object) ;; unknown type
+
+;; pat-h
+(deftype pat-surface (uint32)
+  ()
+  :method-count-assert 9
+  :size-assert         #x4
+  :flag-assert         #x900000004
+  )
+
+(define-extern pat-event->string (function pat-surface string))
+(define-extern pat-material->string (function pat-surface string))
+;;(define-extern pat-surface object) ;; unknown type
+;;(define-extern pat-mode-info object) ;; unknown type
+(define-extern pat-mode->string (function pat-surface string))
 
 ;; pat-h
 (deftype pat-mode-info (structure)
@@ -7770,6 +7834,8 @@
   :size-assert         #x4c
   :flag-assert         #x90000004c
   )
+
+(define-extern pickup-type->string (function int string))
 
 ;; fact-h
 (deftype fact-info (basic)
@@ -33223,58 +33289,7 @@
 (define-extern time-to-ground (function float float float int))
 ;;(define-extern *standard-dynamics* object) ;; unknown type
 (define-extern dynamics type)
-;;(define-extern standard object) ;; unknown type
-;;(define-extern *edge-surface* object) ;; unknown type
-;;(define-extern *uppercut-jump-mods* object) ;; unknown type
-;;(define-extern *forward-pole-jump-mods* object) ;; unknown type
-;;(define-extern *flip-jump-mods* object) ;; unknown type
-(define-extern surface-clamp-speed function)
-;;(define-extern *flop-mods* object) ;; unknown type
-(define-extern surface type)
-;;(define-extern *smack-jump-mods* object) ;; unknown type
-;;(define-extern *dive-mods* object) ;; unknown type
-;;(define-extern *swim-surface* object) ;; unknown type
-(define-extern calc-terminal2-vel (function float float float float float))
-;;(define-extern *wade-surface* object) ;; unknown type
-;;(define-extern *jump-mods* object) ;; unknown type
-;;(define-extern *turn-around-mods* object) ;; unknown type
-;;(define-extern *jump-attack-mods* object) ;; unknown type
-;;(define-extern *grass-surface* object) ;; unknown type
-;;(define-extern *dive-bottom-mods* object) ;; unknown type
-;;(define-extern *tread-surface* object) ;; unknown type
-(define-extern surface-mult! function)
-;;(define-extern *forward-high-jump-mods* object) ;; unknown type
-;;(define-extern *double-jump-mods* object) ;; unknown type
-;;(define-extern edge-grab object) ;; unknown type
-;;(define-extern *high-jump-mods* object) ;; unknown type
-;;(define-extern *ice-surface* object) ;; unknown type
-;;(define-extern *grab-mods* object) ;; unknown type
-;;(define-extern *run-attack-mods* object) ;; unknown type
-;;(define-extern *quicksand-surface* object) ;; unknown type
-;;(define-extern *walk-no-turn-mods* object) ;; unknown type
-(define-extern calc-terminal-vel (function float float float float))
-;;(define-extern *duck-mods* object) ;; unknown type
-;;(define-extern *duck-attack-mods* object) ;; unknown type
-;;(define-extern *slope-surface* object) ;; unknown type
-(define-extern calc-terminal4-vel (function float float float float))
-;;(define-extern *edge-grab-mods* object) ;; unknown type
-;;(define-extern *standard-ground-surface* object) ;; unknown type
-;;(define-extern *flop-land-mods* object) ;; unknown type
-;;(define-extern *wheel-mods* object) ;; unknown type
-;;(define-extern *swim-mods* object) ;; unknown type
-(define-extern surface-interp! function)
-;;(define-extern *walk-mods* object) ;; unknown type
-;;(define-extern *attack-mods* object) ;; unknown type
-;;(define-extern *neutral-mods* object) ;; unknown type
-;;(define-extern grab object) ;; unknown type
-;;(define-extern *wade-mods* object) ;; unknown type
-;;(define-extern *forward-jump-mods* object) ;; unknown type
-;;(define-extern *stone-surface* object) ;; unknown type
-;;(define-extern *launch-jump-mods* object) ;; unknown type
-;;(define-extern *empty-mods* object) ;; unknown type
-;;(define-extern *tar-surface* object) ;; unknown type
-;;(define-extern *wheel-flip-mods* object) ;; unknown type
-;;(define-extern *pole-mods* object) ;; unknown type
+
 ;;(define-extern pole object) ;; unknown type
 ;;(define-extern wheel-flip object) ;; unknown type
 ;;(define-extern swim-bottom object) ;; unknown type
@@ -33294,14 +33309,10 @@
 ;;(define-extern flop object) ;; unknown type
 ;;(define-extern launch-jump object) ;; unknown type
 ;;(define-extern run object) ;; unknown type
-(define-extern pat-event->string function)
-(define-extern pat-material->string function)
-;;(define-extern pat-surface object) ;; unknown type
-;;(define-extern pat-mode-info object) ;; unknown type
-(define-extern pat-mode->string function)
+
 ;;(define-extern *pat-mode-info* object) ;; unknown type
 ;;(define-extern fact-info-target object) ;; unknown type
-(define-extern pickup-type->string function)
+
 (define-extern fact-bank type)
 (define-extern fact-info type)
 ;;(define-extern fact-info-enemy object) ;; unknown type

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -7906,29 +7906,29 @@
     )
   )
 
-; ;; aligner-h
-; (deftype align-control (basic)
-;   ((flags       uint32             :offset-assert 4)
-;    (process     basic              :offset-assert 8)
-;    (frame-group basic              :offset-assert 12)
-;    (frame-num   float              :offset-assert 16)
-;    (matrix      UNKNOWN    2       :offset-assert 32)
-;    (transform   UNKNOWN    2       :offset-assert 160)
-;    (delta       transformq :inline :offset-assert 256)
-;    (last-speed  meters             :offset-assert 304)
-;    (align       transformq :inline :offset-assert 160)
-;    )
-;   :method-count-assert 14
-;   :size-assert         #x134
-;   :flag-assert         #xe00000134
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     )
-;   )
+;; aligner-h
+(deftype align-control (basic)
+  ((flags       uint32             :offset-assert 4)
+   (process     basic              :offset-assert 8)
+   (frame-group basic              :offset-assert 12)
+   (frame-num   float              :offset-assert 16)
+   (matrix      matrix     2  :inline     :offset-assert 32)
+   (transform   transform    2 :inline      :offset-assert 160)
+   (delta       transformq :inline :offset-assert 256)
+   (last-speed  float             :offset-assert 304);; meters
+   (align       transformq :inline :offset 160)
+   )
+  :method-count-assert 14
+  :size-assert         #x134
+  :flag-assert         #xe00000134
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    )
+  )
 
 ;; game-h
 (deftype process-drawable (process)
@@ -8456,12 +8456,12 @@
   :size-assert         #x20
   :flag-assert         #xf00000020
   (:methods
-    (dummy-9 () none 9)
-    (dummy-10 () none 10)
-    (dummy-11 () none 11)
-    (dummy-12 () none 12)
-    (dummy-13 () none 13)
-    (dummy-14 () none 14)
+    (set-zero! (_type_) _type_ 9)
+    (update! (_type_) float 10)
+    (get-no-update (_type_) float 11)
+    (activate! (_type_ float int int float float float) _type_ 12)
+    (nonzero-amplitude? (_type_) symbol 13)
+    (die-on-next-update! (_type_) _type_ 14)
     )
   )
 
@@ -8634,83 +8634,86 @@
   :flag-assert         #x90000002c
   )
 
-; ;; collide-mesh-h
-; (deftype collide-tri-result (structure)
-;   ((vertex    UNKNOWN 3       :offset-assert 0)
-;    (intersect vector  :inline :offset-assert 48)
-;    (normal    vector  :inline :offset-assert 64)
-;    (pat       uint32          :offset-assert 80)
-;    )
-;   :method-count-assert 9
-;   :size-assert         #x54
-;   :flag-assert         #x900000054
-;   )
+;; collide-mesh-h
+(deftype collide-tri-result (structure)
+  ((vertex    vector 3 :inline :offset-assert 0)
+   (intersect vector  :inline  :offset-assert 48)
+   (normal    vector  :inline  :offset-assert 64)
+   (pat       uint32           :offset-assert 80)
+   )
+  :method-count-assert 9
+  :size-assert         #x54
+  :flag-assert         #x900000054
+  )
 
 ; ;; collide-mesh-h
-; (deftype collide-mesh-tri (structure)
-;   ((vertex-index UNKNOWN 3 :offset-assert 0)
-;    (unused       uint8     :offset-assert 3)
-;    (pat          uint32    :offset-assert 4)
-;    )
-;   :method-count-assert 9
-;   :size-assert         #x8
-;   :flag-assert         #x900000008
-;   )
+(deftype collide-mesh-tri (structure)
+  ((vertex-index uint8   3 :offset-assert 0)
+   (unused       uint8     :offset-assert 3)
+   (pat          uint32    :offset-assert 4)
+   )
+  :pack-me
+  :method-count-assert 9
+  :size-assert         #x8
+  :flag-assert         #x900000008
+  )
 
-; ;; collide-mesh-h
-; (deftype collide-mesh (basic)
-;   ((joint-id    int32     :offset-assert 4)
-;    (num-tris    uint32    :offset-assert 8)
-;    (num-verts   uint32    :offset-assert 12)
-;    (vertex-data uint32    :offset-assert 16)
-;    (tris        UNKNOWN 1 :offset-assert 32)
-;    )
-;   :method-count-assert 16
-;   :size-assert         #x28
-;   :flag-assert         #x1000000028
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     )
-;   )
+;; collide-mesh-h
+(deftype collide-mesh (basic)
+  ((joint-id    int32     :offset-assert 4)
+   (num-tris    uint32    :offset-assert 8)
+   (num-verts   uint32    :offset-assert 12)
+   (vertex-data uint32    :offset-assert 16)
+   ;; todo - this could be wrong
+   (tris        collide-mesh-tri 1 :inline :offset 32)
+   )
+  :method-count-assert 16
+  :size-assert         #x28
+  :flag-assert         #x1000000028
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    )
+  )
 
-; ;; collide-mesh-h
-; (deftype collide-mesh-cache (basic)
-;   ((used-size uint32        :offset-assert 4)
-;    (max-size  uint32        :offset-assert 8)
-;    (id        uint64        :offset-assert 16)
-;    (data      UNKNOWN 40960 :offset-assert 32)
-;    )
-;   :method-count-assert 12
-;   :size-assert         #xa020
-;   :flag-assert         #xc0000a020
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     )
-;   )
+;; collide-mesh-h
+(deftype collide-mesh-cache (basic)
+  ((used-size uint32        :offset-assert 4)
+   (max-size  uint32        :offset-assert 8)
+   (id        uint64        :offset-assert 16)
+   (pad uint8 8) ;; added
+   (data      uint8 40960 :offset-assert 32)
+   )
+  :method-count-assert 12
+  :size-assert         #xa020
+  :flag-assert         #xc0000a020
+  (:methods
+    (dummy-9 () none 9)
+    (is-id? (_type_ int) symbol 10)
+    (next-id! (_type_) uint 11)
+    )
+  )
 
-; ;; collide-mesh-h
-; (deftype collide-mesh-cache-tri (structure)
-;   ((vertex UNKNOWN        3       :offset-assert 0)
-;    (normal vector         :inline :offset-assert 48)
-;    (bbox4w bounding-box4w :inline :offset-assert 64)
-;    (pat    uint32                 :offset-assert 60)
-;    )
-;   :method-count-assert 9
-;   :size-assert         #x60
-;   :flag-assert         #x900000060
-;   )
+;; collide-mesh-h
+(deftype collide-mesh-cache-tri (structure)
+  ((vertex vector   3     :inline :offset-assert 0)
+   (normal vector         :inline :offset-assert 48)
+   (bbox4w bounding-box4w :inline :offset-assert 64)
+   (pat    uint32                 :offset 60)
+   )
+  :method-count-assert 9
+  :size-assert         #x60
+  :flag-assert         #x900000060
+  )
 
 ;; collide-shape-h
 (deftype collide-sticky-rider (structure)
-  ((rider-handle    uint64         :offset-assert 0)
+  ((rider-handle    handle         :offset-assert 0)
    (sticky-prim     basic          :offset-assert 8)
    (prim-ry         float          :offset-assert 12)
    (rider-local-pos vector :inline :offset-assert 16)
@@ -8719,24 +8722,25 @@
   :size-assert         #x20
   :flag-assert         #xa00000020
   (:methods
-    (dummy-9 () none 9)
+    (set-rider! (_type_ handle) symbol 9)
     )
   )
 
-; ;; collide-shape-h
-; (deftype collide-sticky-rider-group (basic)
-;   ((num-riders       int32     :offset-assert 4)
-;    (allocated-riders int32     :offset-assert 8)
-;    (rider            UNKNOWN 1 :offset-assert 16)
-;    )
-;   :method-count-assert 11
-;   :size-assert         #x30
-;   :flag-assert         #xb00000030
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-sticky-rider-group (basic)
+  ((num-riders       int32     :offset-assert 4)
+   (allocated-riders int32     :offset-assert 8)
+   (rider            collide-sticky-rider 1 :inline :offset-assert 16)
+   )
+  :method-count-assert 11
+  :size-assert         #x30
+  :flag-assert         #xb00000030
+  (:methods
+    (new (symbol type int) _type_ 0)
+    (dummy-9 () none 9)
+    (reset! (_type_) int 10)
+    )
+  )
 
 ;; collide-shape-h
 (deftype pull-rider-info (structure)
@@ -8750,430 +8754,364 @@
   :flag-assert         #x900000020
   )
 
-; ;; collide-shape-h
-; (deftype collide-shape-intersect (basic)
-;   ((move-vec       vector             :inline :offset-assert 16)
-;    (best-u         float                      :offset-assert 32)
-;    (best-tri       collide-tri-result :inline :offset-assert 48)
-;    (best-from-prim basic                      :offset-assert 132)
-;    (best-to-prim   basic                      :offset-assert 136)
-;    )
-;   :method-count-assert 10
-;   :size-assert         #x8c
-;   :flag-assert         #xa0000008c
-;   (:methods
-;     (dummy-9 () none 9)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-intersect (basic)
+  ((move-vec       vector             :inline :offset-assert 16)
+   (best-u         float                      :offset-assert 32)
+   (best-tri       collide-tri-result :inline :offset-assert 48)
+   (best-from-prim basic                      :offset-assert 132)
+   (best-to-prim   basic                      :offset-assert 136)
+   )
+  :method-count-assert 10
+  :size-assert         #x8c
+  :flag-assert         #xa0000008c
+  (:methods
+    (dummy-9 () none 9)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-overlap-result (structure)
-;   ((best-dist      float                      :offset-assert 0)
-;    (best-from-prim basic                      :offset-assert 4)
-;    (best-to-prim   basic                      :offset-assert 8)
-;    (best-from-tri  collide-tri-result :inline :offset-assert 16)
-;    )
-;   :method-count-assert 10
-;   :size-assert         #x64
-;   :flag-assert         #xa00000064
-;   (:methods
-;     (dummy-9 () none 9)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-overlap-result (structure)
+  ((best-dist      float                      :offset-assert 0)
+   (best-from-prim basic                      :offset-assert 4)
+   (best-to-prim   basic                      :offset-assert 8)
+   (best-from-tri  collide-tri-result :inline :offset-assert 16)
+   )
+  :method-count-assert 10
+  :size-assert         #x64
+  :flag-assert         #xa00000064
+  (:methods
+    (reset! (_type_) none 9)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype overlaps-others-params (structure)
-;   ((options uint32  :offset-assert 0)
-;    (tlist   basic   :offset-assert 4)
-;    )
-;   :method-count-assert 9
-;   :size-assert         #x8
-;   :flag-assert         #x900000008
-;   )
+;; collide-shape-h
+(deftype overlaps-others-params (structure)
+  ((options uint32  :offset-assert 0)
+   (tlist   basic   :offset-assert 4)
+   )
+  :method-count-assert 9
+  :size-assert         #x8
+  :flag-assert         #x900000008
+  )
 
-; ;; collide-shape-h
-; (deftype collide-prim-core (structure)
-;   ((world-sphere vector  :inline :offset-assert 0)
-;    (collide-as   uint64          :offset-assert 16)
-;    (action       uint32          :offset-assert 24)
-;    (offense      int8            :offset-assert 28)
-;    (prim-type    int8            :offset-assert 29)
-;    (extra        UNKNOWN 2       :offset-assert 30)
-;    (quad         UNKNOWN 2       :offset-assert 0)
-;    )
-;   :method-count-assert 9
-;   :size-assert         #x20
-;   :flag-assert         #x900000020
-;   )
+;; collide-shape-h
+(deftype collide-prim-core (structure)
+  ((world-sphere vector  :inline :offset-assert 0)
+   (collide-as   uint64          :offset-assert 16)
+   (action       uint32          :offset-assert 24)
+   (offense      int8            :offset-assert 28)
+   (prim-type    int8            :offset-assert 29)
+   (extra        uint8 2       :offset-assert 30)
+   (quad         uint128 2       :offset 0)
+   )
+  :method-count-assert 9
+  :size-assert         #x20
+  :flag-assert         #x900000020
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape-prim (basic)
-;   ((cshape          basic                     :offset-assert 4)
-;    (prim-id         uint32                    :offset-assert 8)
-;    (transform-index int8                      :offset-assert 12)
-;    (prim-core       collide-prim-core :inline :offset-assert 16)
-;    (local-sphere    vector            :inline :offset-assert 48)
-;    (collide-with    uint64                    :offset-assert 64)
-;    (world-sphere    vector            :inline :offset-assert 16)
-;    (collide-as      uint64                    :offset-assert 32)
-;    (action          uint32                    :offset-assert 40)
-;    (offense         int8                      :offset-assert 44)
-;    (prim-type       int8                      :offset-assert 45)
-;    (radius          meters                    :offset-assert 60)
-;    )
-;   :method-count-assert 28
-;   :size-assert         #x48
-;   :flag-assert         #x1c00000048
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-prim (basic)
+  ((cshape          basic                     :offset-assert 4)
+   (prim-id         uint32                    :offset-assert 8)
+   (transform-index int8                      :offset-assert 12)
+   (prim-core       collide-prim-core :inline :offset-assert 16)
+   (local-sphere    vector            :inline :offset-assert 48)
+   (collide-with    uint64                    :offset-assert 64)
+   (world-sphere    vector            :inline :offset 16)
+   (collide-as      uint64                    :offset 32)
+   (action          uint32                    :offset 40)
+   (offense         int8                      :offset 44)
+   (prim-type       int8                      :offset 45)
+   (radius          float                     :offset 60) ;; meters
+   )
+  :method-count-assert 28
+  :size-assert         #x48
+  :flag-assert         #x1c00000048
+  (:methods
+    (new (symbol type basic uint int) _type_ 0)
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape-prim-sphere (collide-shape-prim)
-;   ((cshape          basic                     :offset-assert 4)
-;    (prim-id         uint32                    :offset-assert 8)
-;    (transform-index int8                      :offset-assert 12)
-;    (prim-core       collide-prim-core :inline :offset-assert 16)
-;    (local-sphere    vector            :inline :offset-assert 48)
-;    (collide-with    uint64                    :offset-assert 64)
-;    (world-sphere    vector            :inline :offset-assert 16)
-;    (collide-as      uint64                    :offset-assert 32)
-;    (action          uint32                    :offset-assert 40)
-;    (offense         int8                      :offset-assert 44)
-;    (prim-type       int8                      :offset-assert 45)
-;    (radius          meters                    :offset-assert 60)
-;    (pat             uint32                    :offset-assert 72)
-;    )
-;   :method-count-assert 28
-;   :size-assert         #x4c
-;   :flag-assert         #x1c0000004c
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-prim-sphere (collide-shape-prim)
+  ((pat             uint32                    :offset-assert 72)
+   )
+  :method-count-assert 28
+  :size-assert         #x4c
+  :flag-assert         #x1c0000004c
+  (:methods
+    (new (symbol type basic uint) _type_ 0)
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape-prim-mesh (collide-shape-prim)
-;   ((cshape          basic                     :offset-assert 4)
-;    (prim-id         uint32                    :offset-assert 8)
-;    (transform-index int8                      :offset-assert 12)
-;    (prim-core       collide-prim-core :inline :offset-assert 16)
-;    (local-sphere    vector            :inline :offset-assert 48)
-;    (collide-with    uint64                    :offset-assert 64)
-;    (world-sphere    vector            :inline :offset-assert 16)
-;    (collide-as      uint64                    :offset-assert 32)
-;    (action          uint32                    :offset-assert 40)
-;    (offense         int8                      :offset-assert 44)
-;    (prim-type       int8                      :offset-assert 45)
-;    (radius          meters                    :offset-assert 60)
-;    (mesh            basic                     :offset-assert 72)
-;    (mesh-id         int32                     :offset-assert 76)
-;    (mesh-cache-id   uint64                    :offset-assert 80)
-;    (mesh-cache-tris uint32                    :offset-assert 88)
-;    )
-;   :method-count-assert 29
-;   :size-assert         #x5c
-;   :flag-assert         #x1d0000005c
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     (dummy-28 () none 28)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-prim-mesh (collide-shape-prim)
+  ((mesh            basic                     :offset-assert 72)
+   (mesh-id         int32                     :offset-assert 76)
+   (mesh-cache-id   uint64                    :offset-assert 80)
+   (mesh-cache-tris uint32                    :offset-assert 88)
+   )
+  :method-count-assert 29
+  :size-assert         #x5c
+  :flag-assert         #x1d0000005c
+  (:methods
+    (new (symbol type basic uint uint) _type_ 0)
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    (dummy-28 () none 28)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape-prim-group (collide-shape-prim)
-;   ((cshape          basic                     :offset-assert 4)
-;    (prim-id         uint32                    :offset-assert 8)
-;    (transform-index int8                      :offset-assert 12)
-;    (prim-core       collide-prim-core :inline :offset-assert 16)
-;    (local-sphere    vector            :inline :offset-assert 48)
-;    (collide-with    uint64                    :offset-assert 64)
-;    (world-sphere    vector            :inline :offset-assert 16)
-;    (collide-as      uint64                    :offset-assert 32)
-;    (action          uint32                    :offset-assert 40)
-;    (offense         int8                      :offset-assert 44)
-;    (prim-type       int8                      :offset-assert 45)
-;    (radius          meters                    :offset-assert 60)
-;    (num-prims       int32                     :offset-assert 72)
-;    (allocated-prims int32                     :offset-assert 76)
-;    (prim            UNKNOWN           1       :offset-assert 80)
-;    )
-;   :method-count-assert 30
-;   :size-assert         #x54
-;   :flag-assert         #x1e00000054
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     (dummy-28 () none 28)
-;     (dummy-29 () none 29)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-prim-group (collide-shape-prim)
+  ((num-prims       int32                     :offset-assert 72)
+   (allocated-prims int32                     :offset-assert 76)
+   (prim            uint32           1       :offset-assert 80)
+   )
+  :method-count-assert 30
+  :size-assert         #x54
+  :flag-assert         #x1e00000054
+  (:methods
+    (new (symbol type basic uint int) _type_ 0)
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    (dummy-28 () none 28)
+    (dummy-29 () none 29)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape (trsqv)
-;   ((trans                 vector     :inline :offset-assert 16)
-;    (rot                   vector     :inline :offset-assert 32)
-;    (scale                 vector     :inline :offset-assert 48)
-;    (quat                  quaternion :inline :offset-assert 32)
-;    (pause-adjust-distance meters             :offset-assert 4)
-;    (nav-radius            meters             :offset-assert 8)
-;    (transv                vector     :inline :offset-assert 64)
-;    (rotv                  vector     :inline :offset-assert 80)
-;    (scalev                vector     :inline :offset-assert 96)
-;    (dir-targ              quaternion :inline :offset-assert 112)
-;    (angle-change-time     uint64             :offset-assert 128)
-;    (old-y-angle-diff      float              :offset-assert 136)
-;    (process               basic              :offset-assert 140)
-;    (max-iteration-count   uint8              :offset-assert 144)
-;    (nav-flags             uint8              :offset-assert 145)
-;    (pad-byte              UNKNOWN    2       :offset-assert 146)
-;    (pat-ignore-mask       uint32             :offset-assert 148)
-;    (event-self            basic              :offset-assert 152)
-;    (event-other           basic              :offset-assert 156)
-;    (root-prim             basic              :offset-assert 160)
-;    (riders                basic              :offset-assert 164)
-;    (backup-collide-as     uint64             :offset-assert 168)
-;    (backup-collide-with   uint64             :offset-assert 176)
-;    )
-;   :method-count-assert 56
-;   :size-assert         #xb8
-;   :flag-assert         #x38000000b8
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     (dummy-28 () none 28)
-;     (dummy-29 () none 29)
-;     (dummy-30 () none 30)
-;     (dummy-31 () none 31)
-;     (dummy-32 () none 32)
-;     (dummy-33 () none 33)
-;     (dummy-34 () none 34)
-;     (dummy-35 () none 35)
-;     (dummy-36 () none 36)
-;     (dummy-37 () none 37)
-;     (dummy-38 () none 38)
-;     (dummy-39 () none 39)
-;     (dummy-40 () none 40)
-;     (dummy-41 () none 41)
-;     (dummy-42 () none 42)
-;     (dummy-43 () none 43)
-;     (dummy-44 () none 44)
-;     (dummy-45 () none 45)
-;     (dummy-46 () none 46)
-;     (dummy-47 () none 47)
-;     (dummy-48 () none 48)
-;     (dummy-49 () none 49)
-;     (dummy-50 () none 50)
-;     (dummy-51 () none 51)
-;     (dummy-52 () none 52)
-;     (dummy-53 () none 53)
-;     (dummy-54 () none 54)
-;     (dummy-55 () none 55)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape (trsqv)
+  ((process               basic              :offset-assert 140)
+   (max-iteration-count   uint8              :offset-assert 144)
+   (nav-flags             uint8              :offset-assert 145)
+   (pad-byte              uint8      2       :offset-assert 146)
+   (pat-ignore-mask       uint32             :offset-assert 148)
+   (event-self            basic              :offset-assert 152)
+   (event-other           basic              :offset-assert 156)
+   (root-prim             basic              :offset-assert 160)
+   (riders                basic              :offset-assert 164)
+   (backup-collide-as     uint64             :offset-assert 168)
+   (backup-collide-with   uint64             :offset-assert 176)
+   )
+  :method-count-assert 56
+  :size-assert         #xb8
+  :flag-assert         #x38000000b8
+  (:methods
+    (new (symbol type process int) _type_)
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    (dummy-28 () none 28)
+    (dummy-29 () none 29)
+    (dummy-30 () none 30)
+    (dummy-31 () none 31)
+    (dummy-32 () none 32)
+    (dummy-33 () none 33)
+    (dummy-34 () none 34)
+    (dummy-35 () none 35)
+    (dummy-36 () none 36)
+    (dummy-37 () none 37)
+    (dummy-38 () none 38)
+    (dummy-39 () none 39)
+    (dummy-40 () none 40)
+    (dummy-41 () none 41)
+    (dummy-42 () none 42)
+    (dummy-43 () none 43)
+    (dummy-44 () none 44)
+    (dummy-45 () none 45)
+    (dummy-46 () none 46)
+    (dummy-47 () none 47)
+    (dummy-48 () none 48)
+    (dummy-49 () none 49)
+    (dummy-50 () none 50)
+    (dummy-51 () none 51)
+    (dummy-52 () none 52)
+    (dummy-53 () none 53)
+    (dummy-54 () none 54)
+    (dummy-55 () none 55)
+    )
+  )
 
-; ;; collide-shape-h
-; (deftype collide-shape-moving (collide-shape)
-;   ((trans                 vector     :inline :offset-assert 16)
-;    (rot                   vector     :inline :offset-assert 32)
-;    (scale                 vector     :inline :offset-assert 48)
-;    (quat                  quaternion :inline :offset-assert 32)
-;    (pause-adjust-distance meters             :offset-assert 4)
-;    (nav-radius            meters             :offset-assert 8)
-;    (transv                vector     :inline :offset-assert 64)
-;    (rotv                  vector     :inline :offset-assert 80)
-;    (scalev                vector     :inline :offset-assert 96)
-;    (dir-targ              quaternion :inline :offset-assert 112)
-;    (angle-change-time     uint64             :offset-assert 128)
-;    (old-y-angle-diff      float              :offset-assert 136)
-;    (process               basic              :offset-assert 140)
-;    (max-iteration-count   uint8              :offset-assert 144)
-;    (nav-flags             uint8              :offset-assert 145)
-;    (pad-byte              UNKNOWN    2       :offset-assert 146)
-;    (pat-ignore-mask       uint32             :offset-assert 148)
-;    (event-self            basic              :offset-assert 152)
-;    (event-other           basic              :offset-assert 156)
-;    (root-prim             basic              :offset-assert 160)
-;    (riders                basic              :offset-assert 164)
-;    (backup-collide-as     uint64             :offset-assert 168)
-;    (backup-collide-with   uint64             :offset-assert 176)
-;    (rider-time            uint64             :offset-assert 184)
-;    (rider-last-move       vector     :inline :offset-assert 192)
-;    (trans-old             UNKNOWN    3       :offset-assert 208)
-;    (poly-pat              uint32             :offset-assert 256)
-;    (cur-pat               uint32             :offset-assert 260)
-;    (ground-pat            uint32             :offset-assert 264)
-;    (status                uint64             :offset-assert 272)
-;    (old-status            uint64             :offset-assert 280)
-;    (prev-status           uint64             :offset-assert 288)
-;    (reaction-flag         uint32             :offset-assert 296)
-;    (reaction              basic              :offset-assert 300)
-;    (no-reaction           basic              :offset-assert 304)
-;    (local-normal          vector     :inline :offset-assert 320)
-;    (surface-normal        vector     :inline :offset-assert 336)
-;    (poly-normal           vector     :inline :offset-assert 352)
-;    (ground-poly-normal    vector     :inline :offset-assert 368)
-;    (ground-touch-point    vector     :inline :offset-assert 384)
-;    (shadow-pos            vector     :inline :offset-assert 400)
-;    (ground-impact-vel     meters             :offset-assert 416)
-;    (surface-angle         float              :offset-assert 420)
-;    (poly-angle            float              :offset-assert 424)
-;    (touch-angle           float              :offset-assert 428)
-;    (coverage              float              :offset-assert 432)
-;    (dynam                 basic              :offset-assert 436)
-;    (surf                  basic              :offset-assert 440)
-;    )
-;   :method-count-assert 65
-;   :size-assert         #x1bc
-;   :flag-assert         #x41000001bc
-;   (:methods
-;     (dummy-9 () none 9)
-;     (dummy-10 () none 10)
-;     (dummy-11 () none 11)
-;     (dummy-12 () none 12)
-;     (dummy-13 () none 13)
-;     (dummy-14 () none 14)
-;     (dummy-15 () none 15)
-;     (dummy-16 () none 16)
-;     (dummy-17 () none 17)
-;     (dummy-18 () none 18)
-;     (dummy-19 () none 19)
-;     (dummy-20 () none 20)
-;     (dummy-21 () none 21)
-;     (dummy-22 () none 22)
-;     (dummy-23 () none 23)
-;     (dummy-24 () none 24)
-;     (dummy-25 () none 25)
-;     (dummy-26 () none 26)
-;     (dummy-27 () none 27)
-;     (dummy-28 () none 28)
-;     (dummy-29 () none 29)
-;     (dummy-30 () none 30)
-;     (dummy-31 () none 31)
-;     (dummy-32 () none 32)
-;     (dummy-33 () none 33)
-;     (dummy-34 () none 34)
-;     (dummy-35 () none 35)
-;     (dummy-36 () none 36)
-;     (dummy-37 () none 37)
-;     (dummy-38 () none 38)
-;     (dummy-39 () none 39)
-;     (dummy-40 () none 40)
-;     (dummy-41 () none 41)
-;     (dummy-42 () none 42)
-;     (dummy-43 () none 43)
-;     (dummy-44 () none 44)
-;     (dummy-45 () none 45)
-;     (dummy-46 () none 46)
-;     (dummy-47 () none 47)
-;     (dummy-48 () none 48)
-;     (dummy-49 () none 49)
-;     (dummy-50 () none 50)
-;     (dummy-51 () none 51)
-;     (dummy-52 () none 52)
-;     (dummy-53 () none 53)
-;     (dummy-54 () none 54)
-;     (dummy-55 () none 55)
-;     (dummy-56 () none 56)
-;     (dummy-57 () none 57)
-;     (dummy-58 () none 58)
-;     (dummy-59 () none 59)
-;     (dummy-60 () none 60)
-;     (dummy-61 () none 61)
-;     (dummy-62 () none 62)
-;     (dummy-63 () none 63)
-;     (dummy-64 () none 64)
-;     )
-;   )
+;; collide-shape-h
+(deftype collide-shape-moving (collide-shape)
+  ((rider-time            uint64             :offset-assert 184)
+   (rider-last-move       vector     :inline :offset-assert 192)
+   (trans-old             vector    3 :inline      :offset-assert 208)
+   (poly-pat              uint32             :offset-assert 256)
+   (cur-pat               uint32             :offset-assert 260)
+   (ground-pat            uint32             :offset-assert 264)
+   (status                uint64             :offset-assert 272)
+   (old-status            uint64             :offset-assert 280)
+   (prev-status           uint64             :offset-assert 288)
+   (reaction-flag         uint32             :offset-assert 296)
+   (reaction              basic              :offset-assert 300)
+   (no-reaction           basic              :offset-assert 304)
+   (local-normal          vector     :inline :offset-assert 320)
+   (surface-normal        vector     :inline :offset-assert 336)
+   (poly-normal           vector     :inline :offset-assert 352)
+   (ground-poly-normal    vector     :inline :offset-assert 368)
+   (ground-touch-point    vector     :inline :offset-assert 384)
+   (shadow-pos            vector     :inline :offset-assert 400)
+   (ground-impact-vel     float              :offset-assert 416) ;; meters
+   (surface-angle         float              :offset-assert 420)
+   (poly-angle            float              :offset-assert 424)
+   (touch-angle           float              :offset-assert 428)
+   (coverage              float              :offset-assert 432)
+   (dynam                 basic              :offset-assert 436)
+   (surf                  basic              :offset-assert 440)
+   )
+  :method-count-assert 65
+  :size-assert         #x1bc
+  :flag-assert         #x41000001bc
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    (dummy-18 () none 18)
+    (dummy-19 () none 19)
+    (dummy-20 () none 20)
+    (dummy-21 () none 21)
+    (dummy-22 () none 22)
+    (dummy-23 () none 23)
+    (dummy-24 () none 24)
+    (dummy-25 () none 25)
+    (dummy-26 () none 26)
+    (dummy-27 () none 27)
+    (dummy-28 () none 28)
+    (dummy-29 () none 29)
+    (dummy-30 () none 30)
+    (dummy-31 () none 31)
+    (dummy-32 () none 32)
+    (dummy-33 () none 33)
+    (dummy-34 () none 34)
+    (dummy-35 () none 35)
+    (dummy-36 () none 36)
+    (dummy-37 () none 37)
+    (dummy-38 () none 38)
+    (dummy-39 () none 39)
+    (dummy-40 () none 40)
+    (dummy-41 () none 41)
+    (dummy-42 () none 42)
+    (dummy-43 () none 43)
+    (dummy-44 () none 44)
+    (dummy-45 () none 45)
+    (dummy-46 () none 46)
+    (dummy-47 () none 47)
+    (dummy-48 () none 48)
+    (dummy-49 () none 49)
+    (dummy-50 () none 50)
+    (dummy-51 () none 51)
+    (dummy-52 () none 52)
+    (dummy-53 () none 53)
+    (dummy-54 () none 54)
+    (dummy-55 () none 55)
+    (dummy-56 () none 56)
+    (dummy-57 () none 57)
+    (dummy-58 () none 58)
+    (dummy-59 () none 59)
+    (dummy-60 () none 60)
+    (dummy-61 () none 61)
+    (dummy-62 () none 62)
+    (dummy-63 () none 63)
+    (dummy-64 () none 64)
+    )
+  )
 
 ;; collide-target-h
 (deftype collide-history (structure)
@@ -32620,7 +32558,7 @@
 (define-extern vector-angle<-quaternion! function)
 (define-extern quaternion-rotate-local-y! function)
 (define-extern quaternion-norm2 function)
-(define-extern quaternion-identity! function)
+(define-extern quaternion-identity! (function quaternion quaternion))
 (define-extern quaternion-y-angle function)
 (define-extern quaternion-vector-y-angle function)
 (define-extern quaternion-copy! function)
@@ -33383,19 +33321,19 @@
 (define-extern cspace<-parented-transformq-joint! function)
 ;;(define-extern target object) ;; unknown type
 ;;(define-extern collide-mesh-tri object) ;; unknown type
-;;(define-extern *collide-mesh-cache* object) ;; unknown type
+(define-extern *collide-mesh-cache* collide-mesh-cache) ;; unknown type
 ;;(define-extern collide-mesh-cache-tri object) ;; unknown type
 ;;(define-extern collide-mesh-cache object) ;; unknown type
 ;;(define-extern collide-tri-result object) ;; unknown type
 ;;(define-extern collide-player-list object) ;; unknown type
 ;;(define-extern collide-shape-moving object) ;; unknown type
 ;;(define-extern collide-shape-prim object) ;; unknown type
-;;(define-extern *collide-usually-hit-by-player-list* object) ;; unknown type
+(define-extern *collide-usually-hit-by-player-list* engine) ;; unknown type
 (define-extern collide-shape-prim-mesh type)
 ;;(define-extern collide-shape-intersect object) ;; unknown type
 ;;(define-extern collide-hit-by-others-list object) ;; unknown type
 ;;(define-extern *collide-shape-prim-water* object) ;; unknown type
-;;(define-extern *collide-player-list* object) ;; unknown type
+(define-extern *collide-player-list* engine) ;; unknown type
 ;;(define-extern collide-shape-prim-sphere object) ;; unknown type
 ;;(define-extern collide-sticky-rider-group object) ;; unknown type
 ;;(define-extern collide-sticky-rider object) ;; unknown type
@@ -33406,8 +33344,8 @@
 ;;(define-extern pull-rider-info object) ;; unknown type
 ;;(define-extern collide-hit-by-player-list object) ;; unknown type
 ;;(define-extern collide-overlap-result object) ;; unknown type
-;;(define-extern *collide-hit-by-others-list* object) ;; unknown type
-;;(define-extern *collide-hit-by-player-list* object) ;; unknown type
+(define-extern *collide-hit-by-others-list* engine) ;; unknown type
+(define-extern *collide-hit-by-player-list* engine) ;; unknown type
 ;;(define-extern collide-shape object) ;; unknown type
 ;;(define-extern overlaps-others-params object) ;; unknown type
 ;;(define-extern camera object) ;; unknown type

--- a/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
@@ -213,7 +213,52 @@
 
 	"surface-h":[
 		["L72", "float", true],
-		["L71", "float", true]
+		["L71", "float", true],
+		["L68", "_auto_", true],
+		["L67", "_auto_", true],
+		["L66", "_auto_", true],
+		["L65", "_auto_", true],
+		["L64", "_auto_", true],
+		["L63", "_auto_", true],
+		["L62", "_auto_", true],
+		["L61", "_auto_", true],
+		["L60", "_auto_", true],
+		["L59", "_auto_", true],
+		["L58", "_auto_", true],
+		["L57", "_auto_", true],
+		["L56", "_auto_", true],
+		["L55", "_auto_", true],
+		["L54", "_auto_", true],
+		["L53", "_auto_", true],
+		["L52", "_auto_", true],
+		["L51", "_auto_", true],
+		["L50", "_auto_", true],
+		["L49", "_auto_", true],
+		["L48", "_auto_", true],
+		["L47", "_auto_", true],
+		["L46", "_auto_", true],
+		["L45", "_auto_", true],
+		["L44", "_auto_", true],
+		["L43", "_auto_", true],
+		["L42", "_auto_", true],
+		["L41", "_auto_", true],
+		["L40", "_auto_", true],
+		["L39", "_auto_", true],
+		["L38", "_auto_", true],
+		["L37", "_auto_", true],
+		["L36", "_auto_", true],
+		["L35", "_auto_", true],
+		["L34", "_auto_", true],
+		["L33", "_auto_", true],
+		["L32", "_auto_", true]
+	],
+
+	"pat-h":[
+		["L1", "(inline-array pat-mode-info)", true, 4]
+	],
+
+	"fact-h":[
+		["L35", "_auto_", true]
 	]
 
 

--- a/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
@@ -259,6 +259,19 @@
 
 	"fact-h":[
 		["L35", "_auto_", true]
+	],
+
+	"smush-control-h":[
+		["L20", "float", true],
+		["L18", "float", true],
+		["L19", "float", true],
+		["L17", "float", true]
+	],
+
+	"collide-shape-h":[
+		["L27", "float", true],
+		["L25", "_auto_", true],
+		["L24", "_auto_", true]
 	]
 
 

--- a/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_hints.jsonc
@@ -221,7 +221,18 @@
     "(method 19 engine)":[
         [8, ["a0", "connection"]]],
     "(method 20 engine)":[
-        [8, ["a0", "connection"]]]
+        [8, ["a0", "connection"]]],
+
+    "(method 0 collide-shape-prim-sphere)":[
+    	[4, ["v0", "collide-shape-prim-sphere"]]
+    ],
+
+    "(method 0 collide-shape-prim-mesh)":[
+    	[6, ["v0", "collide-shape-prim-mesh"]]
+    ],
+    "(method 0 collide-shape-prim-group)":[
+    	[11, ["v0", "collide-shape-prim-group"]]
+    ]
     
 
 

--- a/decompiler/config/jak1_ntsc_black_label/var_names.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/var_names.jsonc
@@ -571,6 +571,15 @@
 	"(method 15 engine)":{
 		"args":["obj", "proc", "func", "p1", "p2", "p3"],
 		"vars":{"v1-0":"con"}
+	},
+
+	"surface-interp!":{
+		"args":["dst", "src0", "src1", "amount"]
+	},
+
+	"surface-mult!":{
+		"args":["dst", "src0", "src1"]
+
 	}
 
 

--- a/decompiler/config/jak1_ntsc_black_label/var_names.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/var_names.jsonc
@@ -580,7 +580,27 @@
 	"surface-mult!":{
 		"args":["dst", "src0", "src1"]
 
+	},
+
+	"(method 0 collide-shape-prim)":{
+		"args":["allocation", "type-to-make", "cshape", "prim-id", "size-bytes"]
+	},
+
+	"(method 0 collide-shape-prim-sphere)":{
+		"args":["allocation", "type-to-make", "cshape", "prim-id"]
+	},
+	"(method 0 collide-shape-prim-mesh)":{
+		"args":["allocation", "type-to-make", "cshape", "mesh-id", "prim-id"]
+	},
+	"(method 0 collide-shape-prim-group)":{
+		"args":["allocation", "type-to-make", "cshape", "elt-count", "prim-id"]
+	},
+	"(method 0 collide-shape)":{
+		"args":["allocation", "type-to-make", "proc", "collide-list-kind", "prim-id"],
+		"vars":{"s5-0":"obj"}
 	}
+
+
 
 
 }

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -510,11 +510,18 @@ goos::Object decompile_structure(const TypeSpec& type,
   }
 
   std::vector<goos::Object> result_def = {
-      pretty_print::to_symbol("new"), pretty_print::to_symbol("'static"),
-      pretty_print::to_symbol(fmt::format("'{}", actual_type.print()))};
+      pretty_print::to_symbol(fmt::format("new 'static '{}", actual_type.print()))};
+  //      pretty_print::to_symbol("new"), pretty_print::to_symbol("'static"),
+  //      pretty_print::to_symbol(fmt::format("'{}", actual_type.print()))};
   for (auto& f : field_defs_out) {
-    result_def.push_back(pretty_print::to_symbol(fmt::format(":{}", f.first)));
-    result_def.push_back(f.second);
+    auto str = f.second.print();
+    if (str.length() < 40) {
+      result_def.push_back(
+          pretty_print::to_symbol(fmt::format(":{} {}", f.first, f.second.print())));
+    } else {
+      result_def.push_back(pretty_print::to_symbol(fmt::format(":{}", f.first)));
+      result_def.push_back(f.second);
+    }
   }
   return pretty_print::build_list(result_def);
 }

--- a/game/kernel/kscheme.cpp
+++ b/game/kernel/kscheme.cpp
@@ -1377,7 +1377,7 @@ u64 print_vu_function(u32 obj) {
  * Dynamically sized basics should override this method.
  */
 u64 asize_of_basic(u32 it) {
-  return Ptr<Type>(it - 4)->allocated_size;
+  return Ptr<Type>(*Ptr<u32>(it - BASIC_OFFSET))->allocated_size;
 }
 
 /*!

--- a/goal_src/engine/collide/collide-func-h.gc
+++ b/goal_src/engine/collide/collide-func-h.gc
@@ -5,3 +5,4 @@
 ;; name in dgo: collide-func-h
 ;; dgos: GAME, ENGINE
 
+;; empty!

--- a/goal_src/engine/collide/collide-mesh-h.gc
+++ b/goal_src/engine/collide/collide-mesh-h.gc
@@ -5,3 +5,112 @@
 ;; name in dgo: collide-mesh-h
 ;; dgos: GAME, ENGINE
 
+(deftype collide-tri-result (structure)
+  ((vertex    vector 3 :inline :offset-assert 0)
+   (intersect vector  :inline  :offset-assert 48)
+   (normal    vector  :inline  :offset-assert 64)
+   (pat       uint32           :offset-assert 80)
+   )
+  :method-count-assert 9
+  :size-assert         #x54
+  :flag-assert         #x900000054
+  )
+
+(deftype collide-mesh-tri (structure)
+  ((vertex-index uint8   3 :offset-assert 0)
+   (unused       uint8     :offset-assert 3)
+   (pat          uint32    :offset-assert 4)
+   )
+  :pack-me
+  :method-count-assert 9
+  :size-assert         #x8
+  :flag-assert         #x900000008
+  )
+
+(deftype collide-mesh (basic)
+  ((joint-id    int32     :offset-assert 4)
+   (num-tris    uint32    :offset-assert 8)
+   (num-verts   uint32    :offset-assert 12)
+   (vertex-data uint32    :offset-assert 16)
+   ;; todo - this could be wrong
+   (tris        collide-mesh-tri 1 :inline :offset 32)
+   )
+  :method-count-assert 16
+  :size-assert         #x28
+  :flag-assert         #x1000000028
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    )
+  )
+
+(deftype collide-mesh-cache (basic)
+  ((used-size uint32        :offset-assert 4)
+   (max-size  uint32        :offset-assert 8)
+   (id        uint64        :offset-assert 16)
+   (pad uint8 8) ;; added
+   (data      uint8 40960 :offset-assert 32)
+   )
+  :method-count-assert 12
+  :size-assert         #xa020
+  :flag-assert         #xc0000a020
+  (:methods
+    (dummy-9 () none 9)
+    (is-id? (_type_ int) symbol 10)
+    (next-id! (_type_) uint 11)
+    )
+  )
+
+(defmethod next-id! collide-mesh-cache ((obj collide-mesh-cache))
+  "Reset all used entries in the cache and increment the id.
+   If the id is zero, set it to 1"
+  ;;     ld v1, 12(a0)
+  (let ((v1 (-> obj id)))
+    ;;     sw r0, 0(a0)
+    (set! (-> obj used-size) 0)
+    ;;     daddiu v0, v1, 1
+    (let ((v0 (+ v1 1)))    
+      ;;     beql v0, r0, L3
+      ;;     addiu v0, r0, 1 (only taken if v0 = 0)
+      (if (= v0 0)
+          (set! v0 (the uint 1))
+          )
+      ;; L3:
+      ;;     sd v0, 12(a0)
+      (set! (-> obj id) v0)
+      v0
+      )
+    )
+  )
+
+(defmethod is-id? collide-mesh-cache ((obj collide-mesh-cache) (arg0 int))
+  "Is this our id?"
+  (= (-> obj id) arg0)
+  )
+
+(deftype collide-mesh-cache-tri (structure)
+  ((vertex vector   3     :inline :offset-assert 0)
+   (normal vector         :inline :offset-assert 48)
+   (bbox4w bounding-box4w :inline :offset-assert 64)
+   (pat    uint32                 :offset 60)
+   )
+  :method-count-assert 9
+  :size-assert         #x60
+  :flag-assert         #x900000060
+  )
+
+;; only allocate if we don't have an existing one.
+(define-extern *collide-mesh-cache* collide-mesh-cache)
+(if (or (not *collide-mesh-cache*) (zero? *collide-mesh-cache*))
+ (set! *collide-mesh-cache* (new 'global 'collide-mesh-cache))
+ )
+
+;; in all cases, re-init.
+(set! (-> *collide-mesh-cache* id) 1)
+(set! (-> *collide-mesh-cache* used-size) 0)
+(set! (-> *collide-mesh-cache* max-size) #xa000)

--- a/goal_src/engine/collide/collide-shape-h.gc
+++ b/goal_src/engine/collide/collide-shape-h.gc
@@ -5,3 +5,639 @@
 ;; name in dgo: collide-shape-h
 ;; dgos: GAME, ENGINE
 
+;; Represents a collision between the "rider" (zoomer?) and a primitive shape.
+;; collisions are "sticky", meaning these structures stick around.
+(deftype collide-sticky-rider (structure)
+  ((rider-handle    handle         :offset-assert 0)
+   (sticky-prim     basic          :offset-assert 8)
+   (prim-ry         float          :offset-assert 12)
+   (rider-local-pos vector :inline :offset-assert 16)
+   )
+  :method-count-assert 10
+  :size-assert         #x20
+  :flag-assert         #xa00000020
+  (:methods
+   (set-rider! (_type_ handle) symbol 9)
+   )
+  )
+
+(defmethod set-rider! collide-sticky-rider ((obj collide-sticky-rider) (arg0 handle))
+  "Set the rider and clear the primitive."
+  (set! (-> obj rider-handle) arg0)
+  (set! (-> obj sticky-prim) #f)
+  #f
+  )
+
+;; A collection of collide-sticky-riders
+;; dynamic type. I think there's one collide-sticky-rider per rider?
+(deftype collide-sticky-rider-group (basic)
+  ((num-riders       int32     :offset-assert 4)
+   (allocated-riders int32     :offset-assert 8)
+   (rider            collide-sticky-rider 1 :inline :offset-assert 16)
+   )
+  :method-count-assert 11
+  :size-assert         #x30
+  :flag-assert         #xb00000030
+  (:methods
+   (new (symbol type int) _type_ 0)
+   (dummy-9 () none 9)
+   (reset! (_type_) int 10)
+   )
+  )
+
+(defmethod reset! collide-sticky-rider-group ((obj collide-sticky-rider-group))
+  "Reset all active riders"
+  (set! (-> obj num-riders) 0)
+  0
+  )
+
+(deftype pull-rider-info (structure)
+  ((rider          collide-sticky-rider         :offset-assert 0)
+   (rider-cshape   basic                        :offset-assert 4)
+   (rider-delta-ry float                        :offset-assert 8)
+   (rider-dest     vector               :inline :offset-assert 16)
+   )
+  :method-count-assert 9
+  :size-assert         #x20
+  :flag-assert         #x900000020
+  )
+
+(deftype collide-shape-intersect (basic)
+  ((move-vec       vector             :inline :offset-assert 16)
+   (best-u         float                      :offset-assert 32)
+   (best-tri       collide-tri-result :inline :offset-assert 48)
+   (best-from-prim basic                      :offset-assert 132)
+   (best-to-prim   basic                      :offset-assert 136)
+   )
+  :method-count-assert 10
+  :size-assert         #x8c
+  :flag-assert         #xa0000008c
+  (:methods
+   (dummy-9 () none 9)
+   )
+  )
+
+(deftype collide-overlap-result (structure)
+  ((best-dist      float                      :offset-assert 0)
+   (best-from-prim basic                      :offset-assert 4)
+   (best-to-prim   basic                      :offset-assert 8)
+   (best-from-tri  collide-tri-result :inline :offset-assert 16)
+   )
+  :method-count-assert 10
+  :size-assert         #x64
+  :flag-assert         #xa00000064
+  (:methods
+   (reset! (_type_) none 9)
+   )
+  )
+
+(defmethod reset! collide-overlap-result ((obj collide-overlap-result))
+  "Reset the result."
+  (set! (-> obj best-dist) 0.000000)
+  (set! (-> obj best-from-prim) #f)
+  (set! (-> obj best-to-prim) #f)
+  (none)
+  )
+
+(deftype overlaps-others-params (structure)
+  ((options uint32  :offset-assert 0)
+   (tlist   basic   :offset-assert 4)
+   )
+  :method-count-assert 9
+  :size-assert         #x8
+  :flag-assert         #x900000008
+  )
+
+;; The engine system is used to link collision checks with processes.
+(define *collide-hit-by-player-list*
+    (new 'global 'engine 'collide-hit-by-player-list 768)
+  )
+
+(define *collide-usually-hit-by-player-list*
+    (new 'global 'engine 'collide-usually-hit-by-player-list 256)
+  )
+
+(define *collide-hit-by-others-list*
+    (new 'global 'engine 'collide-hit-by-others-list 96)
+  )
+
+(define *collide-player-list* (new 'global 'engine 'collide-player-list 32))
+
+;; some parts of collide-shape-prim are broken out here.
+(deftype collide-prim-core (structure)
+  ((world-sphere vector  :inline :offset-assert 0)
+   (collide-as   uint64          :offset-assert 16)
+   (action       uint32          :offset-assert 24)
+   (offense      int8            :offset-assert 28)
+   (prim-type    int8            :offset-assert 29)
+   (extra        uint8 2       :offset-assert 30)
+   (quad         uint128 2       :offset 0)
+   )
+  :method-count-assert 9
+  :size-assert         #x20
+  :flag-assert         #x900000020
+  )
+
+;; the base class for collision shapes.
+(deftype collide-shape-prim (basic)
+  ((cshape          basic                     :offset-assert 4)
+   (prim-id         uint32                    :offset-assert 8)
+   (transform-index int8                      :offset-assert 12)
+   (prim-core       collide-prim-core :inline :offset-assert 16)
+   (local-sphere    vector            :inline :offset-assert 48)
+   (collide-with    uint64                    :offset-assert 64)
+   ;; overlays of the prim-core
+   (world-sphere    vector            :inline :offset 16)
+   (collide-as      uint64                    :offset 32)
+   (action          uint32                    :offset 40)
+   (offense         int8                      :offset 44)
+   (prim-type       int8                      :offset 45)
+   ;; overlay of the local-sphere w
+   (radius          float                     :offset 60) ;; meters
+   )
+  :method-count-assert 28
+  :size-assert         #x48
+  :flag-assert         #x1c00000048
+  (:methods
+   (new (symbol type basic uint int) _type_ 0)
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   )
+  )
+
+;; sphere collision
+;; the pat is stored directly here.
+(deftype collide-shape-prim-sphere (collide-shape-prim)
+  ((pat             uint32                    :offset-assert 72)
+   )
+  :method-count-assert 28
+  :size-assert         #x4c
+  :flag-assert         #x1c0000004c
+  (:methods
+   (new (symbol type basic uint) _type_ 0)
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   )
+  )
+
+;; mesh collision
+;; the pats are stored per tri in the mesh.
+(deftype collide-shape-prim-mesh (collide-shape-prim)
+  ((mesh            basic                     :offset-assert 72)
+   (mesh-id         int32                     :offset-assert 76)
+   (mesh-cache-id   uint64                    :offset-assert 80)
+   (mesh-cache-tris uint32                    :offset-assert 88)
+   )
+  :method-count-assert 29
+  :size-assert         #x5c
+  :flag-assert         #x1d0000005c
+  (:methods
+   (new (symbol type basic uint uint) _type_ 0)
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   (dummy-28 () none 28)
+   )
+  )
+
+;; A group of collide-shape-prim's
+(deftype collide-shape-prim-group (collide-shape-prim)
+  ((num-prims       int32                     :offset-assert 72)
+   (allocated-prims int32                     :offset-assert 76)
+   (prim            uint32           1       :offset-assert 80) ;; array of references.
+   )
+  :method-count-assert 30
+  :size-assert         #x54
+  :flag-assert         #x1e00000054
+  (:methods
+   (new (symbol type basic uint int) _type_ 0)
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   (dummy-28 () none 28)
+   (dummy-29 () none 29)
+   )
+  )
+
+;; an actual instance of a collision primitive.
+;; it's based on a transform (q means quaternion, v means with derivatives)
+(deftype collide-shape (trsqv)
+  ((process               basic              :offset-assert 140)
+   (max-iteration-count   uint8              :offset-assert 144)
+   (nav-flags             uint8              :offset-assert 145)
+   (pad-byte              uint8      2       :offset-assert 146)
+   (pat-ignore-mask       uint32             :offset-assert 148)
+   (event-self            basic              :offset-assert 152)
+   (event-other           basic              :offset-assert 156)
+   (root-prim             basic              :offset-assert 160)
+   (riders                basic              :offset-assert 164)
+   (backup-collide-as     uint64             :offset-assert 168)
+   (backup-collide-with   uint64             :offset-assert 176)
+   )
+  :method-count-assert 56
+  :size-assert         #xb8
+  :flag-assert         #x38000000b8
+  (:methods
+   (new (symbol type process int) _type_)
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   (dummy-28 () none 28)
+   (dummy-29 () none 29)
+   (dummy-30 () none 30)
+   (dummy-31 () none 31)
+   (dummy-32 () none 32)
+   (dummy-33 () none 33)
+   (dummy-34 () none 34)
+   (dummy-35 () none 35)
+   (dummy-36 () none 36)
+   (dummy-37 () none 37)
+   (dummy-38 () none 38)
+   (dummy-39 () none 39)
+   (dummy-40 () none 40)
+   (dummy-41 () none 41)
+   (dummy-42 () none 42)
+   (dummy-43 () none 43)
+   (dummy-44 () none 44)
+   (dummy-45 () none 45)
+   (dummy-46 () none 46)
+   (dummy-47 () none 47)
+   (dummy-48 () none 48)
+   (dummy-49 () none 49)
+   (dummy-50 () none 50)
+   (dummy-51 () none 51)
+   (dummy-52 () none 52)
+   (dummy-53 () none 53)
+   (dummy-54 () none 54)
+   (dummy-55 () none 55)
+   )
+  )
+
+;; More complicated collide-shape?
+(deftype collide-shape-moving (collide-shape)
+  ((rider-time            uint64             :offset-assert 184)
+   (rider-last-move       vector     :inline :offset-assert 192)
+   (trans-old             vector    3 :inline      :offset-assert 208)
+   (poly-pat              uint32             :offset-assert 256)
+   (cur-pat               uint32             :offset-assert 260)
+   (ground-pat            uint32             :offset-assert 264)
+   (status                uint64             :offset-assert 272)
+   (old-status            uint64             :offset-assert 280)
+   (prev-status           uint64             :offset-assert 288)
+   (reaction-flag         uint32             :offset-assert 296)
+   (reaction              basic              :offset-assert 300)
+   (no-reaction           basic              :offset-assert 304)
+   (local-normal          vector     :inline :offset-assert 320)
+   (surface-normal        vector     :inline :offset-assert 336)
+   (poly-normal           vector     :inline :offset-assert 352)
+   (ground-poly-normal    vector     :inline :offset-assert 368)
+   (ground-touch-point    vector     :inline :offset-assert 384)
+   (shadow-pos            vector     :inline :offset-assert 400)
+   (ground-impact-vel     float              :offset-assert 416) ;; meters
+   (surface-angle         float              :offset-assert 420)
+   (poly-angle            float              :offset-assert 424)
+   (touch-angle           float              :offset-assert 428)
+   (coverage              float              :offset-assert 432)
+   (dynam                 basic              :offset-assert 436)
+   (surf                  basic              :offset-assert 440)
+   )
+  :method-count-assert 65
+  :size-assert         #x1bc
+  :flag-assert         #x41000001bc
+  (:methods
+   (dummy-9 () none 9)
+   (dummy-10 () none 10)
+   (dummy-11 () none 11)
+   (dummy-12 () none 12)
+   (dummy-13 () none 13)
+   (dummy-14 () none 14)
+   (dummy-15 () none 15)
+   (dummy-16 () none 16)
+   (dummy-17 () none 17)
+   (dummy-18 () none 18)
+   (dummy-19 () none 19)
+   (dummy-20 () none 20)
+   (dummy-21 () none 21)
+   (dummy-22 () none 22)
+   (dummy-23 () none 23)
+   (dummy-24 () none 24)
+   (dummy-25 () none 25)
+   (dummy-26 () none 26)
+   (dummy-27 () none 27)
+   (dummy-28 () none 28)
+   (dummy-29 () none 29)
+   (dummy-30 () none 30)
+   (dummy-31 () none 31)
+   (dummy-32 () none 32)
+   (dummy-33 () none 33)
+   (dummy-34 () none 34)
+   (dummy-35 () none 35)
+   (dummy-36 () none 36)
+   (dummy-37 () none 37)
+   (dummy-38 () none 38)
+   (dummy-39 () none 39)
+   (dummy-40 () none 40)
+   (dummy-41 () none 41)
+   (dummy-42 () none 42)
+   (dummy-43 () none 43)
+   (dummy-44 () none 44)
+   (dummy-45 () none 45)
+   (dummy-46 () none 46)
+   (dummy-47 () none 47)
+   (dummy-48 () none 48)
+   (dummy-49 () none 49)
+   (dummy-50 () none 50)
+   (dummy-51 () none 51)
+   (dummy-52 () none 52)
+   (dummy-53 () none 53)
+   (dummy-54 () none 54)
+   (dummy-55 () none 55)
+   (dummy-56 () none 56)
+   (dummy-57 () none 57)
+   (dummy-58 () none 58)
+   (dummy-59 () none 59)
+   (dummy-60 () none 60)
+   (dummy-61 () none 61)
+   (dummy-62 () none 62)
+   (dummy-63 () none 63)
+   (dummy-64 () none 64)
+   )
+  )
+
+(defmethod new collide-shape-prim ((allocation symbol) (type-to-make type) (cshape basic) (prim-id uint) (size-bytes int))
+  "Allocate a new collide-shape-prim. It is expected that children of collide-shape-prim override this.
+   NOTE: uses the size-bytes as the TOTAL size of the structure."
+  (local-vars (v0-0 collide-shape-prim))
+  (set! v0-0 (object-new allocation type-to-make size-bytes))
+  ;; not sure what this is.
+  (set! (-> v0-0 cshape) cshape)
+  ;; sphere/mesh?
+  (set! (-> v0-0 prim-id) prim-id)
+  (set! (-> v0-0 prim-core action) 0)
+  (set! (-> v0-0 prim-core collide-as) 0)
+  (set! (-> v0-0 collide-with) 0)
+  (set! (-> v0-0 transform-index) -2)
+  (set! (-> v0-0 prim-core offense) 0)
+  (set! (-> v0-0 prim-core prim-type) -2)
+  v0-0
+  )
+
+(defmethod new collide-shape-prim-sphere ((allocation symbol) (type-to-make type) (cshape basic) (prim-id uint))
+  "Allocate a new sphere primitive"
+  (local-vars (v0-0 collide-shape-prim-sphere))
+  (set! v0-0
+        (the collide-shape-prim-sphere
+             ((method-of-type collide-shape-prim new)
+              allocation
+              type-to-make
+              cshape
+              prim-id
+              76
+              )
+             )
+        )
+  (set! (-> v0-0 pat) 16) ;; todo - bitfield
+  (set! (-> v0-0 prim-core prim-type) -1)
+  v0-0
+  )
+
+(defmethod new collide-shape-prim-mesh ((allocation symbol) (type-to-make type) (cshape basic) (mesh-id uint) (prim-id uint))
+  "Allocate a new mesh primitive"
+  (local-vars (v0-0 collide-shape-prim-mesh))
+  (set! v0-0 (the collide-shape-prim-mesh
+                  ((method-of-type collide-shape-prim new)
+                   allocation
+                   type-to-make
+                   cshape
+                   prim-id
+                   92
+                   )
+                  )
+        )
+  (set! (-> (the-as collide-shape-prim-mesh v0-0) mesh) #f)
+  (set! (-> v0-0 mesh-id) (the int mesh-id))
+  (set! (-> v0-0 mesh-cache-id) 0)
+  (set! (-> v0-0 prim-core prim-type) 1)
+  v0-0
+  )
+
+(defmethod new collide-shape-prim-group ((allocation symbol) (type-to-make type) (cshape basic) (elt-count uint) (prim-id int))
+  "Allocate a group of primitives."
+  (local-vars (v0-0 collide-shape-prim-group))
+  (set! v0-0 (the collide-shape-prim-group
+                  ((method-of-type collide-shape-prim new)
+                   allocation
+                   type-to-make
+                   cshape
+                   (the-as uint prim-id)
+                   ;; minus one for the one reference in the type.
+                   (the-as int (+ (-> type-to-make size) (shl (+ elt-count -1) 2)))
+                   )
+                  )
+        )
+  (set! (-> v0-0 allocated-prims) (the int elt-count))
+  (set! (-> v0-0 num-prims) 0)
+  (set! (-> v0-0 prim-core prim-type) 0)
+  (while (nonzero? elt-count)
+    (+! elt-count -1)
+    (set! (-> v0-0 prim elt-count) (the uint #f))
+    (nop!)
+    )
+  v0-0
+  )
+
+(defmethod length collide-shape-prim-group ((obj collide-shape-prim-group))
+  "How many primitives are used?"
+  (-> obj num-prims)
+  )
+
+(defmethod asize-of collide-shape-prim-group ((obj collide-shape-prim-group))
+  "How big is this in memory?"
+  (the-as int
+          (+ (-> obj type size) (the-as uint (shl (+ (-> obj allocated-prims) -1) 2)))
+          )
+  )
+
+(defmethod new collide-shape ((allocation symbol) (type-to-make type) (proc process) (collide-list-kind int))
+  (local-vars (v1-5 symbol) (obj collide-shape))
+  (set! obj (object-new allocation type-to-make (the-as int (-> type-to-make size))))
+  (set! (-> obj process) proc)
+  (set! (-> obj max-iteration-count) 1)
+  (set! (-> obj nav-flags) 1)
+  (set! (-> obj event-self) #f)
+  (set! (-> obj event-other) #f)
+  (set! (-> obj riders) #f)
+  (set! (-> obj root-prim) #f)
+  (set! v1-5 (-> proc type symbol))
+
+  ;; add a special ignore mask for the camera vs other things.
+  (if (= v1-5 'camera)
+      (set! (-> obj pat-ignore-mask) 2)
+      (set! (-> obj pat-ignore-mask) 1)
+      )
+
+  ;; reset transformation to the origin.
+  (set! (-> obj trans w) 1.000000)
+  (quaternion-identity! (the-as quaternion (-> obj rot)))
+  (vector-identity! (-> obj scale))
+
+  ;; add us to right list.
+  (cond
+    ((zero? collide-list-kind)
+     (add-connection *collide-hit-by-player-list* proc (the (function object object object object object) #f) obj #f #f)
+     )
+    ((= collide-list-kind 1)
+     (add-connection *collide-usually-hit-by-player-list* proc (the (function object object object object object) #f) obj #f #f)
+     )
+    ((= collide-list-kind 2)
+     (add-connection *collide-hit-by-others-list* proc (the (function object object object object object) #f) obj #f #f)
+     )
+    ((= collide-list-kind 3)
+     (add-connection *collide-player-list* proc (the (function object object object object object) #f) obj #f #f)
+     )
+    (else
+     (format 0 "Unsupported collide-list-enum in collide-shape constructor!~%")
+     )
+    )
+  obj
+  )
+
+(defmethod new collide-sticky-rider-group ((allocation symbol) (type-to-make type) (arg0 int))
+  (local-vars (v0-0 collide-sticky-rider-group))
+  (set! v0-0
+        (object-new allocation type-to-make
+                    (the-as int (+ (-> type-to-make size) (the-as uint (shl (+ arg0 -1) 5))))
+                    )
+        )
+  (set! (-> v0-0 allocated-riders) arg0)
+  (set! (-> v0-0 num-riders) 0)
+  v0-0
+  )
+
+(defmethod length collide-sticky-rider-group ((obj collide-sticky-rider-group))
+  (-> obj num-riders)
+  )
+
+(defmethod asize-of collide-sticky-rider-group ((obj collide-sticky-rider-group))
+  (the-as int
+          (+ (-> obj type size) (the-as uint (shl (+ (-> obj allocated-riders) -1) 5)))
+          )
+  )
+
+(define *collide-shape-prim-backgnd*
+    (new 'static 'collide-shape-prim-mesh
+         :cshape #f
+         :prim-core
+         (new 'static 'collide-prim-core
+              :world-sphere
+              (new 'static 'vector :w 204800000.000000)
+              :collide-as #x1
+              :action #x1
+              :offense 4
+              :prim-type 2
+              )
+         :local-sphere
+         (new 'static 'vector :w 204800000.000000)
+         :mesh #f
+         )
+  )
+
+(define *collide-shape-prim-water*
+    (new 'static 'collide-shape-prim-mesh
+         :cshape #f
+         :prim-core
+         (new 'static 'collide-prim-core
+              :world-sphere
+              (new 'static 'vector :w 204800000.000000)
+              :collide-as #x20
+              :action #x1
+              :offense 4
+              :prim-type 2
+              )
+         :local-sphere
+         (new 'static 'vector :w 204800000.000000)
+         :mesh #f
+         )
+  )

--- a/goal_src/engine/game/fact-h.gc
+++ b/goal_src/engine/game/fact-h.gc
@@ -5,3 +5,129 @@
 ;; name in dgo: fact-h
 ;; dgos: GAME, ENGINE
 
+;; NOT FINISHED
+
+(deftype fact-bank (basic)
+  ((eco-level-max        float     :offset-assert 4)
+   (eco-single-inc       float     :offset-assert 8)
+   (eco-full-inc         float     :offset-assert 12)
+   (eco-single-timeout   uint64  :offset-assert 16) ; usec
+   (eco-full-timeout     uint64  :offset-assert 24) ; usec
+   (dummy                uint64  :offset-assert 32) ; usec
+   (health-max-default   float     :offset-assert 40)
+   (health-single-inc    float     :offset-assert 44)
+   (eco-pill-max-default float     :offset-assert 48)
+   (health-small-inc     float     :offset-assert 52)
+   (buzzer-max-default   float     :offset-assert 56)
+   (buzzer-single-inc    float     :offset-assert 60)
+   (suck-bounce-dist     float    :offset-assert 64) ; meters
+   (suck-suck-dist       float    :offset-assert 68) ; meters
+   (default-pill-inc     float     :offset-assert 72)
+   )
+  :method-count-assert 9
+  :size-assert         #x4c
+  :flag-assert         #x90000004c
+  )
+
+(define *FACT-bank*
+    (new 'static 'fact-bank
+         :eco-level-max 2.000000
+         :eco-single-inc 1.000000
+         :eco-full-inc 5.000000
+         :eco-single-timeout #x5dc
+         :eco-full-timeout #x1770
+         :dummy #x1194
+         :health-max-default 3.000000
+         :health-single-inc 1.000000
+         :eco-pill-max-default 50.000000
+         :health-small-inc 1.000000
+         :buzzer-max-default 7.000000
+         :buzzer-single-inc 1.000000
+         :suck-bounce-dist 73728.000000
+         :suck-suck-dist 30720.000000
+         )
+  )
+
+(defun pickup-type->string ((arg0 int))
+  (local-vars (v1-0 int))
+  (set! v1-0 arg0)
+  (cond
+   ((= v1-0 9) "eco-pill-random")
+   ((= v1-0 8) "buzzer")
+   ((= v1-0 7) "eco-pill")
+   ((= v1-0 6) "fuel-cell")
+   ((= v1-0 5) "money")
+   ((= v1-0 4) "eco-green")
+   ((= v1-0 3) "eco-blue")
+   ((= v1-0 2) "eco-red")
+   ((= v1-0 1) "eco-yellow")
+   ((zero? v1-0) "none")
+   (else "*unknown*")
+   )
+  )
+
+(deftype fact-info (basic)
+  ((process             basic   :offset-assert 4)
+   (pickup-type         int32   :offset-assert 8)
+   (pickup-amount       float   :offset-assert 12)
+   (pickup-spawn-amount float   :offset-assert 16)
+   (options             uint64  :offset-assert 24)
+   (fade-time           uint64  :offset-assert 32)
+   )
+  :method-count-assert 12
+  :size-assert         #x28
+  :flag-assert         #xc00000028
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    )
+  )
+
+(deftype fact-info-target (fact-info)
+  ((eco-type              int32     :offset-assert 40)
+   (eco-level             float     :offset-assert 44)
+   (eco-pickup-time       uint64    :offset-assert 48)
+   (eco-timeout           uint64  :offset-assert 56) ;; usec
+   (health                float     :offset-assert 64)
+   (health-max            float     :offset-assert 68)
+   (buzzer                float     :offset-assert 72)
+   (buzzer-max            float     :offset-assert 76)
+   (eco-pill              float     :offset-assert 80)
+   (eco-pill-max          float     :offset-assert 84)
+   (health-pickup-time    uint64    :offset-assert 88)
+   (eco-source            uint64    :offset-assert 96)
+   (eco-source-time       uint64    :offset-assert 104)
+   (money-pickup-time     uint64    :offset-assert 112)
+   (buzzer-pickup-time    uint64    :offset-assert 120)
+   (fuel-cell-pickup-time uint64    :offset-assert 128)
+   (eco-pill-pickup-time  uint64    :offset-assert 136)
+   )
+  :method-count-assert 12
+  :size-assert         #x90
+  :flag-assert         #xc00000090
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    )
+  )
+
+(deftype fact-info-enemy (fact-info)
+  ((speed               float   :offset-assert 40)
+   (idle-distance       float  :offset-assert 44) ; meters 
+   (notice-top          float  :offset-assert 48) ; meters 
+   (notice-bottom       float  :offset-assert 52) ; meters 
+   (cam-horz            float  :offset-assert 56) ; meters 
+   (cam-vert            float  :offset-assert 60) ; meters 
+   (cam-notice-dist     float  :offset-assert 64) ; meters 
+   )
+  :method-count-assert 12
+  :size-assert         #x44
+  :flag-assert         #xc00000044
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    )
+  )

--- a/goal_src/engine/math/quaternion.gc
+++ b/goal_src/engine/math/quaternion.gc
@@ -5,3 +5,12 @@
 ;; name in dgo: quaternion
 ;; dgos: GAME, ENGINE
 
+
+(defun quaternion-identity! ((dst quaternion))
+  (rlet ((r0 :class vf))
+    (.xor.vf r0 r0 r0)
+    (.svf dst r0)
+    )
+  (set! (-> dst w) 1.0)
+  dst
+  )

--- a/goal_src/engine/math/vector.gc
+++ b/goal_src/engine/math/vector.gc
@@ -5,3 +5,10 @@
 ;; name in dgo: vector
 ;; dgos: GAME, ENGINE
 
+(defun vector-identity! ((arg0 vector))
+  (set! (-> arg0 data 0) 1.0)
+  (set! (-> arg0 data 1) 1.0)
+  (set! (-> arg0 data 2) 1.0)
+  (set! (-> arg0 data 3) 1.0)
+  arg0
+  )

--- a/goal_src/engine/physics/trajectory-h.gc
+++ b/goal_src/engine/physics/trajectory-h.gc
@@ -5,3 +5,22 @@
 ;; name in dgo: trajectory-h
 ;; dgos: GAME, ENGINE
 
+  (deftype trajectory (structure)
+    ((initial-position vector :inline :offset-assert 0)
+     (initial-velocity vector :inline :offset-assert 16)
+     (time             float          :offset-assert 32)
+     (gravity          float          :offset-assert 36) ;; meters
+     )
+    :method-count-assert 16
+    :size-assert         #x28
+    :flag-assert         #x1000000028
+    (:methods
+      (dummy-9 () none 9)
+      (dummy-10 () none 10)
+      (dummy-11 () none 11)
+      (dummy-12 () none 12)
+      (dummy-13 () none 13)
+      (dummy-14 () none 14)
+      (dummy-15 () none 15)
+      )
+    )

--- a/goal_src/engine/target/pat-h.gc
+++ b/goal_src/engine/target/pat-h.gc
@@ -5,3 +5,120 @@
 ;; name in dgo: pat-h
 ;; dgos: GAME, ENGINE
 
+(deftype pat-surface (uint32)
+  ()
+  :method-count-assert 9
+  :size-assert         #x4
+  :flag-assert         #x900000004
+  )
+
+(defmethod inspect pat-surface ((obj pat-surface))
+  (format #t "[~8x] ~A~%" obj 'pat-surface)
+  (format #t "~Tskip: ~D~%" (shr (shl (the-as int obj) 61) 61))
+  (format #t "~Tmode: ~D~%" (shr (shl (the-as int obj) 58) 61))
+  (format #t "~Tmaterial: ~D~%" (shr (shl (the-as int obj) 52) 58))
+  (format #t "~Tcamera: ~D~%" (shr (shl (the-as int obj) 50) 62))
+  (format #t "~Tevent: ~D~%" (shr (shl (the-as int obj) 44) 58))
+  (format #t "~Tnoentity: ~D~%" (shr (shl (the-as int obj) 63) 63))
+  (format #t "~Tnocamera: ~D~%" (shr (shl (the-as int obj) 62) 63))
+  (format #t "~Tnoedge: ~D~%" (shr (shl (the-as int obj) 61) 63))
+  (format #t "~Tnolineofsight: ~D~%" (shr (shl (the-as int obj) 51) 63))
+  obj
+  )
+
+(defun-debug pat-material->string ((arg0 pat-surface))
+  (local-vars (v1-1 int))
+  (set! v1-1 (shr (shl (the-as int arg0) 52) 58))
+  (cond
+    ((= v1-1 22) "neutral")
+    ((= v1-1 21) "rotate")
+    ((= v1-1 20) "stopproj")
+    ((= v1-1 19) "swamp")
+    ((= v1-1 18) "tube")
+    ((= v1-1 17) "straw")
+    ((= v1-1 16) "metal")
+    ((= v1-1 15) "dirt")
+    ((= v1-1 14) "gravel")
+    ((= v1-1 13) "crwood")
+    ((= v1-1 12) "lava")
+    ((= v1-1 11) "hotcoals")
+    ((= v1-1 10) "deepsnow")
+    ((= v1-1 9) "snow")
+    ((= v1-1 8) "pcmetal")
+    ((= v1-1 7) "grass")
+    ((= v1-1 6) "wood")
+    ((= v1-1 5) "sand")
+    ((= v1-1 4) "tar")
+    ((= v1-1 3) "waterbottom")
+    ((= v1-1 2) "quicksand")
+    ((= v1-1 1) "ice")
+    ((zero? v1-1) "stone")
+    (else "*unknown*")
+    )
+  )
+
+(defun-debug pat-mode->string ((arg0 pat-surface))
+  (local-vars (v1-1 int))
+  (set! v1-1 (shr (shl (the-as int arg0) 58) 61))
+  (cond
+    ((= v1-1 2) "obstacle")
+    ((= v1-1 1) "wall")
+    ((zero? v1-1) "ground")
+    (else "*unknown*")
+    )
+  )
+
+(defun pat-event->string ((arg0 pat-surface))
+  (local-vars (v1-1 int))
+  (set! v1-1 (shr (shl (the-as int arg0) 44) 58))
+  (cond
+    ((= v1-1 6) "melt")
+    ((= v1-1 5) "burnup")
+    ((= v1-1 4) "deadlyup")
+    ((= v1-1 3) "burn")
+    ((= v1-1 2) "endlessfall")
+    ((= v1-1 1) "deadly")
+    ((zero? v1-1) "none")
+    (else "*unknown*")
+    )
+  )
+
+(deftype pat-mode-info (structure)
+  ((name         basic   :offset-assert 0)
+   (wall-angle   float   :offset-assert 4)
+   (color        uint32  :offset-assert 8)
+   (hilite-color uint32  :offset-assert 12)
+   )
+  :method-count-assert 9
+  :size-assert         #x10
+  :flag-assert         #x900000010
+  )
+
+(define *pat-mode-info*
+    (new 'static 'inline-array pat-mode-info 4
+         (new 'static 'pat-mode-info
+              :name "ground"
+              :wall-angle (the-as float #x3e4ccccd)
+              :color #x4000007f
+              :hilite-color #x800000ff
+              )
+         (new 'static 'pat-mode-info
+              :name "wall"
+              :wall-angle 2.000000
+              :color #x407f0000
+              :hilite-color #x80ff0000
+              )
+         (new 'static 'pat-mode-info
+              :name "obstacle"
+              :wall-angle (the-as float #x3f51eb85)
+              :color #x407f007f
+              :hilite-color #x80ff00ff
+              )
+         (new 'static 'pat-mode-info
+              :name "pole"
+              :wall-angle 2.000000
+              :color #x40007f7f
+              :hilite-color #x8000ffff
+              )
+         )
+  )

--- a/goal_src/engine/target/surface-h.gc
+++ b/goal_src/engine/target/surface-h.gc
@@ -4,3 +4,1249 @@
 ;; name: surface-h.gc
 ;; name in dgo: surface-h
 ;; dgos: GAME, ENGINE
+
+(deftype surface (basic)
+  ((name              basic      :offset-assert 4)
+   ;;(data              UNKNOWN 30 :offset-assert 8)
+   (turnv             float      :offset-assert 8)
+   (turnvv            float      :offset-assert 12)
+   (tiltv             float      :offset-assert 16)
+   (tiltvv            float      :offset-assert 20)
+   (transv-max        float      :offset-assert 24)
+   (target-speed      float      :offset-assert 28)
+   (seek0             float      :offset-assert 32)
+   (seek90            float      :offset-assert 36)
+   (seek180           float      :offset-assert 40)
+   (fric              float      :offset-assert 44)
+   (nonlin-fric-dist  float      :offset-assert 48)
+   (slip-factor       float      :offset-assert 52)
+   (slide-factor      float      :offset-assert 56)
+   (slope-up-factor   float      :offset-assert 60)
+   (slope-down-factor float      :offset-assert 64)
+   (slope-slip-angle  float      :offset-assert 68)
+   (impact-fric       float      :offset-assert 72)
+   (bend-factor       float      :offset-assert 76)
+   (bend-speed        float      :offset-assert 80)
+   (alignv            float      :offset-assert 84)
+   (slope-up-traction float      :offset-assert 88)
+   (align-speed       float      :offset-assert 92)
+   ;;(hook              UNKNOWN 4  :offset-assert 128)
+   (active-hook       basic      :offset 128)
+   (touch-hook        basic      :offset-assert 132)
+   (impact-hook       basic      :offset-assert 136)
+   (mult-hook (function surface surface surface int none) :offset-assert 140)
+   ;;(dataw             UNKNOWN 2  :offset-assert 144)
+   (mode              basic      :offset-assert 144)
+   (flags             uint32     :offset-assert 148)
+
+   ;; overlays used for copying data.
+   (data              float 30 :offset 8)
+   (hook              basic 4  :offset 128)
+   (dataw             uint32 2  :offset 144)
+   )
+  :method-count-assert 9
+  :size-assert         #x98
+  :flag-assert         #x900000098
+  )
+
+(defun calc-terminal-vel ((arg0 float) (arg1 float) (arg2 float))
+  (- (* (/ (- (* (the-as float #x3c888889) arg0) arg1) arg2) (- 1.000000 arg2))
+     arg1
+     )
+  )
+
+(defun calc-terminal2-vel ((arg0 float) (arg1 float) (arg2 float) (arg3 float))
+  (local-vars (f0-4 float))
+  (set! f0-4 (sqrtf (/ (- (* (the-as float #x3c888889) arg0) arg1) arg2)))
+  (- f0-4 (+ arg1 (* arg2 (* f0-4 f0-4))))
+  )
+
+(defun calc-terminal4-vel ((arg0 float) (arg1 float) (arg2 float))
+  (local-vars (f0-5 float))
+  (set! f0-5 (sqrtf (sqrtf (/ (- (* (the-as float #x3c888889) arg0) arg1) arg2))))
+  (- f0-5 (+ arg1 (* arg2 (* (* (* f0-5 f0-5) f0-5) f0-5))))
+  )
+
+(defmethod print surface ((obj surface))
+  ;; seems like an off-by-one bug in the format string here.
+  (format
+   '#t
+   "#<surface f0:~m f1:~f tf+:~f tf-:~f sf:~f tvv:~m"
+   (-> obj turnv)
+   (-> obj turnvv)
+   (-> obj tiltv)
+   (-> obj tiltvv)
+   (-> obj transv-max)
+   0 ;; seesm to be a bug here
+   )
+  (format
+   '#t
+   "  tm:~m rv:~R rvv:~R @ #x~X>"
+   (-> obj target-speed)
+   (-> obj seek0)
+   (-> obj seek90)
+   obj
+   )
+  obj
+  )
+
+(defun surface-interp! ((dst surface) (src0 surface) (src1 surface) (amount float))
+  "Create a surface between src0 and src1. For things like hooks/mode, src1 wins."
+  (local-vars (v1-0 int) (v1-3 int) (v1-6 int))
+
+  ;; iterate through floats
+  (set! v1-0 0)
+  (while (< v1-0 30)
+    ;; interpolate between the two
+    (set! (-> dst data v1-0)
+          (+ (* (-> src1 data v1-0) amount)
+             (* (-> src0 data v1-0) (- 1.000000 amount))
+             )
+          )
+    (+! v1-0 1)
+    )
+
+  ;; iterate through hooks. Check src1, then src0 for a nonzero and non-nothing hook.
+  ;; if there is no good hook, set it to nothing.
+  (set! v1-3 0)
+  (while (< v1-3 4)
+    (set! (-> dst hook v1-3)
+          (if (and (nonzero? (-> src1 hook v1-3)) (!= (-> src1 hook v1-3) nothing))
+              (-> src1 hook v1-3)
+              (if (and (nonzero? (-> src0 hook v1-3)) (!= (-> src0 hook v1-3) nothing))
+                  (-> src0 hook v1-3)
+                  nothing
+                  )
+              )
+          )
+    (+! v1-3 1)
+    )
+
+  ;; just use the dataw's from src1
+  (set! v1-6 0)
+  (while (< v1-6 2)
+    (set! (-> dst dataw v1-6) (-> src1 dataw v1-6))
+    (+! v1-6 1)
+    )
+  
+  dst
+  )
+
+(defun surface-mult! ((dst surface) (src0 surface) (src1 surface))
+  "Multiply src0 by src1, and store the result in dst."
+  (local-vars (v1-0 int) (v1-3 int) (v1-6 int))
+  (set! v1-0 0)
+  (while (< v1-0 30)
+    (set! (-> dst data v1-0) (* (-> src1 data v1-0) (-> src0 data v1-0)))
+    (+! v1-0 1)
+    )
+  (set! v1-3 0)
+  (while (< v1-3 4)
+    (set!
+     (-> dst hook v1-3)
+     (if (and (nonzero? (-> src1 hook v1-3)) (!= (-> src1 hook v1-3) nothing))
+         (-> src1 hook v1-3)
+         (if (and (nonzero? (-> src0 hook v1-3)) (!= (-> src0 hook v1-3) nothing))
+             (-> src0 hook v1-3)
+             nothing
+             )
+         )
+     )
+    (+! v1-3 1)
+    )
+  (set! v1-6 0)
+  (while (< v1-6 2)
+    (set! (-> dst dataw v1-6) (-> src1 dataw v1-6))
+    (+! v1-6 1)
+    )
+  ;; take the or of the flags, I guess
+  (set! (-> dst flags) (logior (-> src0 flags) (-> src1 flags)))
+  ;; and call the mult-hook
+  ((-> dst mult-hook) dst src0 src1 1)
+  dst
+  )
+
+(defun surface-clamp-speed ((arg0 surface) (arg1 surface) (arg2 surface) (arg3 int))
+  "When arg3 is 1, clamp speed of arg0 to the mins of arg0/arg1"
+  (when (= arg3 1)
+    (set! (-> arg0 transv-max) (fmin (-> arg0 transv-max) (-> arg1 transv-max)))
+    (set! (-> arg0 target-speed) (fmin (-> arg0 target-speed) (-> arg1 target-speed)))
+    )
+  (none)
+  )
+
+(define *walk-mods*
+    (new 'static 'surface
+         :name 'run
+         :turnv 131072.000000
+         :turnvv 524288.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :flags #x1
+         )
+  )
+
+(define *walk-no-turn-mods*
+    (new 'static 'surface
+         :name 'run
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         )
+  )
+
+(define *turn-around-mods*
+    (new 'static 'surface
+         :name 'run
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :fric (the-as float #x3dcccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         )
+  )
+
+(let ((a0-3
+       (new 'static 'surface
+            :name 'duck
+            :turnv 131072.000000
+            :turnvv 524288.000000
+            :tiltv 65536.000000
+            :tiltvv (the-as float #x488e38e4)
+            :transv-max 16384.000000
+            :target-speed 16384.000000
+            :seek0 1.000000
+            :seek90 1.000000
+            :seek180 1.000000
+            :fric 1.000000
+            :nonlin-fric-dist 1.000000
+            :slip-factor 1.000000
+            :slide-factor 1.000000
+            :slope-up-factor 1.000000
+            :slope-down-factor 1.000000
+            :slope-slip-angle 1.000000
+            :impact-fric 1.000000
+            :bend-factor 1.000000
+            :bend-speed 1.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            :flags #x2000
+            )
+        ))
+  (set! (-> a0-3 mult-hook) surface-clamp-speed)
+  (define *duck-mods* a0-3)
+  )
+
+(define *duck-attack-mods*
+    (new 'static 'surface
+         :name 'duck
+         :tiltv 65536.000000
+         :tiltvv (the-as float #x488e38e4)
+         :transv-max 16384.000000
+         :target-speed 16384.000000
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x3000
+         )
+  )
+
+(define *jump-mods*
+    (new 'static 'surface
+         :name 'jump
+         :turnv 131072.000000
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 (the-as float #x3e99999a)
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3e99999a)
+         :fric (the-as float #x3e4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *double-jump-mods*
+    (new 'static 'surface
+         :name 'jump-double
+         :turnv 131072.000000
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 32768.000000
+         :target-speed 32768.000000
+         :seek0 (the-as float #x3e99999a)
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3e99999a)
+         :fric (the-as float #x3e4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *smack-jump-mods*
+    (new 'static 'surface
+         :name 'jump
+         :turnv 131072.000000
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 (the-as float #x3e99999a)
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3e99999a)
+         :fric (the-as float #x3d4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *high-jump-mods*
+    (new 'static 'surface
+         :name 'high-jump
+         :turnv 131072.000000
+         :turnvv 65536.000000
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 26624.000000
+         :target-speed 26624.000000
+         :seek0 (the-as float #x3f666666)
+         :seek90 (the-as float #x3f666666)
+         :seek180 (the-as float #x3f666666)
+         :fric (the-as float #x3e99999a)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *launch-jump-mods*
+    (new 'static 'surface
+         :name 'launch-jump
+         :turnv (the-as float #x468e38e4)
+         :turnvv 65536.000000
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 61440.000000
+         :target-speed 61440.000000
+         :seek0 (the-as float #x3f666666)
+         :seek90 (the-as float #x3f666666)
+         :seek180 (the-as float #x3f666666)
+         :fric (the-as float #x3e99999a)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc80
+         )
+  )
+
+(define *forward-high-jump-mods*
+    (new 'static 'surface
+         :name 'high-jump
+         :turnv 131072.000000
+         :turnvv 65536.000000
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 45056.000000
+         :target-speed 45056.000000
+         :seek0 (the-as float #x3f666666)
+         :seek90 (the-as float #x3f666666)
+         :seek180 (the-as float #x3f666666)
+         :fric (the-as float #x3e99999a)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *flip-jump-mods*
+    (new 'static 'surface
+         :name 'high-jump
+         :turnv 131072.000000
+         :turnvv 65536.000000
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max (the-as float #x479ccccd)
+         :target-speed 51200.000000
+         :seek0 (the-as float #x3f666666)
+         :seek90 (the-as float #x3f666666)
+         :seek180 (the-as float #x3f666666)
+         :fric (the-as float #x3e99999a)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *forward-jump-mods*
+    (new 'static 'surface
+         :name 'jump
+         :turnv 131072.000000
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 65536.000000
+         :target-speed 65536.000000
+         :seek0 (the-as float #x3e99999a)
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3e99999a)
+         :fric (the-as float #x3d4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *forward-pole-jump-mods*
+    (new 'static 'surface
+         :name 'jump
+         :turnv 131072.000000
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 53248.000000
+         :target-speed 53248.000000
+         :seek0 (the-as float #x3e99999a)
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3e99999a)
+         :fric (the-as float #x3d4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #xc00
+         )
+  )
+
+(define *attack-mods*
+    (new 'static 'surface
+         :name 'attack
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x1000
+         )
+  )
+
+(define *jump-attack-mods*
+    (new 'static 'surface
+         :name 'attack
+         :turnvv (the-as float #x468e38e4)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 24576.000000
+         :target-speed 24576.000000
+         :seek0 (the-as float #x3f666666)
+         :seek90 (the-as float #x3f666666)
+         :seek180 (the-as float #x3f666666)
+         :fric (the-as float #x3e4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'air
+         :flags #x1c00
+         )
+  )
+
+(let ((a0-4
+       (new 'static 'surface
+            :name 'uppercut
+            :turnvv (the-as float #x468e38e4)
+            :tiltv 32768.000000
+            :tiltvv 131072.000000
+            :transv-max 32768.000000
+            :target-speed 32768.000000
+            :seek0 (the-as float #x3e99999a)
+            :seek90 (the-as float #x3e99999a)
+            :seek180 (the-as float #x3e99999a)
+            :fric (the-as float #x3e4ccccd)
+            :nonlin-fric-dist 1.000000
+            :slip-factor 1.000000
+            :slide-factor 1.000000
+            :slope-up-factor 1.000000
+            :slope-down-factor 1.000000
+            :slope-slip-angle 1.000000
+            :impact-fric 1.000000
+            :bend-factor 1.000000
+            :bend-speed 1.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            :mode 'air
+            :flags #x1c00
+            )
+        ))
+  (set! (-> a0-4 mult-hook) surface-clamp-speed)
+  (define *uppercut-jump-mods* a0-4)
+  )
+
+(define *run-attack-mods*
+    (new 'static 'surface
+         :name 'wheel-flip
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max (the-as float #x47b33333)
+         :target-speed 122880.000000
+         :seek90 0.500000
+         :seek180 (the-as float #x3e19999a)
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 0.250000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x1018
+         )
+  )
+
+(define *wheel-mods*
+    (new 'static 'surface
+         :name 'wheel
+         :turnv 131072.000000
+         :turnvv (the-as float #x45aaaaab)
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max (the-as float #x47b33333)
+         :target-speed (the-as float #x46333333)
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 0.250000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x1000
+         )
+  )
+
+(define *wheel-flip-mods*
+    (new 'static 'surface
+         :name 'wheel-flip
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max (the-as float #x47b33333)
+         :target-speed (the-as float #x47c99999)
+         :seek90 0.500000
+         :seek180 (the-as float #x3e19999a)
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 0.250000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x1c00
+         )
+  )
+
+(define *flop-mods*
+    (new 'static 'surface
+         :name 'flop
+         :tiltv 32768.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 1.000000
+         :seek90 (the-as float #x3e99999a)
+         :seek180 (the-as float #x3fc00000)
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 0.250000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'attack
+         :flags #x1800
+         )
+  )
+
+(let ((a0-5
+       (new 'static 'surface
+            :name 'flop
+            :turnv (the-as float #x460e38e4)
+            :turnvv (the-as float #x460e38e4)
+            :tiltv 32768.000000
+            :tiltvv 131072.000000
+            :transv-max 40960.000000
+            :target-speed 40960.000000
+            :seek0 (the-as float #x3e99999a)
+            :seek90 (the-as float #x3dcccccd)
+            :seek180 (the-as float #x3e19999a)
+            :fric (the-as float #x3e4ccccd)
+            :nonlin-fric-dist 1.000000
+            :slip-factor 1.000000
+            :slide-factor 1.000000
+            :slope-up-factor 0.250000
+            :slope-down-factor 1.000000
+            :slope-slip-angle 1.000000
+            :impact-fric 1.000000
+            :bend-factor 1.000000
+            :bend-speed 1.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            :mode 'air
+            :flags #x800
+            )
+        ))
+  (set! (-> a0-5 mult-hook) surface-clamp-speed)
+  (define *flop-land-mods* a0-5)
+  )
+
+(define *wade-mods*
+    (new 'static 'surface
+         :name 'wade
+         :turnv 131072.000000
+         :turnvv 524288.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :seek0 1.000000
+         :seek90 0.500000
+         :seek180 0.500000
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'wade
+         :flags #x1
+         )
+  )
+
+(define *swim-mods*
+    (new 'static 'surface
+         :name 'swim
+         :turnv 49152.000000
+         :turnvv 524288.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 28672.000000
+         :target-speed 28672.000000
+         :seek0 0.750000
+         :seek90 (the-as float #x3e4ccccd)
+         :seek180 (the-as float #x3e4ccccd)
+         :fric (the-as float #x3d4ccccd)
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'swim
+         )
+  )
+
+(define *dive-mods*
+    (new 'static 'surface
+         :name 'swim
+         :turnv (the-as float #x46aaaaab)
+         :turnvv 32768.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 20480.000000
+         :target-speed 20480.000000
+         :seek0 (the-as float #x3d4ccccd)
+         :seek90 (the-as float #x3d4ccccd)
+         :seek180 (the-as float #x3d4ccccd)
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :align-speed 1.000000
+         :mode 'dive
+         :flags #x2
+         )
+  )
+
+(define *dive-bottom-mods*
+    (new 'static 'surface
+         :name 'swim-bottom
+         :turnv (the-as float #x46aaaaab)
+         :turnvv 32768.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 20480.000000
+         :target-speed 20480.000000
+         :seek0 (the-as float #x3dcccccd)
+         :seek90 (the-as float #x3d4ccccd)
+         :seek180 (the-as float #x3d4ccccd)
+         :fric 1.000000
+         :nonlin-fric-dist 1.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :alignv 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         :mode 'dive
+         :flags #x2
+         )
+  )
+
+(let ((a0-7 (copy *walk-mods* 'global)))
+  (set! (-> a0-7 name) 'pole)
+  (set! (-> a0-7 flags) 0)
+  (define *pole-mods* a0-7)
+  )
+
+(let ((a0-9 (copy *walk-mods* 'global)))
+  (set! (-> a0-9 name) 'grab)
+  (set! (-> a0-9 flags) 0)
+  (define *grab-mods* a0-9)
+  )
+
+(let ((a0-11 (copy *walk-mods* 'global)))
+  (set! (-> a0-11 name) 'edge-grab)
+  (set! (-> a0-11 flags) 0)
+  (define *edge-grab-mods* a0-11)
+  )
+
+(define *empty-mods*
+    (new 'static 'surface
+         :name 'empty
+         :seek0 1.000000
+         :seek90 1.000000
+         :seek180 1.000000
+         :fric 1.000000
+         )
+  )
+
+(define *neutral-mods*
+    (new 'static 'surface
+         :name 'walk
+         :turnv 131072.000000
+         :turnvv 524288.000000
+         :tiltv 65536.000000
+         :tiltvv 131072.000000
+         :transv-max 40960.000000
+         :target-speed 40960.000000
+         :slip-factor 1.000000
+         :slide-factor 1.000000
+         :slope-up-factor 1.000000
+         :slope-down-factor 1.000000
+         :slope-slip-angle 1.000000
+         :impact-fric 1.000000
+         :bend-factor 1.000000
+         :bend-speed 1.000000
+         :slope-up-traction 1.000000
+         :align-speed 1.000000
+         )
+  )
+
+(let ((v1-41
+       (new 'static 'surface
+            :name '*stone-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 1.000000
+            :target-speed 1.000000
+            :seek0 153600.000000
+            :seek90 153600.000000
+            :seek180 256000.000000
+            :fric 153600.000000
+            :nonlin-fric-dist 5120.000000
+            :slip-factor 1.000000
+            :slope-down-factor 10240.000000
+            :slope-slip-angle 8192.000000
+            :impact-fric 1.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            )
+        ))
+  (define *stone-surface* v1-41)
+  (set! (-> v1-41 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-41 touch-hook) nothing)
+  (set! (-> v1-41 active-hook) nothing)
+  )
+
+(let ((v1-42
+       (new 'static 'surface
+            :name '*edge-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 1.000000
+            :target-speed 1.000000
+            :seek0 153600.000000
+            :seek90 153600.000000
+            :seek180 256000.000000
+            :fric 30720.000000
+            :nonlin-fric-dist 5120.000000
+            :slip-factor 1.000000
+            :slope-down-factor 18432.000000
+            :slope-slip-angle 8192.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :align-speed 1.000000
+            )
+        ))
+  (define *edge-surface* v1-42)
+  (set! (-> v1-42 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-42 touch-hook) nothing)
+  (set! (-> v1-42 active-hook) nothing)
+  )
+
+(let ((v1-43
+       (new 'static 'surface
+            :name '*wade-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max (the-as float #x3f333333)
+            :target-speed (the-as float #x3f333333)
+            :seek0 153600.000000
+            :seek90 153600.000000
+            :seek180 256000.000000
+            :fric 153600.000000
+            :nonlin-fric-dist 5120.000000
+            :slip-factor 1.000000
+            :slope-down-factor 10240.000000
+            :slope-slip-angle 8192.000000
+            :impact-fric 1.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv (the-as float #x3f19999a)
+            :slope-up-traction 1.000000
+            :align-speed (the-as float #x3f19999a)
+            )
+        ))
+  (define *wade-surface* v1-43)
+  (set! (-> v1-43 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-43 touch-hook) nothing)
+  (set! (-> v1-43 active-hook) nothing)
+  )
+
+(let ((v1-44
+       (new 'static 'surface
+            :name '*slope-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 1.000000
+            :target-speed 1.000000
+            :seek0 122880.000000
+            :seek90 245760.000000
+            :seek180 409600.000000
+            :fric 122880.000000
+            :nonlin-fric-dist 4096.000000
+            :slip-factor 1.000000
+            :slope-up-factor 40960.000000
+            :slope-down-factor 8192.000000
+            :slope-slip-angle 8192.000000
+            :impact-fric 1.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :align-speed 1.000000
+            )
+        )
+      )
+  (define *slope-surface* v1-44)
+  (set! (-> v1-44 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-44 touch-hook) nothing)
+  (set! (-> v1-44 active-hook) nothing)
+  )
+
+(let ((v1-45
+       (new 'static 'surface
+            :name '*quicksand-surface*
+            :turnv 0.250000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 0.500000
+            :target-speed 0.500000
+            :seek0 81920.000000
+            :seek90 83968.000000
+            :seek180 165888.000000
+            :fric 329728.000000
+            :nonlin-fric-dist 5120.000000
+            :slip-factor 1.000000
+            :slope-down-factor 10240.000000
+            :slope-slip-angle 8192.000000
+            :impact-fric 1.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv 0.500000
+            :slope-up-traction 1.000000
+            :align-speed 0.500000
+            )
+        )
+      )
+  (define *quicksand-surface* v1-45)
+  (set! (-> v1-45 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-45 touch-hook) nothing)
+  (set! (-> v1-45 active-hook) nothing)
+  )
+
+(let ((v1-46
+       (new 'static 'surface
+            :name '*tar-surface*
+            :turnv 0.250000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max (the-as float #x3ecccccd)
+            :target-speed (the-as float #x3ecccccd)
+            :seek0 81920.000000
+            :seek90 83968.000000
+            :seek180 165888.000000
+            :fric 329728.000000
+            :nonlin-fric-dist 5120.000000
+            :slip-factor 1.000000
+            :slope-down-factor 10240.000000
+            :slope-slip-angle 8192.000000
+            :impact-fric 1.000000
+            :bend-factor (the-as float #x3f4ccccd)
+            :bend-speed 4.000000
+            :alignv 0.500000
+            :slope-up-traction 1.000000
+            :align-speed 0.500000
+            )
+        )
+      )
+  (define *tar-surface* v1-46)
+  (set! (-> v1-46 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-46 touch-hook) nothing)
+  (set! (-> v1-46 active-hook) nothing)
+  )
+
+(let ((v1-47
+       (new 'static 'surface
+            :name '*grass-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 1.000000
+            :target-speed 1.000000
+            :seek0 122880.000000
+            :seek90 122880.000000
+            :seek180 409600.000000
+            :fric 122880.000000
+            :nonlin-fric-dist 4096.000000
+            :slip-factor 1.000000
+            :slope-slip-angle 16384.000000
+            :impact-fric 0.500000
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            )
+        ))
+  (define *grass-surface* v1-47)
+  (set! (-> v1-47 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-47 touch-hook) nothing)
+  (set! (-> v1-47 active-hook) nothing)
+  )
+
+(let ((v1-48
+       (new 'static 'surface
+            :name '*ice-surface*
+            :turnv 0.500000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max (the-as float #x3fc00000)
+            :target-speed (the-as float #x3fc00000)
+            :seek0 24576.000000
+            :seek90 24576.000000
+            :seek180 24576.000000
+            :fric (the-as float #x46b9999a)
+            :nonlin-fric-dist 4091904.000000
+            :slip-factor (the-as float #x3f333333)
+            :slope-slip-angle 16384.000000
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            :flags #x18
+            )
+        ))
+  (define *ice-surface* v1-48)
+  (set! (-> v1-48 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-48 touch-hook) nothing)
+  (set! (-> v1-48 active-hook) nothing)
+  )
+
+(let ((v1-49
+       (new 'static 'surface
+            :name '*tread-surface*
+            :turnv 1.000000
+            :turnvv 1.000000
+            :tiltv 1.000000
+            :tiltvv 1.000000
+            :transv-max 1.000000
+            :target-speed 1.000000
+            :seek0 122880.000000
+            :seek90 245760.000000
+            :seek180 409600.000000
+            :fric 122880.000000
+            :nonlin-fric-dist 4096.000000
+            :slip-factor 1.000000
+            :slope-up-factor 8192.000000
+            :slope-down-factor 8192.000000
+            :impact-fric 1.000000
+            :bend-speed 4.000000
+            :alignv 1.000000
+            :slope-up-traction 1.000000
+            :align-speed 1.000000
+            )
+        )
+      )
+  (define *tread-surface* v1-49)
+  (set! (-> v1-49 mult-hook) (the (function surface surface surface int none) nothing))
+  (set! (-> v1-49 touch-hook) nothing)
+  (set! (-> v1-49 active-hook) nothing)
+  )
+
+(define *standard-ground-surface* *stone-surface*)
+(define *swim-surface* *stone-surface*)

--- a/goal_src/engine/util/smush-control-h.gc
+++ b/goal_src/engine/util/smush-control-h.gc
@@ -5,3 +5,135 @@
 ;; name in dgo: smush-control-h
 ;; dgos: GAME, ENGINE
 
+;; A "smush-control" generates a damped sinusoidal floating point value.
+;;  - on each full period, the amplitude and period are changed (multiplied)
+;;  - there is a maximum duration.
+;;  - the amplitude is additionally linearly scaled to go to zero over the duration.
+
+(deftype smush-control (structure)
+  ((start-time  uint64  :offset-assert 0)
+   (period      float   :offset-assert 8)
+   (duration    float   :offset-assert 12)
+   (amp         float   :offset-assert 16)
+   (damp-amp    float   :offset-assert 20)
+   (damp-period float   :offset-assert 24) ;; set a negative value here to flag as die on next update
+   (ticks       float   :offset-assert 28)
+   )
+  :method-count-assert 15
+  :size-assert         #x20
+  :flag-assert         #xf00000020
+  (:methods
+   (set-zero! (_type_) _type_ 9)
+   (update! (_type_) float 10)
+   (get-no-update (_type_) float 11)
+   (activate! (_type_ float int int float float float) _type_ 12)
+   (nonzero-amplitude? (_type_) symbol 13)
+   (die-on-next-update! (_type_) _type_ 14)
+   )
+  )
+
+(defmethod nonzero-amplitude? smush-control ((obj smush-control))
+  (!= (-> obj amp) 0.000000)
+  )
+
+(defmethod set-zero! smush-control ((obj smush-control))
+  (set! (-> obj period) 0.000000)
+  (set! (-> obj duration) 0.000000)
+  (set! (-> obj amp) 0.000000)
+  (set! (-> obj damp-amp) 0.000000)
+  (set! (-> obj damp-period) 0.000000)
+  (set! (-> obj ticks) 0.000000)
+  obj
+  )
+
+(defmethod update! smush-control ((obj smush-control))
+  "Run the smush control and return the result. Updates the internal state."
+  (local-vars (period float) (time-since-period-start float) (time-since-start float))
+  (cond
+    ((!= (-> obj amp) 0.000000)
+     (set! time-since-start
+           (the float (- (-> *display* base-frame-counter) (-> obj start-time)))
+           )
+     (set! period (-> obj period))
+     ;; use float to int rounding to figure out offset into the current period.
+     (set! time-since-period-start (- time-since-start
+                                      (* (the float (the int (/ time-since-start period))) period))
+           )
+     ;; we completed a new period!
+     (when (>= (- time-since-start (-> obj ticks)) (-> obj period))
+       ;; once per period updates of amp/period
+       (set! (-> obj amp) (* (-> obj amp) (-> obj damp-amp)))
+       (set! (-> obj period) (* (-> obj period) (-> obj damp-period)))
+       ;; store the ticks that we did this on
+       (set! (-> obj ticks) time-since-start)
+       ;; you can set damp-period to a negative number to indicate
+       ;; that it should die on the next update. Do that here.
+       (if (< (-> obj damp-period) 0.000000)
+           (set-zero! obj)
+           )
+       )
+
+     ;; absolute duraction check
+     (if (>= time-since-start (-> obj duration))
+         (set-zero! obj)
+         )
+     ;; sine term multiplied by amplitude, and scaled by how much is left to go.
+     (* (sin (/ (* 65536.000000 time-since-period-start) (-> obj period)))
+        (* (-> obj amp)
+           (/ (- (-> obj duration) time-since-start) (-> obj duration)))
+        )
+     )
+    ;; amplitude = 0, die.
+    (else 0.000000)
+    )
+  )
+
+(defmethod get-no-update smush-control ((obj smush-control))
+  "Get the value, but don't update internal state"
+  (local-vars (f0-2 float) (f0-4 float) (f30-0 float))
+  (cond
+    ((!= (-> obj amp) 0.000000)
+     (set! f30-0
+           (the float (- (-> *display* base-frame-counter) (-> obj start-time)))
+           )
+     (set! f0-2 (-> obj period))
+     (set! f0-4 (- f30-0 (* (the float (the int (/ f30-0 f0-2))) f0-2)))
+     (* (sin (/ (* 65536.000000 f0-4) (-> obj period)))
+        (* (-> obj amp) (/ (- (-> obj duration) f30-0) (-> obj duration)))
+        )
+     )
+    (else 0.000000)
+    )
+  )
+
+(defmethod die-on-next-update! smush-control ((obj smush-control))
+  "On the next call to update!, zero everything.
+   Calls to get-no-update will still work."
+  (when (!= (-> obj amp) 0.000000)
+    (set! (-> obj damp-period) -1.000000)
+    )
+  obj
+  )
+
+(defmethod activate! smush-control ((obj smush-control)
+                                    (arg0 float)
+                                    (arg1 int)
+                                    (arg2 int)
+                                    (arg3 float)
+                                    (arg4 float)
+                                    (arg5 float)
+                                    )
+  "Activate the smush! This only activates if the ongoing smush is mostly done."
+  (when (>= (fabs (* 0.2 (-> obj amp)))
+            (fabs (get-no-update obj))
+            )
+    (set! (-> obj amp) arg0)
+    (set! (-> obj period) (the float arg1))
+    (set! (-> obj duration) (the float arg2))
+    (set! (-> obj damp-amp) arg3)
+    (set! (-> obj damp-period) arg4)
+    (set! (-> obj ticks) 0.000000)
+    (set! (-> obj start-time) (-> *display* base-frame-counter))
+    )
+  obj
+  )

--- a/goal_src/engine/util/sync-info-h.gc
+++ b/goal_src/engine/util/sync-info-h.gc
@@ -5,3 +5,154 @@
 ;; name in dgo: sync-info-h
 ;; dgos: GAME, ENGINE
 
+(deftype sync-info (structure)
+  ((offset float   :offset-assert 0)
+   (period uint32  :offset-assert 4)
+   )
+  :method-count-assert 18
+  :size-assert         #x8
+  :flag-assert         #x1200000008
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    )
+  )
+
+(deftype sync-info-eased (sync-info)
+  ((tlo    float   :offset-assert 8)
+   (thi    float   :offset-assert 12)
+   (ylo    float   :offset-assert 16)
+   (m2     float   :offset-assert 20)
+   (yend   float   :offset-assert 24)
+   )
+  :method-count-assert 18
+  :size-assert         #x1c
+  :flag-assert         #x120000001c
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    )
+  )
+
+(deftype sync-info-paused (sync-info)
+  ((pause-after-out float   :offset-assert 8)
+   (pause-after-in  float   :offset-assert 12)
+   )
+  :method-count-assert 18
+  :size-assert         #x10
+  :flag-assert         #x1200000010
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    (dummy-13 () none 13)
+    (dummy-14 () none 14)
+    (dummy-15 () none 15)
+    (dummy-16 () none 16)
+    (dummy-17 () none 17)
+    )
+  )
+
+(deftype delayed-rand-float (structure)
+  ((min-time   int32   :offset-assert 0)
+   (max-time   int32   :offset-assert 4)
+   (max-val    float   :offset-assert 8)
+   (timer      int32   :offset-assert 12)
+   (start-time uint64  :offset-assert 16)
+   (value      float   :offset-assert 24)
+   )
+  :method-count-assert 11
+  :size-assert         #x1c
+  :flag-assert         #xb0000001c
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    )
+  )
+
+(deftype oscillating-float (structure)
+  ((value   float  :offset-assert 0)
+   (target  float  :offset-assert 4)
+   (vel     float  :offset-assert 8)
+   (max-vel float  :offset-assert 12)
+   (damping float  :offset-assert 16)
+   (accel   float  :offset-assert 20)
+   )
+  :method-count-assert 11
+  :size-assert         #x18
+  :flag-assert         #xb00000018
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    )
+  )
+
+(deftype bouncing-float (structure)
+  ((osc        oscillating-float :inline :offset-assert 0)
+   (max-value  float                     :offset-assert 24)
+   (min-value  float                     :offset-assert 28)
+   (elasticity float                     :offset-assert 32)
+   (state      int32                     :offset-assert 36)
+   )
+  :method-count-assert 13
+  :size-assert         #x28
+  :flag-assert         #xd00000028
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    )
+  )
+
+(deftype delayed-rand-vector (structure)
+  ((min-time   int32          :offset-assert 0)
+   (max-time   int32          :offset-assert 4)
+   (xz-max     float          :offset-assert 8)
+   (y-max      float          :offset-assert 12)
+   (timer      int32          :offset-assert 16)
+   (start-time uint64         :offset-assert 24)
+   (value      vector :inline :offset-assert 32)
+   )
+  :method-count-assert 13
+  :size-assert         #x30
+  :flag-assert         #xd00000030
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    (dummy-11 () none 11)
+    (dummy-12 () none 12)
+    )
+  )
+
+(deftype oscillating-vector (structure)
+  ((value   vector :inline :offset-assert 0)
+   (target  vector :inline :offset-assert 16)
+   (vel     vector :inline :offset-assert 32)
+   (max-vel float          :offset-assert 48)
+   (damping float          :offset-assert 52)
+   (accel   float          :offset-assert 56)
+   )
+  :method-count-assert 11
+  :size-assert         #x3c
+  :flag-assert         #xb0000003c
+  (:methods
+    (dummy-9 () none 9)
+    (dummy-10 () none 10)
+    )
+  )


### PR DESCRIPTION
Changes a bug where `(asize-of x)` returns the wrong thing for objects of types which did not define their own `asize-of` method and instead inherited from `basic`.

Fix regression from https://github.com/water111/jak-project/pull/292 where the decompiler would abort when it had an error.

Improve printing of data decompilation.

Decompile a few files, pat-h surface-h. Started on `fact-h`.