### PR TITLE
Change syntax for boxed array to support different length and allocated-length

### DIFF
--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -3359,10 +3359,10 @@ void ArrayFieldAccess::update_with_val(Form* new_val,
     if (m_expected_stride == 1) {
       // reg0 is idx
       auto reg0_matcher =
-          Matcher::match_or({Matcher::any(0), Matcher::cast("int", Matcher::any_reg(0))});
+          Matcher::match_or({Matcher::cast("int", Matcher::any(0)), Matcher::any(0)});
       // reg1 is base
       auto reg1_matcher =
-          Matcher::match_or({Matcher::any_reg(1), Matcher::cast("int", Matcher::any_reg(1))});
+          Matcher::match_or({Matcher::cast("int", Matcher::any(1)), Matcher::any(1)});
       auto matcher = Matcher::fixed_op(FixedOperatorKind::ADDITION, {reg0_matcher, reg1_matcher});
       auto match_result = match(matcher, new_val);
       if (!match_result.matched) {
@@ -3370,8 +3370,8 @@ void ArrayFieldAccess::update_with_val(Form* new_val,
                                  new_val->to_string(env));
       }
       auto idx = match_result.maps.forms.at(0);
-      auto base = match_result.maps.regs.at(1);
-      assert(idx && base.has_value());
+      auto base = match_result.maps.forms.at(1);
+      assert(idx && base);
 
       std::vector<DerefToken> tokens = m_deref_tokens;
       for (auto& x : tokens) {
@@ -3381,7 +3381,7 @@ void ArrayFieldAccess::update_with_val(Form* new_val,
       }
       // tokens.push_back(DerefToken::make_int_expr(var_to_form(idx.value(), pool)));
 
-      auto deref = pool.alloc_element<DerefElement>(var_to_form(base.value(), pool), false, tokens);
+      auto deref = pool.alloc_element<DerefElement>(base, false, tokens);
       result->push_back(deref);
     } else if (is_power_of_two(m_expected_stride, &power_of_two)) {
       // (+ (sll (the-as uint a1-0) 2) (the-as int a0-0))

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -694,19 +694,18 @@ goos::Object decompile_boxed_array(const DecompilerLabel& label,
     throw std::runtime_error("Invalid size in decompile_boxed_array");
   }
 
-  if (size_word_1.data != size_word_2.data) {
-    throw std::runtime_error("Inconsistent size in decompile_boxed_array");
-  }
-
   int array_length = size_word_1.data;
+  int array_allocated_length = size_word_2.data;
 
   auto content_type_info = ts.lookup_type(content_type);
   if (content_type_info->is_reference()) {
     // easy, stride of 4.
     std::vector<goos::Object> result = {
         pretty_print::to_symbol("new"), pretty_print::to_symbol("'static"),
-        pretty_print::to_symbol("'boxed-array"), pretty_print::to_symbol(content_type.print()),
-        pretty_print::to_symbol(fmt::format("{}", array_length))};
+        pretty_print::to_symbol("'boxed-array"),
+        pretty_print::to_symbol(fmt::format(":type {} :length {} :allocated-length {}",
+                                            content_type.print(), array_length,
+                                            array_allocated_length))};
 
     for (int elt = 0; elt < array_length; elt++) {
       auto& word = words.at(label.target_segment).at(first_elt_word_idx + elt);
@@ -727,8 +726,10 @@ goos::Object decompile_boxed_array(const DecompilerLabel& label,
     // value array
     std::vector<goos::Object> result = {
         pretty_print::to_symbol("new"), pretty_print::to_symbol("'static"),
-        pretty_print::to_symbol("'boxed-array"), pretty_print::to_symbol(content_type.print()),
-        pretty_print::to_symbol(fmt::format("{}", array_length))};
+        pretty_print::to_symbol("'boxed-array"),
+        pretty_print::to_symbol(fmt::format(":type {} :length {} :allocated-length {}",
+                                            content_type.print(), array_length,
+                                            array_allocated_length))};
 
     auto stride = content_type_info->get_size_in_memory();
     for (int i = 0; i < array_length; i++) {

--- a/goal_src/engine/dma/dma-disasm.gc
+++ b/goal_src/engine/dma/dma-disasm.gc
@@ -19,7 +19,7 @@
   )
 
 (define *vif-disasm-table*
-    (new 'static 'boxed-array vif-disasm-element 34
+    (new 'static 'boxed-array :type vif-disasm-element :length 34
          (new 'static 'vif-disasm-element :mask #x7f :string1 "nop")
          (new 'static 'vif-disasm-element :mask #x7f :tag #x1 :print #x2 :string1 "stcycl")
          (new 'static 'vif-disasm-element :mask #x7f :tag #x2 :print #x1 :string1 "offset" :string2 "offset")

--- a/goal_src/engine/gfx/texture.gc
+++ b/goal_src/engine/gfx/texture.gc
@@ -279,36 +279,36 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define ct32-24-block-table
-    (new 'static 'boxed-array int32
-         32 0 1 4 5 16 17 20 21 2 3 6 7 18 19 22 23 8 9 12 13 24 25 28 29 10 11 14 15 26 27 30 31))
+    (new 'static 'boxed-array :type int32 :length 32
+         0 1 4 5 16 17 20 21 2 3 6 7 18 19 22 23 8 9 12 13 24 25 28 29 10 11 14 15 26 27 30 31))
 
 (define mz32-24-block-table
-    (new 'static 'boxed-array int32
-         32 16 17 20 21 0 1 4 5 18 19 22 23 2 3 6 7 24 25 28 29 8 9 12 13 26 27 30 31 10 11 14 15))
+    (new 'static 'boxed-array :type int32 :length 32
+         16 17 20 21 0 1 4 5 18 19 22 23 2 3 6 7 24 25 28 29 8 9 12 13 26 27 30 31 10 11 14 15))
 
 (define ct16-block-table
-    (new 'static 'boxed-array int32
-         32 0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15 16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31))
+    (new 'static 'boxed-array :type int32 :length 32
+         0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15 16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31))
 
 (define ct16s-block-table
-    (new 'static 'boxed-array int32
-         32 0 2 16 18 1 3 17 19 8 10 24 26 9 11 25 27 4 6 20 22 5 7 21 23 12 14 28 30 13 15 29 31))
+    (new 'static 'boxed-array :type int32 :length 32
+         0 2 16 18 1 3 17 19 8 10 24 26 9 11 25 27 4 6 20 22 5 7 21 23 12 14 28 30 13 15 29 31))
 
 (define mz16-block-table
-    (new 'static 'boxed-array int32
-         32 16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31 0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15))
+    (new 'static 'boxed-array :type int32 :length 32
+         16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31 0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15))
 
 (define mz16s-block-table
-    (new 'static 'boxed-array int32
-         32 16 18 0 2 17 19 1 3 24 26 8 10 25 27 9 11 20 22 4 6 21 23 5 7 28 30 12 14 29 31 13 15))
+    (new 'static 'boxed-array :type int32 :length 32
+         16 18 0 2 17 19 1 3 24 26 8 10 25 27 9 11 20 22 4 6 21 23 5 7 28 30 12 14 29 31 13 15))
 
 (define mt8-block-table
-    (new 'static 'boxed-array int32
-         32 0 1 4 5 16 17 20 21 2 3 6 7 18 19 22 23 8 9 12 13 24 25 28 29 10 11 14 15 26 27 30 31))
+    (new 'static 'boxed-array :type int32 :length 32
+         0 1 4 5 16 17 20 21 2 3 6 7 18 19 22 23 8 9 12 13 24 25 28 29 10 11 14 15 26 27 30 31))
 
 (define mt4-block-table
-    (new 'static 'boxed-array int32
-         32 0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15 16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31))
+    (new 'static 'boxed-array :type int32 :length 32
+         0 2 8 10 1 3 9 11 4 6 12 14 5 7 13 15 16 18 24 26 17 19 25 27 20 22 28 30 21 23 29 31))
 
 (defun gs-find-block ((bx int) (by int) (tex-format gs-psm))
   "Block index lookup."

--- a/goal_src/engine/gfx/wind-h.gc
+++ b/goal_src/engine/gfx/wind-h.gc
@@ -14,7 +14,7 @@
   :flag-assert         #x900000010
   )
 
- (define *wind-scales* (new 'static 'boxed-array uint8 32
+ (define *wind-scales* (new 'static 'boxed-array :type uint8 :length 32
                             #x2 #x5 #x2 #x3
                             #x2 #x2 #x3 #x10
                             #xa #x2 #x4 #x2

--- a/goal_src/engine/math/euler-h.gc
+++ b/goal_src/engine/math/euler-h.gc
@@ -6,8 +6,10 @@
 ;; dgos: GAME, ENGINE
 
 ;; maybe euler angle storage orders?
-(define EulSafe (new 'static 'boxed-array int32 4 0 1 2 0))
-(define EulNext (new 'static 'boxed-array int32 4 1 2 0 1))
+(define EulSafe (new 'static 'boxed-array :type int32 :length 4
+                     0 1 2 0))
+(define EulNext (new 'static 'boxed-array :type int32 :length 4
+                     1 2 0 1))
 
 ;; just uses the same xyzw and data array as vector.
 ;; the w stores a float that should be an integer that seems to have

--- a/goal_src/engine/math/trigonometry.gc
+++ b/goal_src/engine/math/trigonometry.gc
@@ -126,7 +126,7 @@
 
 ;; create a static array with the given values, interpreted as floats.
 (defmacro make-float-table (name size vals)
-  `(define ,name (new 'static 'boxed-array float ,size
+  `(define ,name (new 'static 'boxed-array :type float :length ,size
                       ,@(apply (lambda (x) `(the-as float ,x))  vals)))
   )
 

--- a/goal_src/engine/ui/credits.gc
+++ b/goal_src/engine/ui/credits.gc
@@ -34,18 +34,18 @@
   )
 
 ;; definition for symbol *title-credits-scale*, type (array float)
-(define
-  *title-credits-scale*
+(define *title-credits-scale*
   (the-as (array float)
-   (new 'static 'boxed-array float 8 0.9 0.9 0.6 0.6 1.0 0.9 1.1 0.9)
+          (new 'static 'boxed-array :type float :length 8
+               0.9 0.9 0.6 0.6 1.0 0.9 1.1 0.9)
    )
   )
 
 ;; definition for symbol *title-credits-spacing*, type (array int32)
-(define
-  *title-credits-spacing*
+(define *title-credits-spacing*
   (the-as (array int32)
-   (new 'static 'boxed-array int32 8 15 20 15 15 20 15 20 15)
+          (new 'static 'boxed-array :type int32 :length 8
+               15 20 15 15 20 15 20 15)
    )
   )
 

--- a/goal_src/engine/ui/text-h.gc
+++ b/goal_src/engine/ui/text-h.gc
@@ -36,7 +36,7 @@
   )
 
 ;; todo, need support for array
-(define *text-group-names* (new 'static 'boxed-array string 1 "common"))
+(define *text-group-names* (new 'static 'boxed-array :type string :length 1 "common"))
 
 (define *common-text-heap* (new 'global 'kheap))
 

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -195,10 +195,11 @@ class Compiler {
                          Env* env,
                          bool call_constructor);
 
-  StaticResult fill_static_array(const goos::Object& form,
-                                 const goos::Object& rest,
-                                 bool boxed,
-                                 Env* env);
+  StaticResult fill_static_array(const goos::Object& form, const goos::Object& rest, Env* env);
+
+  StaticResult fill_static_boxed_array(const goos::Object& form,
+                                       const goos::Object& rest,
+                                       Env* env);
 
   StaticResult fill_static_inline_array(const goos::Object& form,
                                         const goos::Object& rest,
@@ -212,7 +213,8 @@ class Compiler {
                                        Env* env);
   void fill_static_array_inline(const goos::Object& form,
                                 const TypeSpec& content_type,
-                                const std::vector<goos::Object>& args,
+                                goos::Object* args_array,
+                                int args_array_length,
                                 StaticStructure* structure,
                                 int offset,
                                 Env* env);

--- a/test/decompiler/reference/engine/dma/dma-disasm_REF.gc
+++ b/test/decompiler/reference/engine/dma/dma-disasm_REF.gc
@@ -36,8 +36,7 @@
    (new
     'static
     'boxed-array
-    vif-disasm-element
-    34
+    :type vif-disasm-element :length 34 :allocated-length 34
     (new 'static 'vif-disasm-element :mask #x7f :string1 "nop")
     (new 'static 'vif-disasm-element
      :mask #x7f

--- a/test/decompiler/reference/engine/gfx/wind-h_REF.gc
+++ b/test/decompiler/reference/engine/gfx/wind-h_REF.gc
@@ -26,8 +26,7 @@
    (new
     'static
     'boxed-array
-    uint8
-    32
+    :type uint8 :length 32 :allocated-length 32
     #x2
     #x5
     #x2
@@ -98,7 +97,3 @@
    63
    )
   )
-
-
-
-

--- a/test/decompiler/reference/engine/math/euler-h_REF.gc
+++ b/test/decompiler/reference/engine/math/euler-h_REF.gc
@@ -4,13 +4,17 @@
 ;; definition for symbol EulSafe, type (array int32)
 (define
   EulSafe
-  (the-as (array int32) (new 'static 'boxed-array int32 4 0 1 2 0))
+  (the-as (array int32)
+   (new 'static 'boxed-array :type int32 :length 4 :allocated-length 4 0 1 2 0)
+   )
   )
 
 ;; definition for symbol EulNext, type (array int32)
 (define
   EulNext
-  (the-as (array int32) (new 'static 'boxed-array int32 4 1 2 0 1))
+  (the-as (array int32)
+   (new 'static 'boxed-array :type int32 :length 4 :allocated-length 4 1 2 0 1)
+   )
   )
 
 ;; definition of type euler-angles
@@ -37,7 +41,3 @@
 ;; failed to figure out what this is:
 (let ((v0-1 0))
   )
-
-
-
-

--- a/test/decompiler/reference/engine/math/trigonometry_REF.gc
+++ b/test/decompiler/reference/engine/math/trigonometry_REF.gc
@@ -92,8 +92,7 @@
    (new
     'static
     'boxed-array
-    float
-    32
+    :type float :length 32 :allocated-length 32
     1.0
     0.5
     0.25
@@ -137,8 +136,7 @@
    (new
     'static
     'boxed-array
-    float
-    32
+    :type float :length 32 :allocated-length 32
     0.7853982
     0.4636476
     0.24497867

--- a/test/decompiler/reference/engine/ui/credits_REF.gc
+++ b/test/decompiler/reference/engine/ui/credits_REF.gc
@@ -35,7 +35,19 @@
 (define
   *title-credits-scale*
   (the-as (array float)
-   (new 'static 'boxed-array float 8 0.9 0.9 0.6 0.6 1.0 0.9 1.1 0.9)
+   (new
+    'static
+    'boxed-array
+    :type float :length 8 :allocated-length 8
+    0.9
+    0.9
+    0.6
+    0.6
+    1.0
+    0.9
+    1.1
+    0.9
+    )
    )
   )
 
@@ -43,7 +55,19 @@
 (define
   *title-credits-spacing*
   (the-as (array int32)
-   (new 'static 'boxed-array int32 8 15 20 15 15 20 15 20 15)
+   (new
+    'static
+    'boxed-array
+    :type int32 :length 8 :allocated-length 8
+    15
+    20
+    15
+    15
+    20
+    15
+    20
+    15
+    )
    )
   )
 
@@ -196,7 +220,3 @@
     )
    )
   )
-
-
-
-

--- a/test/decompiler/reference/engine/ui/text-h_REF.gc
+++ b/test/decompiler/reference/engine/ui/text-h_REF.gc
@@ -48,7 +48,14 @@
 ;; definition for symbol *text-group-names*, type (array string)
 (define
   *text-group-names*
-  (the-as (array string) (new 'static 'boxed-array string 1 "common"))
+  (the-as (array string)
+   (new
+    'static
+    'boxed-array
+    :type string :length 1 :allocated-length 1
+    "common"
+    )
+   )
   )
 
 ;; definition for symbol *common-text-heap*, type kheap

--- a/test/decompiler/test_DataParser.cpp
+++ b/test/decompiler/test_DataParser.cpp
@@ -210,7 +210,12 @@ TEST_F(DataDecompTest, VifDisasmArray) {
   auto decomp =
       decompile_at_label_guess_type(parsed.label("L148"), parsed.labels, {parsed.words}, dts->ts);
   check_forms_equal(decomp.print(),
-                    "(new 'static 'boxed-array vif-disasm-element 3\n"
+                    "(new 'static 'boxed-array :type\n"
+                    "  vif-disasm-element\n"
+                    "  :length\n"
+                    "  3\n"
+                    "  :allocated-length\n"
+                    "  3\n"
                     "  (new 'static 'vif-disasm-element :mask #x7f :string1 \"nop\")\n"
                     "  (new 'static 'vif-disasm-element :mask #x7f :tag (vif-cmd-32 stcycl) :print "
                     "#x2 :string1 \"stcycl\")\n"

--- a/test/goalc/source_templates/with_game/test-bitfield-and-enum-types.gc
+++ b/test/goalc/source_templates/with_game/test-bitfield-and-enum-types.gc
@@ -21,11 +21,11 @@
   (format #t "int: ~d~%" obj)
   obj)
 
-(let ((test-arr (new 'static 'boxed-array test-bitfield 12)))
+(let ((test-arr (new 'static 'boxed-array :type test-bitfield :length 12)))
   (format #t "content type: ~A~%" (-> test-arr content-type))
   )
 
-(let ((test-arr (new 'static 'boxed-array test-enum 12)))
+(let ((test-arr (new 'static 'boxed-array :type test-enum :length 12)))
   (format #t "content type: ~A~%" (-> test-arr content-type))
   )
 

--- a/test/goalc/source_templates/with_game/test-static-boxed-array.gc
+++ b/test/goalc/source_templates/with_game/test-static-boxed-array.gc
@@ -1,4 +1,4 @@
-(let ((arr (new 'static 'boxed-array object 12 32 'asdf "test" '( a b ))))
+(let ((arr (new 'static 'boxed-array :type object :length 12 32 'asdf "test" '( a b ))))
   (dotimes (i 5)
     (format #t "~A " (-> arr i))
     )


### PR DESCRIPTION
Now the failing example in https://github.com/water111/jak-project/issues/563 should look like this, which will be accepted by the compiler.

```lisp
    (new 'static 'boxed-array :type generic-dma-foreground-sink :length 0 :allocated-length 9)
```