### PR TITLE
[decompiler] Fix cast bug, compiler stack bug, and rpc-h bug

### DIFF
--- a/decompiler/analysis/variable_naming.cpp
+++ b/decompiler/analysis/variable_naming.cpp
@@ -653,7 +653,6 @@ void update_var_info(VariableNames::VarInfo* info,
     info->reg_id.reg = reg;
 
     info->type = type;
-
     info->initialized = true;
   }
 }
@@ -664,15 +663,9 @@ bool merge_infos(VariableNames::VarInfo* info1,
   if (info1->initialized && info2->initialized) {
     bool changed;
     auto new_type = dts.tp_lca(info1->type, info2->type, &changed);
-    if (changed) {
-      //      fmt::print("changed new to {} from {} {} ({} {})\n", new_type.print(),
-      //      info1->type.print(),
-      //                 info2->type.print(), info1->reg_id.print(), info2->reg_id.print());
-      info1->type = new_type;
-      info2->type = new_type;
-
-      return true;
-    }
+    info1->type = new_type;
+    info2->type = new_type;
+    return true;
   }
   return false;
 }

--- a/goal_src/engine/ps2/rpc-h.gc
+++ b/goal_src/engine/ps2/rpc-h.gc
@@ -133,7 +133,7 @@
           (return-from #f '#t)
           )
       (set! (-> active-buffer busy) '#f)
-      (set! (-> active-buffer elt-count) 0)
+      (set! (-> active-buffer elt-used) 0)
       )
     )
   '#f

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -73,6 +73,11 @@
      )
   )
 
+(defmacro lg ()
+  "Load an already built game."
+  `(dgo-load "game" global #xf #x200000)
+  )
+
 (defmacro tc ()
   "Typecheck against the all-types file"
   `(m "decompiler/config/all-types.gc")

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -41,7 +41,7 @@ int get_stack_offset(const RegVal* rv, const AllocationResult& allocs) {
   } else {
     assert(rv->forced_on_stack());
     auto& ass = allocs.ass_as_ranges.at(rv->ireg().id);
-    auto stack_slot = ass.assignment.at(0).stack_slot;
+    auto stack_slot = allocs.get_slot_for_spill(ass.assignment.at(0).stack_slot);
     assert(stack_slot >= 0);
     return stack_slot * 8;
   }

--- a/goalc/listener/Listener.cpp
+++ b/goalc/listener/Listener.cpp
@@ -551,9 +551,6 @@ void Listener::handle_output_message(const char* msg) {
  * Add a load to the load listing.
  */
 void Listener::add_load(const std::string& name, const LoadEntry& le) {
-  if (m_load_entries.find(name) != m_load_entries.end() && name != "*listener*") {
-    printf("[Listener Warning] The runtime has loaded %s twice!\n", name.c_str());
-  }
   m_load_entries[name] = le;
 }
 


### PR DESCRIPTION
Fixes:
- Missing casts in decompiler
- Very bad stack address bug in the compiler when using both address of variables and stack structures.
- Bug in `rpc-h` (manually decompiled wrong, a long time ago)
- Removes stupid "loaded twice" warning from compiler.