### PR TITLE
Compiler performance improvements and error clean-up

### DIFF
--- a/common/goos/Interpreter.h
+++ b/common/goos/Interpreter.h
@@ -23,6 +23,7 @@ class Interpreter {
   void set_global_variable_to_symbol(const std::string& name, const std::string& value);
   Object eval(Object obj, const std::shared_ptr<EnvironmentObject>& env);
   Object intern(const std::string& name);
+  HeapObject* intern_ptr(const std::string& name);
   void disable_printfs();
   Object eval_symbol(const Object& sym, const std::shared_ptr<EnvironmentObject>& env);
   bool eval_symbol(const Object& sym,

--- a/common/goos/Reader.cpp
+++ b/common/goos/Reader.cpp
@@ -189,7 +189,17 @@ Object Reader::read_from_string(const std::string& str, bool add_top_level) {
  * Read a file
  */
 Object Reader::read_from_file(const std::vector<std::string>& file_path) {
-  auto textFrag = std::make_shared<FileText>(file_util::get_file_path(file_path));
+  std::string joined_name;
+
+  for (const auto& thing : file_path) {
+    if (!joined_name.empty()) {
+      joined_name += '/';
+    }
+
+    joined_name += thing;
+  }
+
+  auto textFrag = std::make_shared<FileText>(file_util::get_file_path(file_path), joined_name);
   db.insert(textFrag);
 
   auto result = internal_read(textFrag);
@@ -524,7 +534,7 @@ Object Reader::read_list(TextStream& ts, bool expect_close_paren) {
     db.link(rv, ts.text, start_offset);
     return rv;
   } else {
-    auto rv = build_list(objects);
+    auto rv = build_list(std::move(objects));
     db.link(rv, ts.text, start_offset);
     return rv;
   }

--- a/common/goos/TextDB.h
+++ b/common/goos/TextDB.h
@@ -34,6 +34,7 @@ class SourceText {
   virtual std::string get_description() = 0;
   std::string get_line_containing_offset(int offset);
   int get_line_idx(int offset);
+  int get_offset_of_line(int line_idx);
   // should the compiler keep looking up the stack when printing errors on this, or not?
   // this should return true if the text source is specific enough so that they can find what they
   // want
@@ -73,13 +74,14 @@ class ProgramString : public SourceText {
  */
 class FileText : public SourceText {
  public:
-  FileText(std::string filename_);
+  FileText(const std::string& filename, const std::string& description_name);
 
-  std::string get_description() { return filename; }
+  std::string get_description() { return m_desc_name; }
   ~FileText() = default;
 
  private:
-  std::string filename;
+  std::string m_filename;
+  std::string m_desc_name;
 };
 
 struct TextRef {

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -71,8 +71,8 @@ class Compiler {
   Debugger m_debugger;
   goos::Interpreter m_goos;
   std::unordered_map<std::string, TypeSpec> m_symbol_types;
-  std::unordered_map<std::shared_ptr<goos::SymbolObject>, goos::Object> m_global_constants;
-  std::unordered_map<std::shared_ptr<goos::SymbolObject>, LambdaVal*> m_inlineable_functions;
+  std::unordered_map<goos::HeapObject*, goos::Object> m_global_constants;
+  std::unordered_map<goos::HeapObject*, LambdaVal*> m_inlineable_functions;
   CompilerSettings m_settings;
   bool m_throw_on_define_extern_redefinition = false;
   SymbolInfoMap m_symbol_info;
@@ -109,6 +109,7 @@ class Compiler {
   Val* compile_goos_macro(const goos::Object& o,
                           const goos::Object& macro_obj,
                           const goos::Object& rest,
+                          const goos::Object& name_symbol,
                           Env* env);
   Val* compile_pair(const goos::Object& code, Env* env);
   Val* compile_integer(const goos::Object& code, Env* env);
@@ -357,9 +358,9 @@ class Compiler {
   void throw_compiler_error(const goos::Object& code, const std::string& str, Args&&... args) {
     fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "-- Compilation Error! --\n");
     if (!str.empty() && str.back() == '\n') {
-      fmt::print(str, std::forward<Args>(args)...);
+      fmt::print(fmt::emphasis::bold, str, std::forward<Args>(args)...);
     } else {
-      fmt::print(str + '\n', std::forward<Args>(args)...);
+      fmt::print(fmt::emphasis::bold, str + '\n', std::forward<Args>(args)...);
     }
 
     fmt::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Form:\n");
@@ -371,9 +372,9 @@ class Compiler {
   void throw_compiler_error_no_code(const std::string& str, Args&&... args) {
     fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "-- Compilation Error! --\n");
     if (!str.empty() && str.back() == '\n') {
-      fmt::print(str, std::forward<Args>(args)...);
+      fmt::print(fmt::emphasis::bold, str, std::forward<Args>(args)...);
     } else {
-      fmt::print(str + '\n', std::forward<Args>(args)...);
+      fmt::print(fmt::emphasis::bold, str + '\n', std::forward<Args>(args)...);
     }
 
     fmt::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Form:\n");

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -130,12 +130,12 @@ TypeSpec Compiler::parse_typespec(const goos::Object& src) {
 
 bool Compiler::is_local_symbol(const goos::Object& obj, Env* env) {
   // check in the symbol macro env.
-  auto mlet_env = get_parent_env_of_type<SymbolMacroEnv>(env);
+  auto mlet_env = env->symbol_macro_env();
   while (mlet_env) {
     if (mlet_env->macros.find(obj.as_symbol()) != mlet_env->macros.end()) {
       return true;
     }
-    mlet_env = get_parent_env_of_type<SymbolMacroEnv>(mlet_env->parent());
+    mlet_env = mlet_env->parent()->symbol_macro_env();
   }
 
   // check lexical

--- a/goalc/compiler/Val.cpp
+++ b/goalc/compiler/Val.cpp
@@ -250,7 +250,7 @@ std::string BitFieldVal::print() const {
 
 RegVal* BitFieldVal::to_reg(Env* env) {
   int start_bit = -1;
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
   RegVal* result = fe->make_ireg(coerce_to_reg_type(m_ts), RegClass::GPR_64);
 
   // this first step gets the right 64-bits into a GPR that is also used as the result.

--- a/goalc/compiler/compilation/Asm.cpp
+++ b/goalc/compiler/compilation/Asm.cpp
@@ -33,7 +33,7 @@ Val* Compiler::compile_rlet(const goos::Object& form, const goos::Object& rest, 
 
   auto defs = args.unnamed.front();
 
-  auto fenv = get_parent_env_of_type<FunctionEnv>(env);
+  auto fenv = env->function_env();
   auto lenv = fenv->alloc_env<LexicalEnv>(env);
 
   std::vector<IRegConstraint> constraints;

--- a/goalc/compiler/compilation/Block.cpp
+++ b/goalc/compiler/compilation/Block.cpp
@@ -47,7 +47,7 @@ Val* Compiler::compile_block(const goos::Object& form, const goos::Object& _rest
     throw_compiler_error(form, "Block form has an empty or invalid body");
   }
 
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
 
   // create environment
   auto block_env = fe->alloc_env<BlockEnv>(env, symbol_string(name));
@@ -116,7 +116,7 @@ Val* Compiler::compile_return_from(const goos::Object& form, const goos::Object&
 
   // evaluate expression to return
   auto result = compile_error_guard(value_expression, env);
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
 
   // find block to return from
   auto block = dynamic_cast<BlockEnv*>(env->find_block(block_name));
@@ -163,7 +163,7 @@ Val* Compiler::compile_label(const goos::Object& form, const goos::Object& rest,
 
   // make a label pointing to the end of the current function env. safe because we'll always add
   // a terminating "null" instruction at the end.
-  auto func_env = get_parent_env_of_type<FunctionEnv>(env);
+  auto func_env = env->function_env();
   labels[label_name] = Label(func_env, func_env->code().size());
   return get_none();
 }
@@ -182,7 +182,7 @@ Val* Compiler::compile_goto(const goos::Object& form, const goos::Object& rest, 
 
   // add this goto to the list of gotos to resolve after the function is done.
   // it's safe to have this reference, as the FunctionEnv also owns the goto.
-  get_parent_env_of_type<FunctionEnv>(env)->unresolved_gotos.push_back({ir_goto.get(), label_name});
+  env->function_env()->unresolved_gotos.push_back({ir_goto.get(), label_name});
   env->emit(std::move(ir_goto));
   return get_none();
 }

--- a/goalc/compiler/compilation/CompilerControl.cpp
+++ b/goalc/compiler/compilation/CompilerControl.cpp
@@ -49,7 +49,7 @@ Val* Compiler::compile_seval(const goos::Object& form, const goos::Object& rest,
   (void)env;
   try {
     for_each_in_list(rest, [&](const goos::Object& o) {
-      m_goos.eval_with_rewind(o, m_goos.global_environment.as_env());
+      m_goos.eval_with_rewind(o, m_goos.global_environment.as_env_ptr());
     });
   } catch (std::runtime_error& e) {
     throw_compiler_error(form, "Error while evaluating GOOS: {}", e.what());
@@ -398,7 +398,7 @@ std::string Compiler::make_symbol_info_description(const SymbolInfo& info) {
     case SymbolInfo::Kind::CONSTANT:
       return fmt::format(
           "[Constant] Name: {} Value: {} Defined: {}", info.name(),
-          m_global_constants.at(m_goos.reader.symbolTable.intern(info.name())).print(),
+          m_global_constants.at(m_goos.reader.symbolTable.intern_ptr(info.name())).print(),
           m_goos.reader.db.get_info_for(info.src_form()));
     case SymbolInfo::Kind::FUNCTION:
       return fmt::format("[Function] Name: {} Defined: {}", info.name(),

--- a/goalc/compiler/compilation/ControlFlow.cpp
+++ b/goalc/compiler/compilation/ControlFlow.cpp
@@ -125,7 +125,7 @@ Val* Compiler::compile_condition_as_bool(const goos::Object& form,
   (void)rest;
   auto c = compile_condition(form, env, true);
   auto result = compile_get_sym_obj("#f", env)->to_gpr(env);  // todo - can be optimized.
-  Label label(get_parent_env_of_type<FunctionEnv>(env), -5);
+  Label label(env->function_env(), -5);
   auto branch_ir = std::make_unique<IR_ConditionalBranch>(c, label);
   auto branch_ir_ref = branch_ir.get();
   env->emit(std::move(branch_ir));
@@ -155,7 +155,7 @@ Val* Compiler::compile_when_goto(const goos::Object& form, const goos::Object& _
   // compile as condition (will set flags register with a cmp instruction)
   auto condition = compile_condition(condition_code, env, false);
   auto branch = std::make_unique<IR_ConditionalBranch>(condition, Label());
-  get_parent_env_of_type<FunctionEnv>(env)->unresolved_cond_gotos.push_back({branch.get(), label});
+  env->function_env()->unresolved_cond_gotos.push_back({branch.get(), label});
   env->emit(std::move(branch));
   return get_none();
 }
@@ -169,7 +169,7 @@ Val* Compiler::compile_when_goto(const goos::Object& form, const goos::Object& _
 Val* Compiler::compile_cond(const goos::Object& form, const goos::Object& rest, Env* env) {
   auto result = env->make_gpr(m_ts.make_typespec("object"));
 
-  auto fenv = get_parent_env_of_type<FunctionEnv>(env);
+  auto fenv = env->function_env();
   auto end_label = fenv->alloc_unnamed_label();
   end_label->func = fenv;
   end_label->idx = -3;  // placeholder
@@ -276,7 +276,7 @@ Val* Compiler::compile_and_or(const goos::Object& form, const goos::Object& rest
   }
 
   auto result = env->make_gpr(m_ts.make_typespec("object"));  // temp type for now.
-  auto fenv = get_parent_env_of_type<FunctionEnv>(env);
+  auto fenv = env->function_env();
   auto end_label = fenv->alloc_unnamed_label();
   end_label->func = fenv;
   end_label->idx = -4;  // placeholder

--- a/goalc/compiler/compilation/Define.cpp
+++ b/goalc/compiler/compilation/Define.cpp
@@ -24,7 +24,7 @@ Val* Compiler::compile_define(const goos::Object& form, const goos::Object& rest
         sym.print(), global_constant->second.print());
   }
 
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
   auto sym_val = fe->alloc_val<SymbolVal>(symbol_string(sym), m_ts.make_typespec("symbol"));
   auto compiled_val = compile_error_guard(val, env);
   auto as_lambda = dynamic_cast<LambdaVal*>(compiled_val);
@@ -137,7 +137,7 @@ void Compiler::set_bitfield(const goos::Object& form, BitFieldVal* dst, RegVal* 
     return;
   }
 
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
 
   // first, get the value we want to modify:
   auto original_original = dst->parent()->to_gpr(env);
@@ -151,7 +151,7 @@ void Compiler::set_bitfield(const goos::Object& form, BitFieldVal* dst, RegVal* 
 }
 
 void Compiler::set_bitfield_128(const goos::Object& form, BitFieldVal* dst, RegVal* src, Env* env) {
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
 
   bool get_top = dst->offset() >= 64;
 
@@ -220,7 +220,7 @@ Val* Compiler::do_set(const goos::Object& form, Val* dest, RegVal* src_in_reg, V
 
     // we want to allow setting a 128-bit field from a 64-bit variable.
     if (as_mem_deref->info.size == 16) {
-      auto fe = get_parent_env_of_type<FunctionEnv>(env);
+      auto fe = env->function_env();
       auto src_128 = fe->make_ireg(src_in_reg->type(), RegClass::INT_128);
       env->emit_ir<IR_RegSet>(src_128, src_in_reg);
       src_in_reg = src_128;
@@ -229,7 +229,7 @@ Val* Compiler::do_set(const goos::Object& form, Val* dest, RegVal* src_in_reg, V
     // we want to allow setting a smaller thing from a 128-bit variable
     if (as_mem_deref->info.size != 16 && (src_in_reg->ireg().reg_class == RegClass::VECTOR_FLOAT ||
                                           src_in_reg->ireg().reg_class == RegClass::INT_128)) {
-      auto fe = get_parent_env_of_type<FunctionEnv>(env);
+      auto fe = env->function_env();
       auto src_gpr = fe->make_ireg(src_in_reg->type(), RegClass::GPR_64);
       env->emit_ir<IR_RegSet>(src_gpr, src_in_reg);
       src_in_reg = src_gpr;
@@ -237,7 +237,7 @@ Val* Compiler::do_set(const goos::Object& form, Val* dest, RegVal* src_in_reg, V
 
     // we want to allow setting a 64-bit place to a float
     if (as_mem_deref->info.size == 8 && src_in_reg->ireg().reg_class == RegClass::FLOAT) {
-      auto fe = get_parent_env_of_type<FunctionEnv>(env);
+      auto fe = env->function_env();
       auto src_gpr = fe->make_ireg(src_in_reg->type(), RegClass::GPR_64);
       env->emit_ir<IR_RegSet>(src_gpr, src_in_reg);
       src_in_reg = src_gpr;

--- a/goalc/compiler/compilation/State.cpp
+++ b/goalc/compiler/compilation/State.cpp
@@ -73,8 +73,7 @@ Val* Compiler::compile_define_state_hook(const goos::Object& form,
                          state_name, existing_var->second.print(), state_type.print());
   }
   m_symbol_types[state_name] = state_type;
-  auto sym_val =
-      get_parent_env_of_type<FunctionEnv>(env)->alloc_val<SymbolVal>(state_name, state_type);
+  auto sym_val = env->function_env()->alloc_val<SymbolVal>(state_name, state_type);
   env->emit(std::make_unique<IR_SetSymbolValue>(sym_val, state_object));
 
   return get_none();

--- a/goalc/compiler/compilation/Static.cpp
+++ b/goalc/compiler/compilation/Static.cpp
@@ -265,7 +265,7 @@ StaticResult Compiler::compile_new_static_structure(const goos::Object& form,
 
   obj->data.resize(type_info->get_size_in_memory());
   compile_static_structure_inline(form, type, _field_defs, obj.get(), 0, env);
-  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto fie = env->file_env();
   auto result = StaticResult::make_structure_reference(obj.get(), type);
   fie->add_static(std::move(obj));
   return result;
@@ -444,7 +444,7 @@ Val* Compiler::compile_bitfield_definition(const goos::Object& form,
     if (use_128) {
       auto integer_lo = compile_integer(constant_integer_part.lo, env)->to_gpr(env);
       auto integer_hi = compile_integer(constant_integer_part.hi, env)->to_gpr(env);
-      auto fe = get_parent_env_of_type<FunctionEnv>(env);
+      auto fe = env->function_env();
       auto rv = fe->make_ireg(type, RegClass::INT_128);
       auto xmm_temp = fe->make_ireg(TypeSpec("object"), RegClass::INT_128);
 
@@ -529,8 +529,8 @@ Val* Compiler::compile_bitfield_definition(const goos::Object& form,
  * - Strings
  */
 StaticResult Compiler::compile_static_no_eval_for_pairs(const goos::Object& form, Env* env) {
-  auto fie = get_parent_env_of_type<FileEnv>(env);
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fie = env->file_env();
+  auto fe = env->function_env();
   auto segment = fe->segment;
   if (segment == TOP_LEVEL_SEGMENT) {
     segment = MAIN_SEGMENT;
@@ -586,8 +586,8 @@ StaticResult Compiler::compile_static_no_eval_for_pairs(const goos::Object& form
  */
 StaticResult Compiler::compile_static(const goos::Object& form_before_macro, Env* env) {
   auto form = expand_macro_completely(form_before_macro, env);
-  auto fie = get_parent_env_of_type<FileEnv>(env);
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fie = env->file_env();
+  auto fe = env->function_env();
   auto segment = fe->segment;
   if (segment == TOP_LEVEL_SEGMENT) {
     segment = MAIN_SEGMENT;
@@ -804,7 +804,7 @@ void Compiler::fill_static_array_inline(const goos::Object& form,
 StaticResult Compiler::fill_static_array(const goos::Object& form,
                                          const goos::Object& rest,
                                          Env* env) {
-  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto fie = env->file_env();
   // (new 'static 'boxed-array ...)
   // get all arguments now
   auto args = get_list_as_vector(rest);
@@ -843,7 +843,7 @@ StaticResult Compiler::fill_static_array(const goos::Object& form,
 StaticResult Compiler::fill_static_boxed_array(const goos::Object& form,
                                                const goos::Object& rest,
                                                Env* env) {
-  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto fie = env->file_env();
   // (new 'static 'boxed-array ...)
   // get all arguments now
   // auto args = get_list_as_vector(rest);
@@ -975,7 +975,7 @@ void Compiler::fill_static_inline_array_inline(const goos::Object& form,
 StaticResult Compiler::fill_static_inline_array(const goos::Object& form,
                                                 const goos::Object& rest,
                                                 Env* env) {
-  auto fie = get_parent_env_of_type<FileEnv>(env);
+  auto fie = env->file_env();
   // (new 'static 'inline-array ...)
   // get all arguments now
   auto args = get_list_as_vector(rest);
@@ -1011,7 +1011,7 @@ Val* Compiler::compile_static_pair(const goos::Object& form, Env* env) {
   assert(form.is_pair());  // (quote PAIR)
   auto result = compile_static_no_eval_for_pairs(form, env);
   assert(result.is_reference());
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
   auto static_result = fe->alloc_val<StaticVal>(result.reference(), result.typespec());
   return static_result;
 }
@@ -1020,7 +1020,7 @@ Val* Compiler::compile_new_static_structure_or_basic(const goos::Object& form,
                                                      const TypeSpec& type,
                                                      const goos::Object& field_defs,
                                                      Env* env) {
-  auto fe = get_parent_env_of_type<FunctionEnv>(env);
+  auto fe = env->function_env();
   auto sr = compile_new_static_structure(form, type, field_defs, env);
   auto result = fe->alloc_val<StaticVal>(sr.reference(), type);
   return result;

--- a/goalc/make/MakeSystem.cpp
+++ b/goalc/make/MakeSystem.cpp
@@ -65,7 +65,7 @@ void MakeSystem::load_project_file(const std::string& file_path) {
   // read the file
   auto data = m_goos.reader.read_from_file({file_path});
   // interpret it, which will call various handlers.
-  m_goos.eval(data, m_goos.global_environment.as_env());
+  m_goos.eval(data, m_goos.global_environment.as_env_ptr());
 }
 
 goos::Object MakeSystem::handle_defstep(const goos::Object& form,

--- a/goalc/regalloc/IRegSet.h
+++ b/goalc/regalloc/IRegSet.h
@@ -19,7 +19,7 @@
 
 class IRegSet {
  public:
-  IRegSet() = default;
+  IRegSet() { m_data.reserve(4); }
 
   /*!
    * Add the given ireg to the set.

--- a/test/test_goos.cpp
+++ b/test/test_goos.cpp
@@ -11,7 +11,7 @@ using namespace goos;
 namespace {
 // helper to evaluate a string as a goos expression.
 std::string e(Interpreter& interp, const std::string& in) {
-  return interp.eval(interp.reader.read_from_string(in), interp.global_environment.as_env())
+  return interp.eval(interp.reader.read_from_string(in), interp.global_environment.as_env_ptr())
       .print();
 }
 }  // namespace

--- a/test/test_reader.cpp
+++ b/test/test_reader.cpp
@@ -349,8 +349,6 @@ TEST(GoosReader, TextDb) {
                     .as_pair()
                     ->cdr.as_pair()
                     ->car;
-  std::string expected = "text from " +
-                         file_util::get_file_path({"test", "test_data", "test_reader_file0.gc"}) +
-                         ", line: 5\n(1 2 3 4)\n";
+  std::string expected = "test/test_data/test_reader_file0.gc, line: 5\n(1 2 3 4)\n ^\n";
   EXPECT_EQ(expected, reader.db.get_info_for(result));
 }


### PR DESCRIPTION
This speeds up compilation by 25-30%. It now takes under 3 seconds to start the compiler, run `(build-game)`, and exit the compiler.

This adds some new tracking for macros that will be required to do accurate address -> line mapping in the future.

Compiler errors were changed significantly, but should be better in all cases.