### PR TITLE
docs: cleanup frontend artifacts when rebuilding

### DIFF
--- a/.github/workflows/build-doc-app.yaml
+++ b/.github/workflows/build-doc-app.yaml
@@ -32,6 +32,9 @@ jobs:
           npm install
           npm run build
           cd ../..
+          rm -r ./docs/css
+          rm -r ./docs/img
+          rm -r ./docs/js
           cp -r ./docs/gh-pages-proj/dist/* ./docs/
 
       - name: Add & Commit


### PR DESCRIPTION
Not cleaning up the folder is an issue... https://github.com/water111/jak-project/tree/master/docs/js

This fixes that, leaving the hashes in the file names as it seems a little annoying to fix AND it's for a purpose - it's to cache-bust on a new version of the file.  But the hashes should only change when the file itself changes (the css folder has far fewer versions for example)