### PR TITLE
decomp: Avoid `'` in error output

### DIFF
--- a/decompiler/IR2/AtomicOpTypeAnalysis.cpp
+++ b/decompiler/IR2/AtomicOpTypeAnalysis.cpp
@@ -85,7 +85,7 @@ TP_Type SimpleAtom::get_type(const TypeState& input,
       // look up the type of the symbol
       auto type = dts.symbol_types.find(m_string);
       if (type == dts.symbol_types.end()) {
-        throw std::runtime_error("Don't have the type of symbol " + m_string);
+        throw std::runtime_error("Do not have the type of symbol " + m_string);
       }
 
       if (type->second == TypeSpec("type")) {
@@ -131,8 +131,8 @@ TP_Type SimpleAtom::get_type(const TypeState& input,
       if (hint_kv != env.label_types().end()) {
         return TP_Type::make_from_ts(dts.parse_type_spec(hint_kv->second.type_name));
       }
-      // throw std::runtime_error("IR_StaticAddress couldn't figure out the type: " + label.name);
-      lg::error("IR_StaticAddress doesn't know the type of {}", label.name);
+      // throw std::runtime_error("IR_StaticAddress could not figure out the type: " + label.name);
+      lg::error("IR_StaticAddress does not know the type of {}", label.name);
       return TP_Type::make_from_ts("object");
     }
     case Kind::INVALID:
@@ -195,7 +195,7 @@ TP_Type SimpleExpression::get_type(const TypeState& input,
     case Kind::PCPYLD:
       return TP_Type::make_from_ts("uint");
     default:
-      throw std::runtime_error("Simple expression can't get_type: " +
+      throw std::runtime_error("Simple expression cannot get_type: " +
                                to_form(env.file->labels, env).print());
   }
   return {};
@@ -488,7 +488,7 @@ TP_Type SimpleExpression::get_type_int2(const TypeState& input,
     return TP_Type::make_from_ts(TypeSpec("int"));
   }
 
-  throw std::runtime_error(fmt::format("Can't get_type_int2: {}, args {} and {}",
+  throw std::runtime_error(fmt::format("Cannot get_type_int2: {}, args {} and {}",
                                        to_form(env.file->labels, env).print(), arg0_type.print(),
                                        arg1_type.print()));
 }
@@ -855,7 +855,7 @@ TP_Type LoadVarOp::get_src_type(const TypeState& input,
   throw std::runtime_error(
       fmt::format("Could not get type of load: {}. ", to_form(env.file->labels, env).print()));
 
-  throw std::runtime_error("LoadVarOp can't get_src_type: " +
+  throw std::runtime_error("LoadVarOp cannot get_src_type: " +
                            to_form(env.file->labels, env).print());
 }
 
@@ -935,11 +935,11 @@ TypeState CallOp::propagate_types_internal(const TypeState& input,
   auto in_type = in_tp.typespec();
 
   if (in_type.base_type() != "function") {
-    throw std::runtime_error("Called something that wasn't a function: " + in_type.print());
+    throw std::runtime_error("Called something that was not a function: " + in_type.print());
   }
 
   if (in_type.arg_count() < 1) {
-    throw std::runtime_error("Called a function, but we don't know its type");
+    throw std::runtime_error("Called a function, but we do not know its type");
   }
 
   if (in_type.arg_count() == 2 && in_type.get_arg(0) == TypeSpec("_varargs_")) {

--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -2784,7 +2784,7 @@ void AtomicOpElement::push_to_stack(const Env& env, FormPool& pool, FormStack& s
     return;
   }
 
-  throw std::runtime_error("Can't push atomic op to stack: " + m_op->to_string(env));
+  throw std::runtime_error("Cannot push atomic op to stack: " + m_op->to_string(env));
 }
 
 void AsmOpElement::push_to_stack(const Env& env, FormPool& pool, FormStack& stack) {
@@ -2834,7 +2834,7 @@ void DynamicMethodAccess::update_from_stack(const Env& env,
   auto matcher = Matcher::fixed_op(FixedOperatorKind::ADDITION, {sll_matcher, reg1_matcher});
   auto match_result = match(matcher, new_val);
   if (!match_result.matched) {
-    throw std::runtime_error("Couldn't match DynamicMethodAccess values: " +
+    throw std::runtime_error("Could not match DynamicMethodAccess values: " +
                              new_val->to_string(env));
   }
 
@@ -2950,7 +2950,7 @@ void ArrayFieldAccess::update_with_val(Form* new_val,
       auto matcher = Matcher::fixed_op(FixedOperatorKind::ADDITION, {reg0_matcher, reg1_matcher});
       auto match_result = match(matcher, new_val);
       if (!match_result.matched) {
-        throw std::runtime_error("Couldn't match ArrayFieldAccess (stride 1) values: " +
+        throw std::runtime_error("Could not match ArrayFieldAccess (stride 1) values: " +
                                  new_val->to_string(env));
       }
       auto idx = match_result.maps.forms.at(0);
@@ -2985,7 +2985,7 @@ void ArrayFieldAccess::update_with_val(Form* new_val,
         matcher = Matcher::fixed_op(FixedOperatorKind::ADDITION, {reg1_matcher, sll_matcher});
         match_result = match(matcher, new_val);
         if (!match_result.matched) {
-          throw std::runtime_error("Couldn't match ArrayFieldAccess (stride power of 2) values: " +
+          throw std::runtime_error("Could not match ArrayFieldAccess (stride power of 2) values: " +
                                    new_val->to_string(env));
         }
       }

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -1024,6 +1024,6 @@ const DecompilerLabel& LinkedObjectFile::get_label_by_name(const std::string& na
       return label;
     }
   }
-  throw std::runtime_error("Can't find label " + name);
+  throw std::runtime_error("Cannot find label " + name);
 }
 }  // namespace decompiler

--- a/decompiler/ObjectFile/ObjectFileDB.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB.cpp
@@ -289,13 +289,13 @@ void ObjectFileDB::add_obj_from_dgo(const std::string& obj_name,
   if (!dgo_obj_name_map.empty()) {
     auto dgo_kv = dgo_obj_name_map.find(strip_dgo_extension(dgo_name));
     if (dgo_kv == dgo_obj_name_map.end()) {
-      lg::error("Object {} is from DGO {}, but this DGO wasn't in the map.", obj_name, dgo_name);
+      lg::error("Object {} is from DGO {}, but this DGO was not in the map.", obj_name, dgo_name);
       assert(false);
     }
 
     auto name_kv = dgo_kv->second.find(obj_name);
     if (name_kv == dgo_kv->second.end()) {
-      lg::error("Object {} from DGO {} wasn't found in the name map.", obj_name, dgo_name);
+      lg::error("Object {} from DGO {} was not found in the name map.", obj_name, dgo_name);
       assert(false);
     }
     data.name_from_map = name_kv->second;

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -18,7 +18,7 @@ goos::Object& car(goos::Object& pair) {
   if (pair.is_pair()) {
     return pair.as_pair()->car;
   } else {
-    throw std::runtime_error("car called on something that wasn't a pair: " + pair.print());
+    throw std::runtime_error("car called on something that was not a pair: " + pair.print());
   }
 }
 
@@ -26,7 +26,7 @@ goos::Object& cdr(goos::Object& pair) {
   if (pair.is_pair()) {
     return pair.as_pair()->cdr;
   } else {
-    throw std::runtime_error("cdr called on something that wasn't a pair");
+    throw std::runtime_error("cdr called on something that was not a pair");
   }
 }
 

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -122,7 +122,7 @@ goos::Object decompile_at_label_guess_type(const DecompilerLabel& label,
                                            const TypeSystem& ts) {
   auto guessed_type = get_type_of_label(label, words);
   if (!guessed_type.has_value()) {
-    throw std::runtime_error("Couldn't guess the type of " + label.name);
+    throw std::runtime_error("Could not guess the type of " + label.name);
   }
   return decompile_at_label(*guessed_type, label, labels, words, ts);
 }
@@ -317,7 +317,7 @@ goos::Object decompile_structure(const TypeSpec& type,
       assert(field.name() == "type" && field.offset() == 0);
       auto& word = obj_words.at(0);
       if (word.kind != LinkedWord::TYPE_PTR) {
-        throw std::runtime_error("Basic doesn't start with type pointer");
+        throw std::runtime_error("Basic does not start with type pointer");
       }
 
       if (word.symbol_name != actual_type.base_type()) {


### PR DESCRIPTION
Removing instances where `'` is used in error output, as this breaks editor syntax highlighting (assumes theres a string literal)

![image](https://user-images.githubusercontent.com/13153231/117244628-622c3300-ae07-11eb-9252-9e459c5029aa.png)
vs
![image](https://user-images.githubusercontent.com/13153231/117244643-69534100-ae07-11eb-9e40-425aa7a1929a.png)
