### PR TITLE
tooling: Add some very basic IR2 Syntax Highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ cmake-build-debug/*
 build/*
 decompiler_out/*
 logs/*
-.vscode/settings.json
 
 
 # for Nix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,145 @@
+{
+  "files.associations": {
+    "*ir2.asm": "Plain Text",
+    ".gc": "lisp",
+    ".gs": "lisp",
+    ".gd": "lisp"
+  },
+  "highlight.maxMatches": 50000, // Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes
+  "highlight.regexes": {
+    "(\\.function.*)": [
+      {
+        "overviewRulerColor": "transparent", // TODO - fix this bug, it extends beyond the line match
+        "color": "#41f041",
+        "fontWeight": "bold",
+        "filterFileRegex": ".*\\.asm",
+      }
+    ],
+    "(INFO:.*)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "yellow",
+        "fontWeight": "bold",
+        "filterFileRegex": ".*\\.asm",
+      }
+    ],
+    "(at op \\d+)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#4de0ff"
+      }
+    ],
+    "(.*;; )(\\[\\s*\\d+\\])": [
+      {},
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#4de0ff"
+      }
+    ],
+    "(lw.+, )(.+\\(s7\\))": [
+      {},
+      {
+        "overviewRulerColor": "transparent",
+        "color": "magenta"
+      }
+    ],
+    "(L\\d+)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#f0d541"
+      }
+    ],
+    "(B\\d+:)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#f07341"
+      }
+    ],
+    "(at)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "red"
+      }
+    ],
+    "(gp)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#64c5e3"
+      }
+    ],
+    "(v0)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#c6c1e6"
+      }
+    ],
+    "(v1)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#dae6be"
+      }
+    ],
+    "(s6)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#41f0b0"
+      }
+    ],
+    "(a0)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "pink"
+      }
+    ],
+    "(a1)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#e065bb"
+      }
+    ],
+    "(a2)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#6dd1a6"
+      }
+    ],
+    "(a3)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#bad192"
+      }
+    ],
+    "(t0)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#b56b82"
+      }
+    ],
+    "(t1)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#6d32ba"
+      }
+    ],
+    "(t2)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#db9267"
+      }
+    ],
+    "(t3)": [
+      {
+        "overviewRulerColor": "transparent",
+        "color": "#92db67"
+      }
+    ],
+    "(WARN:.*)": [
+      {
+        "overviewRulerColor": "red",
+        "color": "red",
+        "fontWeight": "bold",
+        "filterFileRegex": ".*\\.asm",
+      }
+    ],
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,139 +7,201 @@
   },
   "highlight.maxMatches": 50000, // Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes
   "highlight.regexes": {
-    "(\\.function.*)": [
-      {
-        "overviewRulerColor": "transparent", // TODO - fix this bug, it extends beyond the line match
-        "color": "#41f041",
-        "fontWeight": "bold",
-        "filterFileRegex": ".*\\.asm",
-      }
-    ],
-    "(INFO:.*)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "yellow",
-        "fontWeight": "bold",
-        "filterFileRegex": ".*\\.asm",
-      }
-    ],
-    "(at op \\d+)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#4de0ff"
-      }
-    ],
-    "(.*;; )(\\[\\s*\\d+\\])": [
-      {},
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#4de0ff"
-      }
-    ],
-    "(lw.+, )(.+\\(s7\\))": [
-      {},
-      {
-        "overviewRulerColor": "transparent",
-        "color": "magenta"
-      }
-    ],
-    "(L\\d+)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#f0d541"
-      }
-    ],
-    "(B\\d+:)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#f07341"
-      }
-    ],
-    "(at)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "red"
-      }
-    ],
-    "(gp)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#64c5e3"
-      }
-    ],
-    "(v0)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#c6c1e6"
-      }
-    ],
-    "(v1)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#dae6be"
-      }
-    ],
-    "(s6)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#41f0b0"
-      }
-    ],
-    "(a0)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "pink"
-      }
-    ],
-    "(a1)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#e065bb"
-      }
-    ],
-    "(a2)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#6dd1a6"
-      }
-    ],
-    "(a3)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#bad192"
-      }
-    ],
-    "(t0)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#b56b82"
-      }
-    ],
-    "(t1)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#6d32ba"
-      }
-    ],
-    "(t2)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#db9267"
-      }
-    ],
-    "(t3)": [
-      {
-        "overviewRulerColor": "transparent",
-        "color": "#92db67"
-      }
-    ],
-    "(WARN:.*)": [
-      {
-        "overviewRulerColor": "red",
-        "color": "red",
-        "fontWeight": "bold",
-        "filterFileRegex": ".*\\.asm",
-      }
-    ],
+    "(\\.function.*)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent", // TODO - fix this bug, it extends beyond the line match
+          "color": "#41f041",
+          "fontWeight": "bold"
+        }
+      ]
+    },
+    "(INFO:.*)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "yellow",
+          "fontWeight": "bold",
+          "filterFileRegex": ".*ir2\\.asm"
+        }
+      ]
+    },
+    "(at op \\d+)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#4de0ff"
+        }
+      ]
+    },
+    "(.*;; )(\\[\\s*\\d+\\])": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {},
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#4de0ff"
+        }
+      ]
+    },
+    "(lw.+, )(.+\\(s7\\))": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {},
+        {
+          "overviewRulerColor": "transparent",
+          "color": "magenta"
+        }
+      ]
+    },
+    "(L\\d+)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#f0d541"
+        }
+      ]
+    },
+    "(B\\d+:)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#f07341"
+        }
+      ]
+    },
+    "(at)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "red"
+        }
+      ]
+    },
+    "(gp)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#64c5e3"
+        }
+      ]
+    },
+    "(v0)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#c6c1e6"
+        }
+      ]
+    },
+    "(v1)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#dae6be"
+        }
+      ]
+    },
+    "(s6)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#41f0b0"
+        }
+      ]
+    },
+    "(a0)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "pink"
+        }
+      ]
+    },
+    "(a1)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#e065bb"
+        }
+      ]
+    },
+    "(a2)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#6dd1a6"
+        }
+      ]
+    },
+    "(a3)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#bad192"
+        }
+      ]
+    },
+    "(t0)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#b56b82"
+        }
+      ]
+    },
+    "(t1)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#6d32ba"
+        }
+      ]
+    },
+    "(t2)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#db9267"
+        }
+      ]
+    },
+    "(t3)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "transparent",
+          "color": "#92db67"
+        }
+      ]
+    },
+    "(WARN:.*)": {
+      "filterFileRegex": ".*ir2\\.asm",
+      "decorations": [
+        {
+          "overviewRulerColor": "red",
+          "color": "red",
+          "fontWeight": "bold",
+          "filterFileRegex": ".*ir2\\.asm"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Requires VSCode

You will need the following extension - https://github.com/fabiospampinato/vscode-highlight

It has a few rough-edges, but for the most part it's pretty solid

![image](https://user-images.githubusercontent.com/13153231/124062040-08f31100-d9fe-11eb-8161-a39b2594593e.png)
