### PR TITLE
[decompiler] Add pass to generate a symbol definition map file

### DIFF
--- a/decompiler/CMakeLists.txt
+++ b/decompiler/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
         analysis/insert_lets.cpp
         analysis/reg_usage.cpp
         analysis/stack_spill.cpp
+        analysis/symbol_def_map.cpp
         analysis/type_analysis.cpp
         analysis/variable_naming.cpp
 

--- a/decompiler/Function/Function.cpp
+++ b/decompiler/Function/Function.cpp
@@ -674,6 +674,7 @@ void Function::find_type_defs(LinkedObjectFile& file, DecompilerTypeSystem& dts)
         flag_label.offset += 4;
         u64 word2 = file.read_data_word(flag_label);
         word |= (word2 << 32);
+        types_defined.push_back(type_name);
         dts.add_type_flags(type_name, word);
         //        fmt::print("Flags are 0x{:x}\n", word);
         state = 0;

--- a/decompiler/Function/Function.h
+++ b/decompiler/Function/Function.h
@@ -166,6 +166,8 @@ class Function {
     bool expressions_succeeded = false;
   } ir2;
 
+  std::vector<std::string> types_defined;
+
  private:
   void check_epilogue(const LinkedObjectFile& file);
   void resize_first_block(int new_start, const LinkedObjectFile& file);

--- a/decompiler/ObjectFile/LinkedObjectFile.h
+++ b/decompiler/ObjectFile/LinkedObjectFile.h
@@ -5,9 +5,6 @@
  * An object file's data with linking information included.
  */
 
-#ifndef NEXT_LINKEDOBJECTFILE_H
-#define NEXT_LINKEDOBJECTFILE_H
-
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -135,5 +132,3 @@ class LinkedObjectFile {
   std::vector<std::unordered_map<int, int>> label_per_seg_by_offset;
 };
 }  // namespace decompiler
-
-#endif  // NEXT_LINKEDOBJECTFILE_H

--- a/decompiler/ObjectFile/ObjectFileDB.h
+++ b/decompiler/ObjectFile/ObjectFileDB.h
@@ -7,9 +7,6 @@
  * (there may be different object files with the same name sometimes)
  */
 
-#ifndef JAK2_DISASSEMBLER_OBJECTFILEDB_H
-#define JAK2_DISASSEMBLER_OBJECTFILEDB_H
-
 #include "common/util/assert.h"
 #include <string>
 #include <unordered_map>
@@ -80,6 +77,7 @@ class ObjectFileDB {
   void ir2_insert_lets();
   void ir2_rewrite_inline_asm_instructions();
   void ir2_insert_anonymous_functions();
+  void ir2_symbol_definition_map(const std::string& output_dir);
   void ir2_write_results(const std::string& output_dir, const Config& config);
   std::string ir2_to_file(ObjectFileData& data, const Config& config);
   std::string ir2_function_to_string(ObjectFileData& data, Function& function, int seg);
@@ -130,12 +128,9 @@ class ObjectFileDB {
   template <typename Func>
   void for_each_function(Func f) {
     for_each_obj([&](ObjectFileData& data) {
-      //      printf("IN %s\n", data.record.to_unique_name().c_str());
       for (int i = 0; i < int(data.linked_data.segments); i++) {
-        //        printf("seg %d\n", i);
         int fn = 0;
         for (auto& goal_func : data.linked_data.functions_by_seg.at(i)) {
-          //          printf("fn %d\n", fn);
           f(goal_func, i, data);
           fn++;
         }
@@ -146,13 +141,9 @@ class ObjectFileDB {
   template <typename Func>
   void for_each_function_def_order(Func f) {
     for_each_obj([&](ObjectFileData& data) {
-      //      printf("IN %s\n", data.record.to_unique_name().c_str());
       for (int i = 0; i < int(data.linked_data.segments); i++) {
-        //        printf("seg %d\n", i);
         int fn = 0;
-        //        for (auto& goal_func : data.linked_data.functions_by_seg.at(i)) {
         for (size_t j = data.linked_data.functions_by_seg.at(i).size(); j-- > 0;) {
-          //          printf("fn %d\n", fn);
           f(data.linked_data.functions_by_seg.at(i).at(j), i, data);
           fn++;
         }
@@ -175,5 +166,3 @@ class ObjectFileDB {
   } stats;
 };
 }  // namespace decompiler
-
-#endif  // JAK2_DISASSEMBLER_OBJECTFILEDB_H

--- a/decompiler/analysis/symbol_def_map.cpp
+++ b/decompiler/analysis/symbol_def_map.cpp
@@ -1,0 +1,125 @@
+#include "common/link_types.h"
+#include "symbol_def_map.h"
+#include "third-party/json.hpp"
+#include "decompiler/ObjectFile/ObjectFileDB.h"
+
+namespace decompiler {
+
+void SymbolMapBuilder::add_object(const ObjectFileData& data) {
+  // skip non-code files
+  if (data.obj_version != 3) {
+    return;
+  }
+  m_first_detections.emplace_back();
+  m_first_detections.back().object_file_name = data.name_from_map;
+  // add load/stores from all functions
+  for (const auto& seg_functions : data.linked_data.functions_by_seg) {
+    for (const auto& function : seg_functions) {
+      add_load_store_from_function(function, &m_first_detections.back());
+    }
+  }
+
+  // add deftypes in the top level function
+  const auto& top_level_functions = data.linked_data.functions_by_seg.at(TOP_LEVEL_SEGMENT);
+  assert(top_level_functions.size() == 1);
+  add_deftypes_from_top_level_function(top_level_functions.at(0), &m_first_detections.back());
+}
+
+void SymbolMapBuilder::build_map() {
+  // build a map where each symbol appears only once.  If a symbol appears as both a type and a
+  // load/store, then the load/store will be removed.
+  m_result.clear();
+  for (auto& obj_info : m_first_detections) {
+    ObjectSymbolList result;
+    result.object_file_name = obj_info.object_file_name;
+
+    for (auto& sym_info : obj_info.symbols) {
+      if (sym_info.is_type ||
+          (!sym_info.is_type && (m_seen_types.find(sym_info.name) == m_seen_types.end()))) {
+        result.symbols.push_back(sym_info);
+      }
+    }
+    m_result.push_back(result);
+  }
+}
+
+std::string SymbolMapBuilder::convert_to_json() const {
+  nlohmann::json result;
+
+  for (const auto& file : m_result) {
+    if (file.symbols.empty()) {
+      continue;
+    }
+    nlohmann::json syms;
+    for (const auto& sym : file.symbols) {
+      syms.push_back(sym.name);
+    }
+    result[file.object_file_name] = syms;
+  }
+
+  return result.dump();
+}
+
+namespace {
+std::optional<std::string> get_loaded_or_stored_symbol_name(const AtomicOp* op) {
+  // look for (set! <blah> <SYMBOL>)
+  auto as_set = dynamic_cast<const SetVarOp*>(op);
+  if (as_set) {
+    // source is a single thing:
+    if (as_set->src().is_identity()) {
+      const auto& src_atom = as_set->src().get_arg(0);
+      // sym val means loading the value in the symbol
+      if (src_atom.is_sym_val()) {
+        return src_atom.get_str();
+      }
+    }
+  }
+
+  auto as_store = dynamic_cast<const StoreOp*>(op);
+  if (as_store) {
+    if (as_store->addr().is_identity()) {
+      const auto& src_atom = as_store->addr().get_arg(0);
+      if (src_atom.is_sym_val()) {
+        return src_atom.get_str();
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+}  // namespace
+
+void SymbolMapBuilder::add_load_store_from_function(const Function& f, ObjectSymbolList* output) {
+  if (!f.ir2.atomic_ops_succeeded) {
+    lg::error("Atomic ops failed in {}", f.guessed_name.to_string());
+    return;
+  }
+
+  for (const auto& op : f.ir2.atomic_ops->ops) {
+    const auto sym = get_loaded_or_stored_symbol_name(op.get());
+    if (sym) {
+      if (m_seen_symbols.find(*sym) == m_seen_symbols.end()) {
+        SymbolInfo info;
+        info.name = *sym;
+        info.is_type = false;
+        output->symbols.push_back(info);
+        m_seen_symbols.insert(*sym);
+      }
+    }
+  }
+}
+
+void SymbolMapBuilder::add_deftypes_from_top_level_function(const Function& f,
+                                                            ObjectSymbolList* output) {
+  for (const auto& name : f.types_defined) {
+    if (m_seen_types.find(name) == m_seen_types.end()) {
+      SymbolInfo info;
+      info.name = name;
+      info.is_type = true;
+      output->symbols.push_back(info);
+      m_seen_types.insert(name);
+    }
+  }
+}
+
+}  // namespace decompiler

--- a/decompiler/analysis/symbol_def_map.h
+++ b/decompiler/analysis/symbol_def_map.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+namespace decompiler {
+
+class ObjectFileData;
+class Function;
+
+class SymbolMapBuilder {
+ public:
+  void add_object(const ObjectFileData& data);
+  void build_map();
+  std::string convert_to_json() const;
+
+ private:
+  struct SymbolInfo {
+    std::string name;
+    bool is_type = false;
+  };
+
+  struct ObjectSymbolList {
+    std::string object_file_name;
+    std::vector<SymbolInfo> symbols;
+  };
+
+  // symbols that we've seen load/store
+  std::unordered_set<std::string> m_seen_symbols;
+  // symbol that we've seen used in a deftype
+  std::unordered_set<std::string> m_seen_types;
+
+  // the first place we see symbols
+  std::vector<ObjectSymbolList> m_first_detections;
+
+  // the output of this tool - a list of where symbols are "defined" meaning:
+  // - if it's a type, the location of the deftype
+  // - if it's a global variable, the first location where it is read or written
+  // - other symbols do not appear.
+  std::vector<ObjectSymbolList> m_result;
+
+  void add_load_store_from_function(const Function& f, ObjectSymbolList* output);
+  void add_deftypes_from_top_level_function(const Function& f, ObjectSymbolList* output);
+};
+
+}  // namespace decompiler

--- a/decompiler/analysis/symbol_def_map.h
+++ b/decompiler/analysis/symbol_def_map.h
@@ -6,7 +6,7 @@
 
 namespace decompiler {
 
-class ObjectFileData;
+struct ObjectFileData;
 class Function;
 
 class SymbolMapBuilder {

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -50,6 +50,7 @@ Config read_config_file(const std::string& path_to_config_file) {
   config.hexdump_data = cfg.at("hexdump_data").get<bool>();
   config.dump_objs = cfg.at("dump_objs").get<bool>();
   config.print_cfgs = cfg.at("print_cfgs").get<bool>();
+  config.generate_symbol_definition_map = cfg.at("generate_symbol_definition_map").get<bool>();
 
   auto allowed = cfg.at("allowed_objects").get<std::vector<std::string>>();
   for (const auto& x : allowed) {

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -79,6 +79,8 @@ struct Config {
   bool dump_objs = false;
   bool print_cfgs = false;
 
+  bool generate_symbol_definition_map = false;
+
   std::unordered_set<std::string> allowed_objects;
   std::unordered_map<std::string, std::unordered_map<int, std::vector<TypeCast>>>
       type_casts_by_function_by_atomic_op_idx;

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -41,6 +41,10 @@
   // output a file type_defs.gc which is used the types part of all-types.gc
   "regenerate_all_types": false,
 
+  // generate the symbol_map.json file.
+  // this is a guess at where each symbol is first defined/used.
+  "generate_symbol_definition_map": true,
+
   // debug option for instruction decoder
   "write_hex_near_instructions": false,
 


### PR DESCRIPTION
In the config, set `"generate_symbol_definition_map": true,` and run the decompiler. It will generate a `symbol_map.json` file in the output folder.
You can kill the decompiler after seeing `[info] Built symbol map in 224.18 ms` if you don't want to wait for the whole thing to run.

The order within files should now be correct, and `deftype`s will win over load/store use of symbols.  Symbols that aren't `deftype` args and are never loaded/stored won't show up.

Example:
```
  "gkernel-h": [
    "process-tree",
    "stack-frame",
    "uint64",
    "kernel-context",
    "thread",
    "cpu-thread",
    "dead-pool",
    "dead-pool-heap-rec",
    "dead-pool-heap",
    "catch-frame",
    "protect-frame",
    "handle",
    "state",
    "event-message-block"
  ],
```
