### PR TITLE
Fix use def issues

### DIFF
--- a/decompiler/IR2/Form.h
+++ b/decompiler/IR2/Form.h
@@ -1593,6 +1593,8 @@ class Form {
   std::vector<FormElement*> m_elements;
 };
 
+class CfgVtx;
+
 /*!
  * A FormPool is used to allocate forms and form elements.
  * It will clean up everything when it is destroyed.
@@ -1640,11 +1642,25 @@ class FormPool {
     return form;
   }
 
+  Form* lookup_cached_conversion(const CfgVtx* vtx) const {
+    auto it = m_vtx_to_form_cache.find(vtx);
+    if (it == m_vtx_to_form_cache.end()) {
+      return nullptr;
+    }
+    return it->second;
+  }
+
+  void cache_conversion(const CfgVtx* vtx, Form* form) {
+    assert(m_vtx_to_form_cache.find(vtx) == m_vtx_to_form_cache.end());
+    m_vtx_to_form_cache[vtx] = form;
+  }
+
   ~FormPool();
 
  private:
   std::vector<Form*> m_forms;
   std::vector<FormElement*> m_elements;
+  std::unordered_map<const CfgVtx*, Form*> m_vtx_to_form_cache;
 };
 
 std::optional<SimpleAtom> form_element_as_atom(const FormElement* f);

--- a/decompiler/IR2/FormStack.h
+++ b/decompiler/IR2/FormStack.h
@@ -68,12 +68,13 @@ class FormStack {
   bool m_is_root_stack = false;
 };
 
-void rewrite_to_get_var(std::vector<FormElement*>& default_result,
-                        FormPool& pool,
-                        const RegisterAccess& var,
-                        const Env& env);
+std::optional<RegisterAccess> rewrite_to_get_var(std::vector<FormElement*>& default_result,
+                                                 FormPool& pool,
+                                                 const RegisterAccess& var,
+                                                 const Env& env);
 std::vector<FormElement*> rewrite_to_get_var(FormStack& stack,
                                              FormPool& pool,
                                              const RegisterAccess& var,
-                                             const Env& env);
+                                             const Env& env,
+                                             std::optional<RegisterAccess>* used_var = nullptr);
 }  // namespace decompiler

--- a/decompiler/analysis/cfg_builder.cpp
+++ b/decompiler/analysis/cfg_builder.cpp
@@ -1653,11 +1653,19 @@ Form* cfg_to_ir_helper(FormPool& pool, Function& f, const CfgVtx* vtx) {
 }
 
 Form* cfg_to_ir(FormPool& pool, Function& f, const CfgVtx* vtx) {
+  // we cache these because some functions will do a conversion, give up, and throw away the result.
+  // converting multiple times means that env-modifications will happen multiple times.
+  auto cached = pool.lookup_cached_conversion(vtx);
+  if (cached) {
+    return cached;
+  }
   Form* result = cfg_to_ir_helper(pool, f, vtx);
   if (vtx->needs_label) {
     result->elts().insert(result->elts().begin(),
                           pool.alloc_element<LabelElement>(vtx->get_first_block_id()));
   }
+
+  pool.cache_conversion(vtx, result);
   return result;
 }
 

--- a/test/decompiler/reference/engine/load/file-io_REF.gc
+++ b/test/decompiler/reference/engine/load/file-io_REF.gc
@@ -149,7 +149,6 @@
   )
 
 ;; definition for function file-info-correct-version?
-;; WARN: disable def twice: 16. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defun
   file-info-correct-version?
   ((info file-info) (kind file-kind) (version-override int))


### PR DESCRIPTION
This fixes two bugs that appear to fix all known use-def issues.

First, it fixes a bug where attempted structuring on the same vertex multiple times, resulting in env updates happening twice. Now these are cached.  This was harmless but triggered error.

The second bug is a little more complicated. The structuring pass marks the `(set! x #f)` in the delay slot as not a def, and leaves the defs as the actual expressions that write.  Of course, we may not find one in all cases because of move elimination.

This standardizes on the last non-eliminated set, not in a delay slot, as the result variable to use for a `cond` without an else.

We could possibly use something else if detecting this causes trouble, but this was easy to implement and easy to understand the debug output.