### PR TITLE
[decompiler] detect small integer not equal

### DIFF
--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -2614,9 +2614,20 @@ FormElement* ConditionElement::make_nonzero_check_generic(const Env& env,
 
   if (bitfield_compare) {
     return bitfield_compare;
-  } else {
-    return pool.alloc_element<GenericElement>(GenericOperator::make_compare(m_kind), source_forms);
   }
+
+  auto mr = match(Matcher::op(GenericOpMatcher::fixed(FixedOperatorKind::ADDITION),
+                              {Matcher::any(0), Matcher::any_integer(1)}),
+                  source_forms.at(0));
+  if (mr.matched) {
+    s64 value = -mr.maps.ints.at(1);
+    auto value_form = pool.alloc_single_element_form<SimpleAtomElement>(
+        nullptr, SimpleAtom::make_int_constant(value));
+    return pool.alloc_element<GenericElement>(GenericOperator::make_fixed(FixedOperatorKind::NEQ),
+                                              std::vector<Form*>{mr.maps.forms.at(0), value_form});
+  }
+
+  return pool.alloc_element<GenericElement>(GenericOperator::make_compare(m_kind), source_forms);
 }
 
 FormElement* ConditionElement::make_equal_check_generic(const Env& env,

--- a/test/decompiler/reference/kernel/gstring_REF.gc
+++ b/test/decompiler/reference/kernel/gstring_REF.gc
@@ -458,11 +458,7 @@
      (return (begin
               (let ((arg-end (&-> arg-word-start 1)))
                (let ((arg-start arg-end))
-                (while
-                 (and
-                  (nonzero? (-> arg-end 0))
-                  (nonzero? (+ (-> arg-end 0) -34))
-                  )
+                (while (and (nonzero? (-> arg-end 0)) (!= (-> arg-end 0) 34))
                  (set! arg-end (&-> arg-end 1))
                  )
                 (copyn-string<-charp
@@ -488,10 +484,10 @@
                (while
                 (and
                  (nonzero? (-> arg-word-start 0))
-                 (nonzero? (+ (-> arg-word-start 0) -32))
-                 (nonzero? (+ (-> arg-word-start 0) -9))
-                 (nonzero? (+ (-> arg-word-start 0) -13))
-                 (nonzero? (+ (-> arg-word-start 0) -10))
+                 (!= (-> arg-word-start 0) 32)
+                 (!= (-> arg-word-start 0) 9)
+                 (!= (-> arg-word-start 0) 13)
+                 (!= (-> arg-word-start 0) 10)
                  )
                 (set! arg-word-start (&-> arg-word-start 1))
                 )


### PR DESCRIPTION
Code like:
```
(nonzero? (+ (-> arg-word-start 0) -32))
```
will be converted to
```
(!= (-> arg-word-start 0) 32)
```