### PR TITLE
[runtime] prevent deadlock during tests

### DIFF
--- a/game/system/vm/vm.cpp
+++ b/game/system/vm/vm.cpp
@@ -82,7 +82,9 @@ void subscribe_component() {
     throw std::runtime_error("[VM] Cannot add new components when VM is dead!");
   }
 
+  status_mutex.lock();
   ++components;
+  status_mutex.unlock();
 
   // stall component until VM is ready
   if (status == Status::Uninited) {
@@ -91,7 +93,9 @@ void subscribe_component() {
 }
 
 void unsubscribe_component() {
+  status_mutex.lock();
   --components;
+  status_mutex.unlock();
   vm_dead_cv.notify_all();
 }
 


### PR DESCRIPTION
The tests got stuck here:
```
[DECI2] Got message: 24 0 0xe042 H -> E
IOP shut down
DMA shut down
dconnect: closed socket at kernel side
[2021-05-12 22:05:47:686] [debug] [VM] Killing
[2021-05-12 22:05:47:686] [debug] [SYSTEM] Thread VM-DMAC is returning
[Listener] Closed connection to target
```

The runtime was stuck at `vm_dead_cv.wait(lk, [&] { return components == 0; });`
I think due to a race condition decrementing components and wait_vm_dead going to sleep
```
  --components; // no mutex locked
  vm_dead_cv.notify_all();
```
and
```
  std::unique_lock<std::mutex> lk(status_mutex);

  vm_dead_cv.wait(lk, [&] { return components == 0; });
```