### PR TITLE
[Compiler] Support dynamically constructed bitfields

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -131,3 +131,4 @@
 - Fixed a bug where 128-bit variable spills could be misaligned, causing a segfault at `vmovaps`.
 - Added `.ppach` and `.pceqw`
 - Fixed a bug where setting 128-bit / 64-bit variables from each other only did a 32-bit set
+- Added support for creating a static bitfield where fields may not be known at compile time.

--- a/doc/goal_doc.md
+++ b/doc/goal_doc.md
@@ -1729,9 +1729,11 @@ Because these objects are uninitialized, you cannot provide constructor argument
 You cannot use this on dynamically sized member types. However, the array size can be determined at runtime.
 
 ### Static Objects
-You can create a static object with `(new 'static 'obj-type [field-def]...)`. For now it must be a structure or basic.
-Each field def looks like `:field-name field-value`. The `field-value` is evaluated at compile time. For now, fields
-can only be integers, floats, or symbols.
+You can create a static object with `(new 'static 'obj-type [field-def]...)`. It can be a structure, basic, bitfield, array, boxed array, or inline array.
+Each field def looks like `:field-name field-value`. The `field-value` is evaluated at compile time. Fields
+can be integers, floats, symbols, pairs, strings, or other statics. These field values may come from macros or GOAL constants.
+
+For bitfields, there is an exception, and fields can be set to expression that are not known at compile time.  The compiler will generate the appropriate code to combine the values known at compile time and run time. This exception does not apply to a bitfield inside of another `(new 'static ...)`.
 
 Fields which aren't explicitly initialized are zeroed, except for the type field of basics, which is properly initialized to the correct type.
 

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -167,7 +167,7 @@ class Compiler {
                                   const std::string& method_type_name = "");
 
   bool try_getting_constant_integer(const goos::Object& in, int64_t* out, Env* env);
-  float try_getting_constant_float(const goos::Object& in, float* out, Env* env);
+  bool try_getting_constant_float(const goos::Object& in, float* out, Env* env);
   Val* compile_heap_new(const goos::Object& form,
                         const std::string& allocation,
                         const goos::Object& type,
@@ -286,17 +286,15 @@ class Compiler {
                                              const TypeSpec& type,
                                              const goos::Object& field_defs,
                                              Env* env);
-  Val* compile_new_static_bitfield(const goos::Object& form,
-                                   const TypeSpec& type,
-                                   const goos::Object& field_defs,
-                                   Env* env);
   Val* compile_static_pair(const goos::Object& form, Env* env);
   StaticResult compile_static(const goos::Object& form, Env* env);
   StaticResult compile_static_no_eval_for_pairs(const goos::Object& form, Env* env);
-  StaticResult compile_static_bitfield(const goos::Object& form,
-                                       const TypeSpec& type,
-                                       const goos::Object& _field_defs,
-                                       Env* env);
+
+  Val* compile_bitfield_definition(const goos::Object& form,
+                                   const TypeSpec& type,
+                                   const goos::Object& _field_defs,
+                                   bool allow_dynamic_construction,
+                                   Env* env);
   StaticResult compile_new_static_structure(const goos::Object& form,
                                             const TypeSpec& type,
                                             const goos::Object& _field_defs,

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -231,7 +231,7 @@ bool Compiler::try_getting_constant_integer(const goos::Object& in, int64_t* out
   return false;
 }
 
-float Compiler::try_getting_constant_float(const goos::Object& in, float* out, Env* env) {
+bool Compiler::try_getting_constant_float(const goos::Object& in, float* out, Env* env) {
   (void)env;
   if (in.is_float()) {
     *out = in.as_float();

--- a/goalc/compiler/Val.h
+++ b/goalc/compiler/Val.h
@@ -243,6 +243,7 @@ class IntegerConstantVal : public Val {
   IntegerConstantVal(TypeSpec ts, s64 value) : Val(std::move(ts)), m_value(value) {}
   std::string print() const override { return "integer-constant-" + std::to_string(m_value); }
   RegVal* to_reg(Env* fe) override;
+  s64 value() const { return m_value; }
 
  protected:
   s64 m_value = -1;

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -783,13 +783,11 @@ Val* Compiler::compile_static_new(const goos::Object& form,
     }
 
     if (is_bitfield(type_of_object)) {
-      return compile_new_static_bitfield(form, type_of_object, *rest, env);
+      return compile_bitfield_definition(form, type_of_object, *rest, true, env);
     }
   }
 
-  throw_compiler_error(form,
-                       "Cannot do a static new of a {} because it is not a bitfield or structure.",
-                       type.print());
+  throw_compiler_error(form, "Cannot allocate a static object of type {}", type.print());
   return get_none();
 }
 

--- a/test/goalc/source_templates/with_game/test-static-bitfield.gc
+++ b/test/goalc/source_templates/with_game/test-static-bitfield.gc
@@ -7,7 +7,7 @@
    )
   )
 
-(let ((temp (new 'static 'test-bf-type7 :f1 #x12 :f2 #x13 :f3 12.3433 :f4 #x1)))
+(let ((temp (new 'static 'test-bf-type7 :f1 #x12 :f2 (+ #x10 3 #x100) :f3 12.3433 :f4 ((lambda () 1)))))
   (format #t "~A" (eq? 0 (-> temp f5))) ; check it gets truncated
   (format #t "~f~%" (+ (-> temp f3) (-> temp f2) (-> temp f1) (-> temp f4)))
   )


### PR DESCRIPTION
The compiler will now accept bifield defintions like
```lisp
(new 'static 'test-bf-type7 :f1 #x12 :f2 (+ #x10 3 #x100) :f3 12.3433 :f4 ((lambda () 1)))
```

It works just like GOAL and will combine all fields known at compile time, then `or` in the others:
```asm
  [0x10031] mov rax, 0x20A2BF14000012              mov-ic igpr-11, 9186140812738578
  [0x1003b] mov ecx, 0x10                          mov-ic igpr-13, 16
  [0x10040] mov edx, 0x03                          mov-ic igpr-14, 3
  [0x10045] add rcx, rdx                           addi igpr-12, igpr-14
  [0x10048] mov edx, 0x100                         mov-ic igpr-15, 256
  [0x1004d] add rcx, rdx                           addi igpr-12, igpr-15
  [0x10050] shl rcx, 0x39                          shl igpr-12, 57
  [0x10054] shr rcx, 0x29                          shr igpr-12, 41
  [0x10058] or rax, rcx                            or igpr-11, igpr-12
  [0x1005b] mov ecx, 0x01                          mov-ic igpr-16, 1
  [0x10060] shl rcx, 0x3F                          shl igpr-16, 63
  [0x10064] shr rcx, 0x08                          shr igpr-16, 8
  [0x10068] or rax, rcx                            or igpr-11, igpr-16
```