### PR TITLE
[decompiler] add config option for changing cond splitting behavior

### DIFF
--- a/decompiler/Function/CfgVtx.h
+++ b/decompiler/Function/CfgVtx.h
@@ -317,7 +317,7 @@ class ControlFlowGraph {
   void link_fall_through(BlockVtx* first, BlockVtx* second, std::vector<BasicBlock>& blocks);
   void link_fall_through_likely(BlockVtx* first, BlockVtx* second, std::vector<BasicBlock>& blocks);
   void link_branch(BlockVtx* first, BlockVtx* second, std::vector<BasicBlock>& blocks);
-  bool find_cond_w_else();
+  bool find_cond_w_else(const CondWithElseLengthHack& hacks);
   bool find_cond_w_empty_else();
   bool find_cond_n_else();
 
@@ -382,6 +382,9 @@ class ControlFlowGraph {
 
 class LinkedObjectFile;
 class Function;
-std::shared_ptr<ControlFlowGraph> build_cfg(const LinkedObjectFile& file, int seg, Function& func);
+std::shared_ptr<ControlFlowGraph> build_cfg(const LinkedObjectFile& file,
+                                            int seg,
+                                            Function& func,
+                                            const CondWithElseLengthHack& cond_with_else_hack);
 }  // namespace decompiler
 #endif  // JAK_DISASSEMBLER_CFGVTX_H

--- a/decompiler/ObjectFile/ObjectFileDB.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB.cpp
@@ -717,7 +717,7 @@ void ObjectFileDB::analyze_functions_ir1(const Config& config) {
       // run analysis
 
       // build a control flow graph, just looking at branch instructions.
-      func.cfg = build_cfg(data.linked_data, segment_id, func);
+      func.cfg = build_cfg(data.linked_data, segment_id, func, {});
 
       // convert individual basic blocks to sequences of IR Basic Ops
       for (auto& block : func.basic_blocks) {

--- a/decompiler/ObjectFile/ObjectFileDB.h
+++ b/decompiler/ObjectFile/ObjectFileDB.h
@@ -69,7 +69,7 @@ class ObjectFileDB {
   void analyze_functions_ir2(const std::string& output_dir, const Config& config);
   void ir2_top_level_pass(const Config& config);
   void ir2_stack_spill_slot_pass();
-  void ir2_basic_block_pass();
+  void ir2_basic_block_pass(const Config& config);
   void ir2_atomic_op_pass(const Config& config);
   void ir2_type_analysis_pass(const Config& config);
   void ir2_register_usage_pass();
@@ -80,8 +80,8 @@ class ObjectFileDB {
   void ir2_insert_lets();
   void ir2_rewrite_inline_asm_instructions();
   void ir2_insert_anonymous_functions();
-  void ir2_write_results(const std::string& output_dir);
-  std::string ir2_to_file(ObjectFileData& data);
+  void ir2_write_results(const std::string& output_dir, const Config& config);
+  std::string ir2_to_file(ObjectFileData& data, const Config& config);
   std::string ir2_function_to_string(ObjectFileData& data, Function& function, int seg);
   std::string ir2_final_out(ObjectFileData& data,
                             const std::unordered_set<std::string>& skip_functions = {});

--- a/decompiler/analysis/variable_naming.cpp
+++ b/decompiler/analysis/variable_naming.cpp
@@ -419,7 +419,9 @@ SSA make_rc_ssa(const Function& function, const RegUsageInfo& rui, const Functio
       if (succ != -1) {
         for (auto reg : end_op_info.live) {
           // only update phis for variables that are actually live at the next block.
-          ssa.add_source_to_phi(succ, reg, current_regs.at(reg));
+          if (reg.get_kind() != Reg::VF) {
+            ssa.add_source_to_phi(succ, reg, current_regs.at(reg));
+          }
         }
       }
     }

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -49,6 +49,7 @@ Config read_config_file(const std::string& path_to_config_file) {
   config.hexdump_code = cfg.at("hexdump_code").get<bool>();
   config.hexdump_data = cfg.at("hexdump_data").get<bool>();
   config.dump_objs = cfg.at("dump_objs").get<bool>();
+  config.print_cfgs = cfg.at("print_cfgs").get<bool>();
 
   auto allowed = cfg.at("allowed_objects").get<std::vector<std::string>>();
   for (const auto& x : allowed) {
@@ -142,6 +143,14 @@ Config read_config_file(const std::string& path_to_config_file) {
       hacks_json.at("no_type_analysis_functions_by_name").get<std::unordered_set<std::string>>();
   config.hacks.types_with_bad_inspect_methods =
       hacks_json.at("types_with_bad_inspect_methods").get<std::unordered_set<std::string>>();
+
+  for (auto& entry : hacks_json.at("cond_with_else_max_lengths")) {
+    auto func_name = entry.at(0).get<std::string>();
+    auto cond_name = entry.at(1).get<std::string>();
+    auto max_len = entry.at(2).get<int>();
+    config.hacks.cond_with_else_len_by_func_name[func_name].max_length_by_start_block[cond_name] =
+        max_len;
+  }
   return config;
 }
 

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -42,12 +42,17 @@ struct StackVariableHint {
   int stack_offset = 0;     // where it's located on the stack (relative to sp after prologue)
 };
 
+struct CondWithElseLengthHack {
+  std::unordered_map<std::string, int> max_length_by_start_block;
+};
+
 struct DecompileHacks {
   std::unordered_set<std::string> types_with_bad_inspect_methods;
   std::unordered_set<std::string> no_type_analysis_functions_by_name;
   std::unordered_set<std::string> hint_inline_assembly_functions;
   std::unordered_set<std::string> asm_functions_by_name;
   std::unordered_set<std::string> pair_functions_by_name;
+  std::unordered_map<std::string, CondWithElseLengthHack> cond_with_else_len_by_func_name;
 };
 
 struct Config {
@@ -71,6 +76,7 @@ struct Config {
   bool hexdump_code = false;
   bool hexdump_data = false;
   bool dump_objs = false;
+  bool print_cfgs = false;
 
   std::unordered_set<std::string> allowed_objects;
   std::unordered_map<std::string, std::unordered_map<int, std::vector<TypeCast>>>

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -52,6 +52,8 @@
   "hexdump_data": false,
   // dump raw obj files
   "dump_objs": false,
+  // print control flow graph
+  "print_cfgs": false,
 
   ////////////////////////////
   // CONFIG FILES

--- a/decompiler/config/jak1_ntsc_black_label/hacks.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/hacks.jsonc
@@ -12,6 +12,13 @@
 
   "no_type_analysis_functions_by_name": [],
 
+  // this limits the number of cases in a cond.  The first argument is the name of the function.
+  // the second argument is the name of the first condition in the cond. Use print_cfg to find it out.
+  // The third argument is the number of cases. If you set it too small it may fail to build the CFG.
+  "cond_with_else_max_lengths":[
+    ["(method 20 res-lump)", "b0", 2]
+  ],
+
   // this provides a hint to the decompiler that these functions will have a lot of inline assembly.
   "hint_inline_assembly_functions": ["matrix-transpose!"],
 

--- a/docs/markdown/progress-notes/changelog.md
+++ b/docs/markdown/progress-notes/changelog.md
@@ -40,12 +40,10 @@
 - The `&+` form now works on `inline-array` and `structure`.
 - In the case where the type system would use a result type of `lca(none, x)`, the result type is now `none` instead of compiler abort.
 - The "none value" is now `(none)` instead of `none`
-
 - Creating a field of 128-bit value type no longer causes a compiler crash
 - 128-bit fields are inspected as `<cannot-print>`
 - Static fields can now contain floating point values
 - Fixed a bug where loading a float from an object and immediately using it math would cause a compiler crash
-
 - Arrays of value types can be created on the stack with `new`.
 
 ## V0.2
@@ -159,3 +157,5 @@
 
 ## V0.8 New Calling Convention for 128-bit
 - 128-bit values may now be used in function arguments and return values.
+- Fixed a bug where reader errors in `goal-lib.gc` or any error in `goos-lib.gs` would cause a crash
+- Fixed a bug where `''a` or similar repeated reader macros would generate a reader error.

--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -46,19 +46,23 @@ int main(int argc, char** argv) {
   lg::info("OpenGOAL Compiler {}.{}", versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
 
   // Init REPL
-  std::unique_ptr<Compiler> compiler = std::make_unique<Compiler>();
-
-  if (argument.empty()) {
-    ReplStatus status = ReplStatus::WANT_RELOAD;
-    while (status == ReplStatus::WANT_RELOAD) {
-      compiler = std::make_unique<Compiler>(std::make_unique<ReplWrapper>());
-      status = compiler->execute_repl(auto_listen);
-      if (status == ReplStatus::WANT_RELOAD) {
-        fmt::print("Reloading compiler...\n");
+  // the compiler may throw an exception if it fails to load its standard library.
+  try {
+    std::unique_ptr<Compiler> compiler = std::make_unique<Compiler>();
+    if (argument.empty()) {
+      ReplStatus status = ReplStatus::WANT_RELOAD;
+      while (status == ReplStatus::WANT_RELOAD) {
+        compiler = std::make_unique<Compiler>(std::make_unique<ReplWrapper>());
+        status = compiler->execute_repl(auto_listen);
+        if (status == ReplStatus::WANT_RELOAD) {
+          fmt::print("Reloading compiler...\n");
+        }
       }
+    } else {
+      compiler->run_front_end_on_string(argument);
     }
-  } else {
-    compiler->run_front_end_on_string(argument);
+  } catch (std::exception& e) {
+    fmt::print("Compiler Fatal Error: {}\n", e.what());
   }
 
   return 0;

--- a/test/decompiler/FormRegressionTest.cpp
+++ b/test/decompiler/FormRegressionTest.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<FormRegressionTest::TestData> FormRegressionTest::make_function(
   // analyze function prologue/epilogue
   test->func.analyze_prologue(test->file);
   // build control flow graph
-  test->func.cfg = build_cfg(test->file, 0, test->func);
+  test->func.cfg = build_cfg(test->file, 0, test->func, {});
   EXPECT_TRUE(test->func.cfg->is_fully_resolved());
   if (!test->func.cfg->is_fully_resolved()) {
     fmt::print("CFG:\n{}\n", test->func.cfg->to_dot());

--- a/test/test_goos.cpp
+++ b/test/test_goos.cpp
@@ -1255,6 +1255,14 @@ TEST(GoosSpecialForms, Quote) {
   }
 }
 
+TEST(GoosSpecialForms, DoubleQuote) {
+  Interpreter i;
+  e(i, "(define x ''y)");
+  EXPECT_EQ(e(i, "x"), "(quote y)");
+  e(i, "(define x `'`y)");
+  EXPECT_EQ(e(i, "x"), "(quote (quasiquote y))");
+}
+
 TEST(GoosSpecialForms, QuasiQuote) {
   Interpreter i;
   e(i, "(define x 'y)");


### PR DESCRIPTION
Also fixes bugs with `''a` and crashing when `goal-lib.gc` has reader errors.