### PR TITLE
[goalc] support storing a float in a 64-bit memory location

### DIFF
--- a/docs/markdown/progress-notes/changelog.md
+++ b/docs/markdown/progress-notes/changelog.md
@@ -188,3 +188,4 @@
 - The register allocator has been dramatically improved and generates ~5x fewer spill instructions and is able to eliminate more moves.
 - Added a `(print-debug-compiler-stats)` form to print out statistics related to register allocation and move elimination
 - Added `get-enum-vals` which returns a list of pairs. Each pair is the name (symbol) and value (int) for each value in the enum
+- It is now possible to set a 64-bit memory location from a float, if you insert a cast. It will zero-extend the float, just like any other float -> 64-bit conversion.

--- a/test/goalc/source_templates/with_game/test-set-u64-from-float.gc
+++ b/test/goalc/source_templates/with_game/test-set-u64-from-float.gc
@@ -1,0 +1,8 @@
+(let ((a (new 'stack-no-clear 'array 'float 4))
+      (b (new 'stack-no-clear 'array 'uint64 2))
+      )
+  (set! (-> b 0) #xbbbbbbbbbbbbbbbb)
+  (set! (-> a 0) 12.0)
+  (set! (-> b 0) (the-as uint (- (-> a 0))))
+  (format #t "~f #x~X #x~X #x~X~%" (-> b 0) (-> b 0) (-> (the-as (pointer uint32) b) 0) (-> (the-as (pointer uint32) b) 1))
+  )

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -830,6 +830,11 @@ TEST_F(WithGameTests, GetEnumVals) {
                           "(thing5 . #<invalid object #x5>))\n0\n"});
 }
 
+TEST_F(WithGameTests, SetU64FromFloat) {
+  runner.run_static_test(env, testCategory, "test-set-u64-from-float.gc",
+                         {"-12.0000 #xc1400000 #xc1400000 #x0\n0\n"});
+}
+
 TEST(TypeConsistency, TypeConsistency) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();


### PR DESCRIPTION
this makes storing consistent with other promotions to 64-bit, which the decompiler and GOAL code both rely on.