### PR TITLE
[decompiler] fix `(gpr->fpr` when an integer arg is converted to float

### DIFF
--- a/decompiler/IR2/Env.cpp
+++ b/decompiler/IR2/Env.cpp
@@ -489,6 +489,12 @@ void Env::disable_def(const RegisterAccess& access, DecompWarnings& warnings) {
   }
 }
 
+void Env::disable_use(const RegisterAccess& access) {
+  if (has_local_vars()) {
+    m_var_names.disable_use(access);
+  }
+}
+
 /*!
  * Set the stack hints. This must be done before type analysis.
  * This actually parses the types, so it should be done after the dts is set up.

--- a/decompiler/IR2/Env.h
+++ b/decompiler/IR2/Env.h
@@ -162,11 +162,7 @@ class Env {
   const std::vector<StackVarEntry>& stack_var_hints() const { return m_stack_vars; }
 
   const UseDefInfo& get_use_def_info(const RegisterAccess& ra) const;
-  void disable_use(const RegisterAccess& access) {
-    if (has_local_vars()) {
-      m_var_names.disable_use(access);
-    }
-  }
+  void disable_use(const RegisterAccess& access);
 
   void disable_def(const RegisterAccess& access, DecompWarnings& warnings);
 

--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -143,9 +143,14 @@ void pop_helper(const std::vector<RegisterAccess>& vars,
           submit_reg_to_var.push_back(var_idx);
           submit_regs.push_back(var.reg());
         } else {
-          //          fmt::print("Unsafe to pop {}: used {} times, def {} times, expected use {}\n",
-          //                     var.to_string(env), use_def.use_count(), use_def.def_count(),
-          //                     times);
+          /*auto var_id = env.get_program_var_id(var);
+          fmt::print(
+              "Unsafe to pop {}: used {} times, def {} times, expected use {} ({} {} rd: {}) ({}
+             {})\n", var.to_string(env), use_def.use_count(), use_def.def_count(), times,
+              var.reg().to_string(), var.idx(), var.mode() == AccessMode::READ,
+             var_id.reg.to_string(), var_id.id);
+              */
+
           //          if (var.to_string(env) == "a3-0") {
           //            for (auto& use : use_def.uses) {
           //              if (!use.disabled) {

--- a/decompiler/analysis/variable_naming.h
+++ b/decompiler/analysis/variable_naming.h
@@ -111,6 +111,7 @@ struct SSA {
     std::vector<VarSSA> src;
     int op_id = -1;
     bool is_arg_coloring_move = false;
+    bool is_gpr_fpr_coloring_move = false;
     bool is_dead_set = false;
 
     std::string print(const VarMapSSA& var_map) const;

--- a/scripts/update_decomp_reference.py
+++ b/scripts/update_decomp_reference.py
@@ -1,0 +1,36 @@
+import os
+import glob
+import argparse
+import shutil
+
+## Script to update failing _REF.gc files
+## Instructions:
+##  run offline-test with the `--dump-mode` flag set. This generates a "failures" folder.
+## update reference like this
+##    python3 ../scripts/update_decomp_reference.py ./failures ../test/decompiler/reference
+
+def get_goal_files(root_dir):
+	return [f for file in os.walk(root_dir) for f in glob.glob(os.path.join(file[0], '*.gc'))]
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(dest='diff', help='the failures folder')
+    parser.add_argument(dest='reference', help='the test/decompiler/reference folder')
+    args = parser.parse_args()
+
+    location_map = {os.path.basename(x) : x for x in get_goal_files(args.reference)}
+
+    replacements = []
+
+    for replacement in get_goal_files(args.diff):
+    	base = os.path.basename(replacement)
+    	if base not in location_map:
+    		print("Could not find file {}".format(base))
+    		exit(-1)
+    	print("replace {} with {}".format(location_map[base], replacement))
+    	shutil.copyfile(replacement, location_map[base])
+
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_decomp_reference.py
+++ b/scripts/update_decomp_reference.py
@@ -20,8 +20,6 @@ def main():
 
     location_map = {os.path.basename(x) : x for x in get_goal_files(args.reference)}
 
-    replacements = []
-
     for replacement in get_goal_files(args.diff):
     	base = os.path.basename(replacement)
     	if base not in location_map:

--- a/test/decompiler/reference/all_forward_declarations.gc
+++ b/test/decompiler/reference/all_forward_declarations.gc
@@ -97,9 +97,6 @@
   '(none)
   )
 
-(defmacro gpr->fpr (in)
-  in)
-
 (define-extern get-current-time (function uint))
 (define-extern get-integral-current-time (function uint))
 

--- a/test/decompiler/reference/engine/gfx/font-h_REF.gc
+++ b/test/decompiler/reference/engine/gfx/font-h_REF.gc
@@ -119,18 +119,14 @@
 
 ;; definition for method 10 of type font-context
 (defmethod set-origin! font-context ((obj font-context) (x int) (y int))
-  (let ((x (gpr->fpr x)))
-   (set! (-> obj origin x) (the float x))
-   )
+  (set! (-> obj origin x) (the float x))
   (set! (-> obj origin y) (the float y))
   obj
   )
 
 ;; definition for method 11 of type font-context
 (defmethod set-depth! font-context ((obj font-context) (z int))
-  (let ((z (gpr->fpr z)))
-   (set! (-> obj origin z) (the float z))
-   )
+  (set! (-> obj origin z) (the float z))
   obj
   )
 
@@ -142,17 +138,13 @@
 
 ;; definition for method 13 of type font-context
 (defmethod set-width! font-context ((obj font-context) (width int))
-  (let ((width (gpr->fpr width)))
-   (set! (-> obj width) (the float width))
-   )
+  (set! (-> obj width) (the float width))
   obj
   )
 
 ;; definition for method 14 of type font-context
 (defmethod set-height! font-context ((obj font-context) (height int))
-  (let ((height (gpr->fpr height)))
-   (set! (-> obj height) (the float height))
-   )
+  (set! (-> obj height) (the float height))
   obj
   )
 

--- a/test/decompiler/reference/engine/gfx/hw/gs_REF.gc
+++ b/test/decompiler/reference/engine/gfx/hw/gs_REF.gc
@@ -1159,15 +1159,9 @@
 ;; definition for function draw-context-set-xy
 ;; INFO: Return type mismatch int vs none.
 (defun draw-context-set-xy ((ctxt draw-context) (x int) (y int))
-  (let* ((y (gpr->fpr y))
-         (v0-0 (the int (* (the float y) (-> *video-parms* relative-y-scale))))
-         )
+  (let ((v0-0 (the int (* (the float y) (-> *video-parms* relative-y-scale)))))
    (set! (-> ctxt orgx) x)
    (set! (-> ctxt orgy) v0-0)
    )
   (none)
   )
-
-
-
-

--- a/test/decompiler/reference/engine/math/math_REF.gc
+++ b/test/decompiler/reference/engine/math/math_REF.gc
@@ -46,9 +46,7 @@
 
 ;; definition for function log2
 (defun log2 ((arg0 int))
-  (let ((arg0 (gpr->fpr arg0)))
-   (+ (sar (the-as int (the float arg0)) 23) -127)
-   )
+  (+ (sar (the-as int (the float arg0)) 23) -127)
   )
 
 ;; definition for function seek
@@ -226,4 +224,3 @@
 ;; failed to figure out what this is:
 (let ((v0-6 0))
   )
-

--- a/test/decompiler/reference/engine/ps2/pad_REF.gc
+++ b/test/decompiler/reference/engine/ps2/pad_REF.gc
@@ -180,8 +180,7 @@
 (defun
   analog-input
   ((in int) (offset float) (center-val float) (max-val float) (out-range float))
-  (let* ((in (gpr->fpr in))
-         (offset-in (- (the float in) offset))
+  (let* ((offset-in (- (the float in) offset))
          (magnitude (- (fabs offset-in) center-val))
          (max-magnitude (- max-val center-val))
          )
@@ -367,7 +366,3 @@
 ;; failed to figure out what this is:
 (let ((v0-4 0))
   )
-
-
-
-

--- a/test/decompiler/test_FormExpressionBuild2.cpp
+++ b/test/decompiler/test_FormExpressionBuild2.cpp
@@ -1135,3 +1135,22 @@ TEST_F(FormRegressionTest, StupidFloatMove) {
       "  )";
   test_with_expr(func, type, expected);
 }
+
+// gpr->fpr not being propagated
+TEST_F(FormRegressionTest, Method11FontContext) {
+  std::string func =
+      "sll r0, r0, 0\n"
+      "    mtc1 f0, a1\n"
+      "    cvt.s.w f0, f0\n"
+      "    swc1 f0, 20(a0)\n"
+      "    or v0, a0, r0\n"
+      "    jr ra\n"
+      "    daddu sp, sp, r0";
+  std::string type = "(function font-context int font-context)";
+  std::string expected =
+      "(begin\n"
+      "  (set! (-> arg0 origin z) (the float arg1))\n"
+      "  arg0\n"
+      "  )";
+  test_with_expr(func, type, expected);
+}


### PR DESCRIPTION
The decompiler misrecognized the gpr->fpr as an "argument coloring move" so the use/def info was wrong.  Now it will only recognize `mtc1`'s as coloring moves if the argument is a float.

To make this work, I disabled coloring move recognition unless we have function types.

Also added a script for updating the reference automatically from the result of a failed `offline-tests` run.