### PR TITLE
decomp: Finish `subdivide` except 2 CFG failing functions

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -11186,7 +11186,7 @@
   :flag-assert         #xe00000034
   (:methods
     (dummy-9 (_type_) none 9)
-    (dummy-10 (_type_) none 10)
+    (print-stats (_type_ string) perf-stat 10)
     (PERF-COUNTER-REG-ACCESS-11 (_type_) none 11)
     (PERF-COUNTER-REG-ACCESS-12 (_type_) none 12)
     (update-wait-stats-13 (_type_ uint uint uint) none 13)
@@ -14465,32 +14465,32 @@
 
 ;; - Functions
 
-(define-extern perf-stat-bucket->string function)
-(define-extern print-tr-stat function)
-(define-extern clear-tr-stat function)
-(define-extern print-terrain-stats function)
-(define-extern update-subdivide-settings! function)
-(define-extern set-tfrag-dists! function)
+(define-extern perf-stat-bucket->string (function int string))
+(define-extern print-tr-stat (function tr-stat string string uint)) ;; TODO - only the last int arg is used, it sets it to none anyway...
+(define-extern clear-tr-stat (function tr-stat none))
+(define-extern print-terrain-stats (function int int rgba int float none)) ;; TODO - the ints are unused
+(define-extern update-subdivide-settings! (function subdivide-settings math-camera int none))
+(define-extern set-tfrag-dists! (function subdivide-settings subdivide-settings))
 (define-extern start-perf-stat-collection function)
 (define-extern end-perf-stat-collection function)
-(define-extern print-perf-stats function)
+(define-extern print-perf-stats (function none))
 
 ;; - Unknowns
 
 (define-extern *subdivide-settings* subdivide-settings)
-;;(define-extern *tfrag-work* object) ;; unknown type
-;;(define-extern *perf-stats* object) ;; unknown type
-;;(define-extern *merc-global-stats* object) ;; unknown type
-;;(define-extern *stat-string-tfrag-near* object) ;; unknown type
-;;(define-extern *stat-string-tfrag* object) ;; unknown type
-;;(define-extern *stat-string-total* object) ;; unknown type
-;;(define-extern *terrain-context* object) ;; unknown type
-;;(define-extern GSH_ENABLE object) ;; unknown type
-;;(define-extern GSH_BUCKET object) ;; unknown type
-;;(define-extern GSH_WHICH_STAT object) ;; unknown type
-;;(define-extern GSH_MAX_DISPLAY object) ;; unknown type
-;;(define-extern GSH_TIME object) ;; unknown type
-;;(define-extern *gomi-stats-hack* object) ;; unknown type
+(define-extern *tfrag-work* tfrag-work)
+(define-extern *perf-stats* perf-stat-array)
+(define-extern *merc-global-stats* merc-global-stats)
+(define-extern *stat-string-tfrag-near* string)
+(define-extern *stat-string-tfrag* string)
+(define-extern *stat-string-total* string)
+(define-extern *terrain-context* terrain-context)
+(define-extern GSH_ENABLE symbol) ;; TODO - guess
+(define-extern GSH_BUCKET int)
+(define-extern GSH_WHICH_STAT int)
+(define-extern GSH_MAX_DISPLAY symbol) ;; TODO - guess
+(define-extern GSH_TIME int)
+(define-extern *gomi-stats-hack* pointer) ;; TODO - result from a malloc
 
 
 ;; ----------------------

--- a/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
@@ -538,11 +538,11 @@
    ["L275", "uint64", true],
    ["L133", "_auto_", true]
   ],
-  
+
   "vol-h": [
     ["L13", "float", true]
   ],
-  
+
   "joint": [
     ["L330", "float", true],
     ["L329", "float", true]
@@ -555,7 +555,7 @@
   "navigate-h": [
     ["L20", "float", true]
   ],
-  
+
   "debug": [
     ["L221", "float", true],
     ["L217", "float", true],
@@ -586,7 +586,7 @@
   "entity-table": [
     ["L8", "(array entity-info)", true]
   ],
-  
+
   "main": [
     ["L230", "_lambda_", true]
   ],
@@ -594,7 +594,7 @@
   "geometry": [
     ["L125", "float", true]
   ],
-  
+
   "level": [
     ["L452", "_auto_", true],
     ["L482", "float", true],
@@ -602,24 +602,30 @@
     ["L484", "uint64", true],
     ["L485", "uint64", true]
   ],
-  
+
   "process-drawable": [
     ["L257", "float", true],
     ["L262", "float", true],
     ["L260", "float", true],
     ["L259", "float", true]
   ],
-  
+
   "logic-target": [
     ["L264", "float", true],
     ["L253", "float", true],
     ["L255", "float", true]
   ],
-  
+
   "load-boundary": [
     ["L327", "(inline-array lbvtx)", true, 3]
   ],
-  
+
+  "subdivide": [
+    ["L114", "rgba", true],
+    ["L128", "float", true],
+    ["L129", "float", true]
+  ],
+
   // please do not add things after this entry! git is dumb.
   "object-file-that-doesnt-actually-exist-and-i-just-put-this-here-to-prevent-merge-conflicts-with-this-file":[]
 }

--- a/decompiler/util/DecompilerTypeSystem.cpp
+++ b/decompiler/util/DecompilerTypeSystem.cpp
@@ -414,6 +414,12 @@ int DecompilerTypeSystem::get_format_arg_count(const std::string& str) const {
       if (i + 1 < str.length() && (str.at(i) == '2') && str.at(i + 1) == 'j') {
         continue;
       }
+
+      // ~0k
+      if (i + 1 < str.length() && (str.at(i) == '0') && str.at(i + 1) == 'k') {
+        continue;
+      }
+
       arg_count++;
     }
   }


### PR DESCRIPTION
```
start-perf-stat-collection
end-perf-stat-collection
```

Both cannot resolve the CFG