### PR TITLE
Add type-ref in static data

### DIFF
--- a/common/type_system/TypeSystem.h
+++ b/common/type_system/TypeSystem.h
@@ -125,6 +125,9 @@ class TypeSystem {
   Type* add_type(const std::string& name, std::unique_ptr<Type> type);
   void forward_declare_type_as_type(const std::string& name);
   void forward_declare_type_as(const std::string& new_type, const std::string& parent_type);
+  void forward_declare_type_method_count(const std::string& name, int num_methods);
+  int get_type_method_count(const std::string& name) const;
+  std::optional<int> try_get_type_method_count(const std::string& name) const;
   std::string get_runtime_type(const TypeSpec& ts);
 
   DerefInfo get_deref_info(const TypeSpec& ts) const;
@@ -257,6 +260,8 @@ class TypeSystem {
 
   std::unordered_map<std::string, std::unique_ptr<Type>> m_types;
   std::unordered_map<std::string, std::string> m_forward_declared_types;
+  std::unordered_map<std::string, int> m_forward_declared_method_counts;
+
   std::vector<std::unique_ptr<Type>> m_old_types;
 
   bool m_allow_redefinition = false;

--- a/decompiler/ObjectFile/LinkedObjectFileCreation.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFileCreation.cpp
@@ -760,10 +760,8 @@ static void link_v3(LinkedObjectFile& f,
         link_ptr--;
         s_name = (const char*)(&data.at(link_ptr));
       } else {
-        // methods todo
-
         s_name = (const char*)(&data.at(link_ptr));
-        // get_type_info().inform_type_method_count(s_name, reloc & 0x7f); todo
+        dts.ts.forward_declare_type_method_count(s_name, reloc & 0x7f);
         kind = SymbolLinkKind::TYPE;
       }
 

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -12736,7 +12736,7 @@
 (deftype entity-actor (entity)
   (
     (nav-mesh nav-mesh :offset-assert 52)
-    (etype basic :offset-assert 56) ;; probably type
+    (etype type :offset-assert 56) ;; probably type
     (task uint8 :offset-assert 60)
     (vis-id uint16 :offset-assert 62)
     (quat quaternion :inline :offset-assert 64)
@@ -12754,9 +12754,9 @@
   )
 
 (deftype entity-info (basic)
-  ((ptype     basic  :offset-assert 4)
+  ((ptype     type   :offset-assert 4)
    (package   basic  :offset-assert 8)
-   (art-group basic  :offset-assert 12)
+   (art-group pair   :offset-assert 12)
    (pool      basic  :offset-assert 16)
    (heap-size int32  :offset-assert 20)
    )
@@ -15988,7 +15988,7 @@
 
 ;; - Unknowns
 
-;;(define-extern *entity-info* object) ;; unknown type
+(define-extern *entity-info* (array entity-info))
 
 
 ;; ----------------------

--- a/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
@@ -581,5 +581,9 @@
     ["L227", "uint64", true],
     ["L228", "uint64", true],
     ["L229", "uint64", true]
+  ],
+
+  "entity-table": [
+    ["L8", "(array entity-info)", true]
   ]
 }

--- a/docs/markdown/progress-notes/changelog.md
+++ b/docs/markdown/progress-notes/changelog.md
@@ -165,3 +165,4 @@
 - Fixed a bug where saved xmm registers might be clobbered when calling a C++ function that wasn't `format`.
 - The `declare-type` form now supports any parent type. The type system will do a better job of trying to make things work out when only part of the type hierarchy is defined, and you can now chain type forward declarations. The compiler is stricter and will not accept forward declarations that are possibly incompatible. Instead, forward declare enough types and their parents for the compiler to be able to figure it out.  
 - The `deftype` form is more strict and will throw an error if the type definition is in any way incompatible with existing forward declarations of types.
+- Added a `type-ref` form to insert a reference to a type into a static structure and optionally forward declare the number of methods

--- a/goal_src/engine/entity/entity-h.gc
+++ b/goal_src/engine/entity/entity-h.gc
@@ -160,7 +160,7 @@
 (declare-type nav-mesh basic)
 (deftype entity-actor (entity)
   ((nav-mesh nav-mesh           :offset-assert 52)
-   (etype    basic              :offset-assert 56)
+   (etype    type               :offset-assert 56)
    (task     uint8              :offset-assert 60)
    (vis-id   uint16             :offset-assert 62)
    (quat     quaternion :inline :offset-assert 64)
@@ -178,9 +178,9 @@
 
 ;; definition of type entity-info
 (deftype entity-info (basic)
-  ((ptype     basic  :offset-assert 4)
+  ((ptype     type   :offset-assert 4)
    (package   basic  :offset-assert 8)
-   (art-group basic  :offset-assert 12)
+   (art-group pair   :offset-assert 12)
    (pool      basic  :offset-assert 16)
    (heap-size int32  :offset-assert 20)
    )

--- a/goalc/compiler/StaticObject.cpp
+++ b/goalc/compiler/StaticObject.cpp
@@ -216,3 +216,12 @@ StaticResult StaticResult::make_symbol(const std::string& name) {
   result.m_ts = TypeSpec("symbol");
   return result;
 }
+
+StaticResult StaticResult::make_type_ref(const std::string& type_name, int method_count) {
+  StaticResult result;
+  result.m_kind = Kind::TYPE;
+  result.m_symbol = type_name;
+  result.m_method_count = method_count;
+  result.m_ts = TypeSpec("type");
+  return result;
+}

--- a/goalc/compiler/StaticObject.h
+++ b/goalc/compiler/StaticObject.h
@@ -101,13 +101,13 @@ class StaticResult {
   static StaticResult make_constant_data(const ConstantValue& data, TypeSpec ts);
   static StaticResult make_constant_data(u64 data, const TypeSpec& ts);
   static StaticResult make_symbol(const std::string& name);
-
-  std::string print() const;
+  static StaticResult make_type_ref(const std::string& type_name, int method_count);
 
   const TypeSpec& typespec() const { return m_ts; }
   bool is_reference() const { return m_kind == Kind::STRUCTURE_REFERENCE; }
   bool is_constant_data() const { return m_kind == Kind::CONSTANT_DATA; }
   bool is_symbol() const { return m_kind == Kind::SYMBOL; }
+  bool is_type() const { return m_kind == Kind::TYPE; }
 
   StaticStructure* reference() const {
     assert(is_reference());
@@ -121,8 +121,13 @@ class StaticResult {
   }
 
   const std::string& symbol_name() const {
-    assert(is_symbol());
+    assert(is_symbol() || is_type());
     return m_symbol;
+  }
+
+  int method_count() const {
+    assert(is_type());
+    return m_method_count;
   }
 
   u64 constant_u64() const {
@@ -145,10 +150,19 @@ class StaticResult {
   // used for only constant data
   std::optional<ConstantValue> m_constant_data;
 
-  // used for only symbol
+  // used for only symbol and type
   std::string m_symbol;
 
-  enum class Kind { STRUCTURE_REFERENCE, CONSTANT_DATA, SYMBOL, INVALID } m_kind = Kind::INVALID;
+  // used only for type
+  int m_method_count = -1;
+
+  enum class Kind {
+    STRUCTURE_REFERENCE,
+    CONSTANT_DATA,
+    SYMBOL,
+    TYPE,
+    INVALID
+  } m_kind = Kind::INVALID;
 };
 
 class StaticPair : public StaticStructure {

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -124,7 +124,7 @@ void Compiler::generate_field_description(const goos::Object& form,
                                           const Field& f) {
   std::string str_template;
   std::vector<RegVal*> format_args = {};
-  if (m_ts.tc(m_ts.make_typespec("type"), f.type())) {
+  if (f.name() == "type" && f.offset() == 0) {
     // type
     return;
   } else if (f.is_array() && !f.is_dynamic()) {

--- a/goalc/emitter/ObjectGenerator.cpp
+++ b/goalc/emitter/ObjectGenerator.cpp
@@ -458,7 +458,7 @@ void ObjectGenerator::emit_link_type_pointer(int seg, const TypeSystem* ts) {
     out.push_back(0);
 
     // method count
-    out.push_back(ts->get_next_method_id(ts->lookup_type(rec.first)));
+    out.push_back(ts->get_type_method_count(rec.first));
 
     // number of links
     push_data<u32>(size, out);

--- a/test/decompiler/reference/engine/entity/entity-h_REF.gc
+++ b/test/decompiler/reference/engine/entity/entity-h_REF.gc
@@ -234,7 +234,7 @@
 ;; definition of type entity-actor
 (deftype entity-actor (entity)
   ((nav-mesh nav-mesh           :offset-assert  52)
-   (etype    basic              :offset-assert  56)
+   (etype    type               :offset-assert  56)
    (task     uint8              :offset-assert  60)
    (vis-id   uint16             :offset-assert  62)
    (quat     quaternion :inline :offset-assert  64)
@@ -252,9 +252,9 @@
 
 ;; definition of type entity-info
 (deftype entity-info (basic)
-  ((ptype     basic  :offset-assert   4)
+  ((ptype     type   :offset-assert   4)
    (package   basic  :offset-assert   8)
-   (art-group basic  :offset-assert  12)
+   (art-group pair   :offset-assert  12)
    (pool      basic  :offset-assert  16)
    (heap-size int32  :offset-assert  20)
    )

--- a/test/goalc/source_templates/with_game/test-type-ref.gc
+++ b/test/goalc/source_templates/with_game/test-type-ref.gc
@@ -1,0 +1,24 @@
+
+;; define a type with fields that hold a type.
+(deftype test-type-with-type-field (basic)
+  ((name string)
+   (some-type-1 type)
+   (some-type-2 type))
+  )
+
+(let ((obj (new 'static 'test-type-with-type-field
+                :name "test"
+                :some-type-2 (type-ref some-unknown-type :method-count 20)
+                :some-type-1 (type-ref string :method-count 9)))
+      (old-string string))
+  (format #t "~A ~A ~A ~A ~D ~D~%"
+          (-> obj some-type-1 symbol)
+          (= (-> obj some-type-1) old-string) ;; should not reallocate string
+          (-> obj some-type-1 parent)
+          (-> obj some-type-2 symbol) ;; should fill out type symbol
+          (-> obj some-type-2 allocated-length) ;; and method length
+          (-> obj some-type-2 parent) ;; but other stuff should be 0's
+          )
+  )
+
+

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -621,6 +621,12 @@ TEST_F(WithGameTests, StaticArrayField) {
                           "0\n"});
 }
 
+TEST_F(WithGameTests, TypeReference) {
+  runner.run_static_test(env, testCategory, "test-type-ref.gc",
+                         {"string #t basic some-unknown-type 20 0\n"
+                          "0\n"});
+}
+
 TEST_F(WithGameTests, StaticFieldInlineArray) {
   runner.run_static_test(env, testCategory, "test-static-field-inline-arrays.gc",
                          {"\"second\" \"first\"\n"


### PR DESCRIPTION
This adds a `type-ref` form to the compiler/decompiler to insert a reference to a type in a static object.

There's something weird about this though - the game has `type-ref`s on types that aren't defined yet.  When the linker encounters these, it allocates memory for the type, and in order to do this, it needs to know the number of methods.   To support this, if the type system can't figure out the number of methods, you can manually add a `:method-count` argument.