### PR TITLE
[decompiler] Don't crash when static refs pass fails

### DIFF
--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -624,7 +624,12 @@ void ObjectFileDB::ir2_insert_anonymous_functions() {
     (void)segment_id;
     (void)data;
     if (func.ir2.top_form && func.ir2.env.has_type_analysis()) {
-      total += insert_static_refs(func.ir2.top_form, *func.ir2.form_pool, func, dts);
+      try {
+        total += insert_static_refs(func.ir2.top_form, *func.ir2.form_pool, func, dts);
+      } catch (std::exception& e) {
+        func.warnings.general_warning("Failed static ref finding: {}\n", e.what());
+        lg::error("Function {} failed static ref: {}\n", func.guessed_name.to_string(), e.what());
+      }
     }
   });
 


### PR DESCRIPTION
will fix https://github.com/water111/jak-project/issues/730