### PR TITLE
[decompiler] update gtest, fix some small bugs

### DIFF
--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -1926,15 +1926,17 @@ void SimpleExpressionElement::update_from_stack_int_to_float(const Env& env,
   auto fpr_convert_matcher =
       Matcher::op(GenericOpMatcher::fixed(FixedOperatorKind::GPR_TO_FPR), {Matcher::any(0)});
   auto type = env.get_types_before_op(var.idx()).get(var.reg()).typespec();
-  if (type == TypeSpec("int") || type == TypeSpec("uint") || type == TypeSpec("seconds")) {
+  // want to allow any child of integer so integer enums can also be converted to floats.
+  if (env.dts->ts.tc(TypeSpec("integer"), type) || type == TypeSpec("seconds")) {
     auto mr = match(fpr_convert_matcher, arg);
     if (mr.matched) {
       arg = mr.maps.forms.at(0);
     }
     result->push_back(pool.alloc_element<CastElement>(TypeSpec("float"), arg, true));
   } else {
-    throw std::runtime_error(fmt::format("Used int to float on a {} from {}: {}", type.print(),
-                                         var.to_form(env).print(), arg->to_string(env)));
+    throw std::runtime_error(fmt::format("Used int to float on a {} from {}: {} (op {})",
+                                         type.print(), var.to_form(env).print(),
+                                         arg->to_string(env), m_my_idx));
   }
 }
 

--- a/decompiler/IR2/IR2_common.h
+++ b/decompiler/IR2/IR2_common.h
@@ -180,7 +180,7 @@ struct UseDefInfo {
   std::vector<AccessRecord> uses;
   std::vector<AccessRecord> defs;
 
-  void disable_use(int op_id) {
+  void disable_use(int op_id, const Register& this_reg) {
     for (auto& x : uses) {
       if (x.op_id == op_id) {
         if (x.disabled) {
@@ -191,7 +191,11 @@ struct UseDefInfo {
       }
     }
 
-    throw std::runtime_error("Invalid disable use");
+    throw std::runtime_error(
+        fmt::format("Invalid disable use on register {} at op {}. The decompiler expects something "
+                    "to use the value stored in this register, but nothing does.  This could be "
+                    "caused by a missing return type or function argument.",
+                    this_reg.to_charp(), op_id));
   }
 
   void disable_def(int op_id, DecompWarnings& warnings) {
@@ -259,7 +263,7 @@ struct VariableNames {
   void disable_use(const RegisterAccess& access) {
     assert(access.mode() == AccessMode::READ);
     auto var_id = read_opid_to_varid.at(access.reg()).at(access.idx());
-    use_def_info.at(RegId(access.reg(), var_id)).disable_use(access.idx());
+    use_def_info.at(RegId(access.reg(), var_id)).disable_use(access.idx(), access.reg());
   }
 
   void disable_def(const RegisterAccess& access, DecompWarnings& warnings) {


### PR DESCRIPTION
Will fix https://github.com/water111/jak-project/issues/815 and improve the error message on int-to-float in cases where it's actually invalid.

Will improve the error message for https://github.com/water111/jak-project/issues/814 to tell you that you might have the return type wrong.

Also will update gtest submodule (https://github.com/water111/jak-project/issues/817), to hopefully prevent a compiler warning on newer versions of Visual Studio.