### PR TITLE
[decomp] minor type cleanup

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -5540,7 +5540,7 @@
 
 (declare-type engine basic)
 (deftype connection (connectable)
-  ((param0 (function object object object object object)      :offset-assert 16)
+  ((param0 basic         :offset-assert 16) ;; often (function object object object object object), but can be other things.
    (param1 basic         :offset-assert 20)
    (param2 basic         :offset-assert 24)
    (param3 basic         :offset-assert 28)
@@ -5584,7 +5584,7 @@
     (execute-connections (engine object) int 12)
     (execute-connections-and-move-to-dead (engine object) int 13)
     (execute-connections-if-needed (engine object) int 14)
-    (add-connection (engine process (function object object object object object) object object object) connection 15)
+    (add-connection (engine process object object object object) connection 15)
     (remove-from-process (engine process) int 16)
     (remove-matching (engine (function connection engine symbol)) int 17)
     (remove-all (engine) int 18)
@@ -5719,7 +5719,7 @@
   :flag-assert         #xe00000278
   (:methods
     (new (symbol type int) _type_ 0)
-    (push-setting! (_type_ process (function object object object object object) object object object) none 9)
+    (push-setting! (_type_ process symbol object object object) none 9)
     (set-setting! (_type_ process symbol symbol float int) none 10)
     (clear-pending-settings-from-process (_type_ process symbol) none 11)
     (copy-settings-from-target! (_type_) setting-data 12)

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -5704,7 +5704,7 @@
   :size-assert         #xc4
   :flag-assert         #xa000000c4
   (:methods
-    (handle-pending-updates (_type_ engine) setting-data 9)
+    (update-from-engine (_type_ engine) setting-data 9)
     )
   )
 

--- a/decompiler/config/jak1_ntsc_black_label/type_casts.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_casts.jsonc
@@ -340,9 +340,15 @@
 
   "(method 0 engine)": [[39, "v0", "pointer"]],
 
-  "(method 12 engine)": [[[5, 16], "s4", "connection"]],
+  "(method 12 engine)": [
+    [[5, 16], "s4", "connection"],
+    [12, "t9", "(function basic basic basic object object)"]
+  ],
 
-  "(method 13 engine)": [[[5, 24], "s4", "connection"]],
+  "(method 13 engine)": [
+    [[5, 24], "s4", "connection"],
+    [12, "t9", "(function basic basic basic object object)"]
+  ],
 
   "(method 15 engine)": [[[0, 36], "v1", "connection"]],
 

--- a/docs/markdown/progress-notes/changelog.md
+++ b/docs/markdown/progress-notes/changelog.md
@@ -206,3 +206,4 @@
 - Using `->` on a plain `pointer` or `inline-array` now generates an error instead of crashing the compiler
 - It is now possible to use a macro to provide a static inline array element definition
 - It is now possible to have symbol names that have a `#` in the middle of them
+- `go-hook` now returns the return value of the `enter-state` function it calls

--- a/goal_src/engine/ambient/ambient.gc
+++ b/goal_src/engine/ambient/ambient.gc
@@ -426,14 +426,7 @@
   (set! (-> self total-off-time) 0)
   (set! (-> self last-time) (-> *display* base-frame-counter))
   (set! *hint-semaphore* (the-as (pointer level-hint) (process->ppointer self)))
-  (push-setting!
-   *setting-control*
-   self
-   (the-as (function object object object object object) 'hint)
-   (process->ppointer self)
-   0.0
-   0
-   )
+  (push-setting! *setting-control* self 'hint (process->ppointer self) 0.0 0)
   (set! (-> self voicebox) (the-as handle #f))
   (let ((s5-1 (res-lump-struct arg2 'play-mode structure))
         (a0-6
@@ -486,24 +479,10 @@
   (set! (-> self last-time) (-> *display* base-frame-counter))
   (set! (-> self trans) arg1)
   (set! *hint-semaphore* (the-as (pointer level-hint) (process->ppointer self)))
-  (push-setting!
-   *setting-control*
-   self
-   (the-as (function object object object object object) 'hint)
-   (process->ppointer self)
-   0.0
-   0
-   )
+  (push-setting! *setting-control* self 'hint (process->ppointer self) 0.0 0)
   (set! (-> self mode) arg2)
   (if (or (= arg2 'camera) (= arg2 'ambient) (= arg2 'stinger))
-   (push-setting!
-    *setting-control*
-    self
-    (the-as (function object object object object object) 'ambient)
-    (process->ppointer self)
-    0.0
-    0
-    )
+   (push-setting! *setting-control* self 'ambient (process->ppointer self) 0.0 0)
    )
   (copy-settings-from-target! *setting-control*)
   (set!
@@ -736,30 +715,9 @@
        )
       (cond
        ((= (current-str-id) s5-2)
-        (push-setting!
-         *setting-control*
-         self
-         (the-as (function object object object object object) 'music-volume)
-         'rel
-         (-> *setting-control* current music-volume-movie)
-         0
-         )
-        (push-setting!
-         *setting-control*
-         self
-         (the-as (function object object object object object) 'sfx-volume)
-         'rel
-         (-> *setting-control* current sfx-volume-movie)
-         0
-         )
-        (push-setting!
-         *setting-control*
-         self
-         (the-as (function object object object object object) 'dialog-volume)
-         'rel
-         (-> *setting-control* current dialog-volume-hint)
-         0
-         )
+        (push-setting! *setting-control* self 'music-volume 'rel (-> *setting-control* current music-volume-movie) 0)
+        (push-setting! *setting-control* self 'sfx-volume 'rel (-> *setting-control* current sfx-volume-movie) 0)
+        (push-setting! *setting-control* self 'dialog-volume 'rel (-> *setting-control* current dialog-volume-hint) 0)
         (while (= (current-str-id) s5-2)
          (suspend)
          )
@@ -849,22 +807,8 @@
    (cond
     ((= (current-str-id) (-> self sound-id))
      (when (or (= (-> self mode) 'stinger) (= (-> self mode) 'camera))
-      (push-setting!
-       *setting-control*
-       self
-       (the-as (function object object object object object) 'music-volume)
-       'rel
-       (-> *setting-control* current music-volume-movie)
-       0
-       )
-      (push-setting!
-       *setting-control*
-       self
-       (the-as (function object object object object object) 'sfx-volume)
-       'rel
-       (-> *setting-control* current sfx-volume-movie)
-       0
-       )
+      (push-setting! *setting-control* self 'music-volume 'rel (-> *setting-control* current music-volume-movie) 0)
+      (push-setting! *setting-control* self 'sfx-volume 'rel (-> *setting-control* current sfx-volume-movie) 0)
       )
      (while (= (current-str-id) (-> self sound-id))
       (suspend)

--- a/goal_src/engine/collide/collide-shape-h.gc
+++ b/goal_src/engine/collide/collide-shape-h.gc
@@ -430,16 +430,16 @@
     ;; add us to right list.
     (case collide-list-kind
       (((collide-list-enum hit-by-player))
-       (add-connection *collide-hit-by-player-list* proc (the (function object object object object object) #f) obj #f #f))
+       (add-connection *collide-hit-by-player-list* proc #f obj #f #f))
 
       (((collide-list-enum usually-hit-by-player))
-       (add-connection *collide-usually-hit-by-player-list* proc (the (function object object object object object) #f) obj #f #f))
+       (add-connection *collide-usually-hit-by-player-list* proc #f obj #f #f))
 
       (((collide-list-enum hit-by-others))
-       (add-connection *collide-hit-by-others-list* proc (the (function object object object object object) #f) obj #f #f))
+       (add-connection *collide-hit-by-others-list* proc #f obj #f #f))
 
       (((collide-list-enum player))
-       (add-connection *collide-player-list* proc (the (function object object object object object) #f) obj #f #f))
+       (add-connection *collide-player-list* proc #f obj #f #f))
 
       (else
        (format 0 "Unsupported collide-list-enum in collide-shape constructor!~%"))

--- a/goal_src/engine/draw/drawable-ambient-h.gc
+++ b/goal_src/engine/draw/drawable-ambient-h.gc
@@ -7,6 +7,9 @@
 
 
 (declare-type entity-ambient basic)
+
+(define-extern vector-for-ambient (function process-drawable vector vector))
+
 (deftype drawable-ambient (drawable)
   ((ambient entity-ambient :offset 8)
    )

--- a/goal_src/engine/engine/connect.gc
+++ b/goal_src/engine/engine/connect.gc
@@ -53,11 +53,11 @@
 
 (declare-type engine basic)
 (deftype connection (connectable)
-  ((param0 (function object object object object object) :offset-assert 16)
-   (param1 basic         :offset-assert 20)
-   (param2 basic         :offset-assert 24)
-   (param3 basic         :offset-assert 28)
-   (quad   uint128     2 :offset 0)
+  ((param0 basic      :offset-assert 16) ;; often (function object object object object object)
+   (param1 basic      :offset-assert 20)
+   (param2 basic      :offset-assert 24)
+   (param3 basic      :offset-assert 28)
+   (quad   uint128  2 :offset 0)
    )
   :method-count-assert 14
   :size-assert         #x20
@@ -108,7 +108,7 @@
     (execute-connections (engine object) int 12)
     (execute-connections-and-move-to-dead (engine object) int 13)
     (execute-connections-if-needed (engine object) int 14)
-    (add-connection (engine process (function object object object object object) object object object) connection 15)
+    (add-connection (engine process object object object object) connection 15)
     (remove-from-process (engine process) int 16)
     (remove-matching (engine (function connection engine symbol)) int 17)
     (remove-all (engine) int 18)
@@ -336,7 +336,7 @@
   (let ((ct (the-as connection (-> obj alive-list-end prev0))))
     (while (!= ct (-> obj alive-list))
       ;; execute!
-      ((-> ct param0) (-> ct param1) (-> ct param2) (-> ct param3) arg0)
+      ((the-as (function basic basic basic object object) (-> ct param0)) (-> ct param1) (-> ct param2) (-> ct param3) arg0)
       ;; advance to previous.
       (set! ct (the-as connection (-> ct prev0)))
       )
@@ -350,7 +350,7 @@
   (let ((ct (the-as connection (-> obj alive-list-end prev0))))
     (while (!= ct (-> obj alive-list))
       ;; execute function
-      (let ((result ((-> ct param0) (-> ct param1) (-> ct param2) (-> ct param3) arg0)))
+      (let ((result ((the-as (function basic basic basic object object) (-> ct param0)) (-> ct param1) (-> ct param2) (-> ct param3) arg0)))
         ;; set the next one, _before_ removing
         (set! ct (the-as connection (-> ct prev0)))
         ;; remove if desired.
@@ -397,7 +397,7 @@
 (defmethod add-connection engine
     ((obj engine)
      (proc process)
-     (func (function object object object object object))
+     (func object) ;; not always a function, you can technically put whatever
      (p1 object)
      (p2 object)
      (p3 object)
@@ -412,7 +412,7 @@
                  (= con (-> obj dead-list-end))))
     (let ((con (the connection con)))
       ;; set the params of the connection
-      (set! (-> con param0) func)
+      (set! (-> con param0) (the basic func))
       (set! (-> con param1) (the basic p1))
       (set! (-> con param2) (the basic p2))
       (set! (-> con param3) (the basic p3))

--- a/goal_src/engine/game/collectables.gc
+++ b/goal_src/engine/game/collectables.gc
@@ -77,3 +77,4 @@
   :flag-assert         #x1f0130019c
   )
 (define-extern fuel-cell-init-as-clone (function handle object none))
+(define-extern fuel-cell-pick-anim (function process-taskable none))

--- a/goal_src/engine/game/game-save.gc
+++ b/goal_src/engine/game/game-save.gc
@@ -2212,14 +2212,7 @@
    (set! (-> *game-info* mode) 'play)
    (initialize! *game-info* 'game (-> self save) (the-as string #f))
    (set-master-mode 'game)
-   (push-setting!
-    *setting-control*
-    self
-    (the-as (function object object object object object) 'process-mask)
-    'set
-    0.0
-    16
-    )
+   (push-setting! *setting-control* self 'process-mask 'set 0.0 16)
    (copy-settings-from-target! *setting-control*)
    (dotimes (gp-1 15)
     (suspend)

--- a/goal_src/engine/game/generic-obs-h.gc
+++ b/goal_src/engine/game/generic-obs-h.gc
@@ -10,6 +10,8 @@
 ;; TODO - for babak-with-cannon
 (define-extern beachcam-spawn (function none))
 
+(define-extern ja-anim-done? (function symbol))
+
 ;; decomp begins
 
 (deftype manipy (process-drawable)

--- a/goal_src/engine/game/settings-h.gc
+++ b/goal_src/engine/game/settings-h.gc
@@ -5,21 +5,11 @@
 ;; name in dgo: settings-h
 ;; dgos: GAME, ENGINE
 
-;; The settings system handles settings transitions.
-;; There are three copies of setting data:
-;;  - default
-;;  - target
-;;  - current
-
-;; Processes may request a setting change. Once the process dies, the change will be reverted.
-
-;; Internally, the frame's current settings are determined with this process:
-;;  1). The target settings are set to default.
-;;  2). Any changes to settings requested by processes are applied to target
-;;    NOTE: these requests are _not_ cleared on every frame.
-;;  3). Target and current are compared and updated. Mostly this is just copying, but
-;;    some settings may also call a function when they are changed.
-
+;; The settings system manages the state of settings like volume, language, and some other game state.
+;; There are two special features of settings:
+;; - To avoid changing a setting and forgetting to restore it, all changes must have an associated process. When that process dies, the settings is reverted.
+;; - If there are no processes trying to set a setting, it will go to a "default" setting.
+;; - We must catch the actual changing of settings once per frame, and possibly call functions for certains settings.
 
 ;; The full setting state.
 (deftype setting-data (structure)
@@ -66,7 +56,7 @@
   :size-assert         #xc4
   :flag-assert         #xa000000c4
   (:methods
-    (handle-pending-updates (_type_ engine) setting-data 9)
+    (update-from-engine (_type_ engine) setting-data 9)
     )
   )
 
@@ -113,6 +103,10 @@
   obj
   )
 
+;; There are three copies of setting data:
+;;  - default - if nothing is requesting a setting to be set, you end up with this value.
+;;  - target  - the default settings, plus the changes from all processes
+;;  - current - the actual settings. gets set to target on each frame.
 
 ;; The setting-control manages the current/target/default system.
 ;; The setting requests are managed by the engine.

--- a/goal_src/engine/game/settings-h.gc
+++ b/goal_src/engine/game/settings-h.gc
@@ -127,7 +127,7 @@
   :flag-assert         #xe00000278
   (:methods
     (new (symbol type int) _type_ 0)
-    (push-setting! (_type_ process (function object object object object object) object object object) none 9)
+    (push-setting! (_type_ process symbol object object object) none 9)
     (set-setting! (_type_ process symbol symbol float int) none 10)
     (clear-pending-settings-from-process (_type_ process symbol) none 11)
     (copy-settings-from-target! (_type_) setting-data 12)
@@ -145,8 +145,7 @@
   s4-0
   )
 
-;; believed unused.
-;; possibly the PS2 BIOS time type.
+;; used for memory card time information
 (deftype scf-time (structure)
   ((stat   uint8  :offset-assert 0)
    (second uint8  :offset-assert 1)

--- a/goal_src/engine/game/settings.gc
+++ b/goal_src/engine/game/settings.gc
@@ -204,22 +204,17 @@
   obj
   )
 
-(defmethod push-setting! setting-control ((obj setting-control) (arg0 process) (arg1 (function object object object object object)) (arg2 object) (arg3 object) (arg4 object))
+(defmethod push-setting! setting-control ((obj setting-control) (arg0 process) (arg1 symbol) (arg2 object) (arg3 object) (arg4 object))
+  "Set the setting. The set is linked to this process and will be reverted if the process dies"
   (add-connection (-> obj engine) arg0 arg1 arg2 arg3 arg4)
   0
   (none)
   )
 
 (defmethod set-setting! setting-control ((obj setting-control) (arg0 process) (arg1 symbol) (arg2 symbol) (arg3 float) (arg4 int))
+  "Replace"
   (clear-pending-settings-from-process obj arg0 arg1)
-  (add-connection
-   (-> obj engine)
-   arg0
-   (the-as (function object object object object object) arg1)
-   arg2
-   arg3
-   arg4
-   )
+  (add-connection (-> obj engine) arg0 arg1 arg2 arg3 arg4)
   0
   (none)
   )

--- a/goal_src/engine/game/settings.gc
+++ b/goal_src/engine/game/settings.gc
@@ -6,8 +6,8 @@
 ;; dgos: GAME, ENGINE
 
 
-(defmethod handle-pending-updates setting-data ((obj setting-data) (arg0 engine))
-  "this goes through the list of pending setting changes in 
+(defmethod update-from-engine setting-data ((obj setting-data) (arg0 engine))
+  "this goes through the list of desired setting changes in 
    the engine/connection list and updates the setting-data"
   (let ((conn (the-as connection (-> arg0 alive-list-end)))
         (s4-0 (-> arg0 alive-list-end prev0))
@@ -212,7 +212,7 @@
   )
 
 (defmethod set-setting! setting-control ((obj setting-control) (arg0 process) (arg1 symbol) (arg2 symbol) (arg3 float) (arg4 int))
-  "Replace"
+  "Replace all settings from this process with this one."
   (clear-pending-settings-from-process obj arg0 arg1)
   (add-connection (-> obj engine) arg0 arg1 arg2 arg3 arg4)
   0
@@ -220,6 +220,7 @@
   )
 
 (defmethod clear-pending-settings-from-process setting-control ((obj setting-control) (arg0 process) (arg1 symbol))
+  "Remove requests to change settings from the given process."
   (when arg0
    (let ((s5-0 (-> obj engine))
          (s4-0 (-> arg0 connection-list next1))
@@ -245,143 +246,164 @@
 
 
 (defmethod copy-settings-from-target! setting-control ((obj setting-control))
+  "Update the current settings. This only updates settings that are 'safe' to do multiple times per frame."
   (let ((gp-0 (-> obj current)))
-   (let ((s5-0 (-> obj target)))
-    (mem-copy! (the-as pointer s5-0) (the-as pointer (-> obj default)) 196)
-    (set!
-     (-> s5-0 ambient-volume)
-     (* (* 0.01 (-> obj default ambient-volume)) (-> obj default sfx-volume))
-     )
-    (handle-pending-updates s5-0 (-> obj engine))
-    (set! (-> gp-0 border-mode) (-> s5-0 border-mode))
-    (set! (-> gp-0 common-page) (-> s5-0 common-page))
-    (set! (-> gp-0 vibration) (-> s5-0 vibration))
-    (set! (-> gp-0 auto-save) (-> s5-0 auto-save))
-    (set! (-> gp-0 play-hints) (-> s5-0 play-hints))
-    (set! (-> gp-0 movie) (-> s5-0 movie))
-    (set! (-> gp-0 talking) (-> s5-0 talking))
-    (set! (-> gp-0 spooling) (-> s5-0 spooling))
-    (set! (-> gp-0 hint) (-> s5-0 hint))
-    (set! (-> gp-0 ambient) (-> s5-0 ambient))
-    (set! (-> gp-0 allow-pause) (-> s5-0 allow-pause))
-    (set! (-> gp-0 allow-progress) (-> s5-0 allow-progress))
-    (set! (-> gp-0 allow-look-around) (-> s5-0 allow-look-around))
-    (set! (-> gp-0 ocean-off) (-> s5-0 ocean-off))
-    (set! (-> gp-0 ambient-volume-movie) (-> s5-0 ambient-volume-movie))
-    (set! (-> gp-0 music-volume-movie) (-> s5-0 music-volume-movie))
-    (set! (-> gp-0 sfx-volume-movie) (-> s5-0 sfx-volume-movie))
-    (set! (-> gp-0 dialog-volume-hint) (-> s5-0 dialog-volume-hint))
-    (set! (-> gp-0 process-mask) (-> s5-0 process-mask))
+    (let ((s5-0 (-> obj target)))
+      ;; set the settings to default
+      (mem-copy! (the-as pointer s5-0) (the-as pointer (-> obj default)) 196)
+      ;; hack
+      (set! (-> s5-0 ambient-volume)
+            (* (* 0.01 (-> obj default ambient-volume)) (-> obj default sfx-volume))
+            )
+      ;; apply requesting changes
+      (update-from-engine s5-0 (-> obj engine))
+      ;; copy those settings to current.
+      (set! (-> gp-0 border-mode) (-> s5-0 border-mode))
+      (set! (-> gp-0 common-page) (-> s5-0 common-page))
+      (set! (-> gp-0 vibration) (-> s5-0 vibration))
+      (set! (-> gp-0 auto-save) (-> s5-0 auto-save))
+      (set! (-> gp-0 play-hints) (-> s5-0 play-hints))
+      (set! (-> gp-0 movie) (-> s5-0 movie))
+      (set! (-> gp-0 talking) (-> s5-0 talking))
+      (set! (-> gp-0 spooling) (-> s5-0 spooling))
+      (set! (-> gp-0 hint) (-> s5-0 hint))
+      (set! (-> gp-0 ambient) (-> s5-0 ambient))
+      (set! (-> gp-0 allow-pause) (-> s5-0 allow-pause))
+      (set! (-> gp-0 allow-progress) (-> s5-0 allow-progress))
+      (set! (-> gp-0 allow-look-around) (-> s5-0 allow-look-around))
+      (set! (-> gp-0 ocean-off) (-> s5-0 ocean-off))
+      (set! (-> gp-0 ambient-volume-movie) (-> s5-0 ambient-volume-movie))
+      (set! (-> gp-0 music-volume-movie) (-> s5-0 music-volume-movie))
+      (set! (-> gp-0 sfx-volume-movie) (-> s5-0 sfx-volume-movie))
+      (set! (-> gp-0 dialog-volume-hint) (-> s5-0 dialog-volume-hint))
+      (set! (-> gp-0 process-mask) (-> s5-0 process-mask))
+      )
+    (set! (-> *kernel-context* prevent-from-run) (-> gp-0 process-mask))
+    gp-0
     )
-   (set! (-> *kernel-context* prevent-from-run) (-> gp-0 process-mask))
-   gp-0
-   )
   )
 
 
 (defmethod update-per-frame-settings! setting-control ((obj setting-control))
+  "Do a per-frame update of all settings"
+  ;; compute all settings
   (copy-settings-from-target! obj)
+  
+  ;; now handle the special ones.
   (let ((gp-0 (-> obj current)))
-   (let ((s5-1 (-> obj target)))
-    (when *sound-player-enable*
-     (when (!= (-> gp-0 sfx-volume) (-> s5-1 sfx-volume))
-      (seek! (-> gp-0 sfx-volume) (-> s5-1 sfx-volume) (* 100.0 (-> *display* seconds-per-frame)))
-      (sound-set-volume (the-as uint 1) (-> gp-0 sfx-volume))
+    (let ((s5-1 (-> obj target)))
+      ;; the volume change is done slowly
+      (when *sound-player-enable*
+        (when (!= (-> gp-0 sfx-volume) (-> s5-1 sfx-volume))
+          (seek! (-> gp-0 sfx-volume) (-> s5-1 sfx-volume) (* 100.0 (-> *display* seconds-per-frame)))
+          (sound-set-volume (the-as uint 1) (-> gp-0 sfx-volume))
+          )
+        (when (!= (-> gp-0 music-volume) (-> s5-1 music-volume))
+          (seek! (-> gp-0 music-volume) (-> s5-1 music-volume) (* 100.0 (-> *display* seconds-per-frame)))
+          (sound-set-volume (the-as uint 2) (-> gp-0 music-volume))
+          )
+        (when (!= (-> gp-0 dialog-volume) (-> s5-1 dialog-volume))
+          (seek! (-> gp-0 dialog-volume) (-> s5-1 dialog-volume) (* 100.0 (-> *display* seconds-per-frame)))
+          (sound-set-volume (the-as uint 4) (-> gp-0 dialog-volume))
+          )
+        (when (!= (-> gp-0 ambient-volume) (-> s5-1 ambient-volume))
+          (seek! (-> gp-0 ambient-volume) (-> s5-1 ambient-volume) (* 100.0 (-> *display* seconds-per-frame)))
+          (sound-set-volume (the-as uint 16) (-> gp-0 ambient-volume))
+          )
+        )
+      ;; send language change to the IOP.
+      (when (!= (-> gp-0 language) (-> s5-1 language))
+        (set! (-> gp-0 language) (-> s5-1 language))
+        (set-language (-> gp-0 language))
+        )
+      
+      ;; try to load music
+      (when (and (!= (-> s5-1 music) (-> gp-0 music))
+                 (and (< 0.0 (-> *setting-control* current music-volume))
+                      (zero? (rpc-busy? 1))
+                      *sound-bank-1*
+                      *sound-bank-2*
+                      )
+                 )
+        (cond
+          ((-> s5-1 music)
+           (format 0 "Load music ~A~%" (-> s5-1 music))
+           (sound-music-load (string->sound-name (symbol->string (-> s5-1 music))))
+           )
+          (else
+            (format 0 "Unload music~%")
+            (sound-music-unload)
+            )
+          )
+        (set! (-> gp-0 music) (-> s5-1 music))
+        )
+      
+      ;; set sound flava
+      (set! (-> s5-1 sound-flava) (the-as uint (flava-lookup (-> gp-0 music) (the-as int (-> s5-1 sound-flava)))))
+      (set! (-> gp-0 sound-flava) (-> s5-1 sound-flava))
+      (if *sound-player-enable*
+          (sound-set-flava (-> gp-0 sound-flava))
+          )
+      
+      ;; update display settings
+      (when (!= (-> gp-0 aspect-ratio) (-> s5-1 aspect-ratio))
+        (set! (-> gp-0 aspect-ratio) (-> s5-1 aspect-ratio))
+        (set-aspect-ratio (-> gp-0 aspect-ratio))
+        )
+      (when (!= (-> gp-0 video-mode) (-> s5-1 video-mode))
+        (set! (-> gp-0 video-mode) (-> s5-1 video-mode))
+        (set-video-mode (-> gp-0 video-mode))
+        )
+      (when (!= (-> gp-0 screenx) (-> s5-1 screenx))
+        (set! (-> gp-0 screenx) (-> s5-1 screenx))
+        (set! (-> *video-parms* display-dx) (/ (-> s5-1 screenx) 2))
+        (set! (-> *video-parms* set-video-mode) #t)
+        )
+      (when (!= (-> gp-0 screeny) (-> s5-1 screeny))
+        (set! (-> gp-0 screeny) (-> s5-1 screeny))
+        (set! (-> *video-parms* display-dy) (* (/ (-> s5-1 screeny) 2) 2))
+        (set! (-> *video-parms* set-video-mode) #t)
+        )
+      
+      ;; update display bg color
+      (set! (-> gp-0 bg-a-speed) (-> s5-1 bg-a-speed))
+      (set! (-> gp-0 bg-a-force) (-> s5-1 bg-a-force))
+      (set! (-> gp-0 bg-r) (-> s5-1 bg-r))
+      (set! (-> gp-0 bg-g) (-> s5-1 bg-g))
+      (set! (-> gp-0 bg-b) (-> s5-1 bg-b))
+      (seek! (-> gp-0 bg-a) (-> s5-1 bg-a) (* (-> s5-1 bg-a-speed) (-> *display* seconds-per-frame)))
       )
-     (when (!= (-> gp-0 music-volume) (-> s5-1 music-volume))
-      (seek! (-> gp-0 music-volume) (-> s5-1 music-volume) (* 100.0 (-> *display* seconds-per-frame)))
-      (sound-set-volume (the-as uint 2) (-> gp-0 music-volume))
+    (let ((v1-60 (-> *display* frames (-> *display* on-screen) display))
+          (f0-39 (-> gp-0 bg-a))
+          )
+      (if (!= (-> gp-0 bg-a-force) 0.0)
+          (set! f0-39 (-> gp-0 bg-a-force))
+          )
+      (set! (-> v1-60 bgcolor r) (the int (* 255.0 (-> gp-0 bg-r))))
+      (set! (-> v1-60 bgcolor g) (the int (* 255.0 (-> gp-0 bg-g))))
+      (set! (-> v1-60 bgcolor b) (the int (* 255.0 (-> gp-0 bg-b))))
+      (set! (-> v1-60 pmode alp) (the int (* 255.0 (- 1.0 f0-39))))
       )
-     (when (!= (-> gp-0 dialog-volume) (-> s5-1 dialog-volume))
-      (seek! (-> gp-0 dialog-volume) (-> s5-1 dialog-volume) (* 100.0 (-> *display* seconds-per-frame)))
-      (sound-set-volume (the-as uint 4) (-> gp-0 dialog-volume))
-      )
-     (when (!= (-> gp-0 ambient-volume) (-> s5-1 ambient-volume))
-      (seek! (-> gp-0 ambient-volume) (-> s5-1 ambient-volume) (* 100.0 (-> *display* seconds-per-frame)))
-      (sound-set-volume (the-as uint 16) (-> gp-0 ambient-volume))
-      )
-     )
-    (when (!= (-> gp-0 language) (-> s5-1 language))
-     (set! (-> gp-0 language) (-> s5-1 language))
-     (set-language (-> gp-0 language))
-     )
-    (when (and (!= (-> s5-1 music) (-> gp-0 music))
-               (and (< 0.0 (-> *setting-control* current music-volume))
-                    (zero? (rpc-busy? 1))
-                    *sound-bank-1*
-                    *sound-bank-2*
-                    )
-               )
-     (cond
-      ((-> s5-1 music)
-       (format 0 "Load music ~A~%" (-> s5-1 music))
-       (sound-music-load (string->sound-name (symbol->string (-> s5-1 music))))
-       )
-      (else
-       (format 0 "Unload music~%")
-       (sound-music-unload)
-       )
-      )
-     (set! (-> gp-0 music) (-> s5-1 music))
-     )
-    (set! (-> s5-1 sound-flava) (the-as uint (flava-lookup (-> gp-0 music) (the-as int (-> s5-1 sound-flava)))))
-    (set! (-> gp-0 sound-flava) (-> s5-1 sound-flava))
-    (if *sound-player-enable*
-     (sound-set-flava (-> gp-0 sound-flava))
-     )
-    (when (!= (-> gp-0 aspect-ratio) (-> s5-1 aspect-ratio))
-     (set! (-> gp-0 aspect-ratio) (-> s5-1 aspect-ratio))
-     (set-aspect-ratio (-> gp-0 aspect-ratio))
-     )
-    (when (!= (-> gp-0 video-mode) (-> s5-1 video-mode))
-     (set! (-> gp-0 video-mode) (-> s5-1 video-mode))
-     (set-video-mode (-> gp-0 video-mode))
-     )
-    (when (!= (-> gp-0 screenx) (-> s5-1 screenx))
-     (set! (-> gp-0 screenx) (-> s5-1 screenx))
-     (set! (-> *video-parms* display-dx) (/ (-> s5-1 screenx) 2))
-     (set! (-> *video-parms* set-video-mode) #t)
-     )
-    (when (!= (-> gp-0 screeny) (-> s5-1 screeny))
-     (set! (-> gp-0 screeny) (-> s5-1 screeny))
-     (set! (-> *video-parms* display-dy) (* (/ (-> s5-1 screeny) 2) 2))
-     (set! (-> *video-parms* set-video-mode) #t)
-     )
-    (set! (-> gp-0 bg-a-speed) (-> s5-1 bg-a-speed))
-    (set! (-> gp-0 bg-a-force) (-> s5-1 bg-a-force))
-    (set! (-> gp-0 bg-r) (-> s5-1 bg-r))
-    (set! (-> gp-0 bg-g) (-> s5-1 bg-g))
-    (set! (-> gp-0 bg-b) (-> s5-1 bg-b))
-    (seek! (-> gp-0 bg-a) (-> s5-1 bg-a) (* (-> s5-1 bg-a-speed) (-> *display* seconds-per-frame)))
+    
+    ;; ??
+    (set! (-> *level* border?) (-> gp-0 border-mode))
+    ;; common pool texture page mask
+    (set! (-> *texture-pool* common-page-mask) (-> gp-0 common-page))
+    (set! (-> *cpad-list* cpads 0 buzz) (-> gp-0 vibration))
+    
+    (case (-> gp-0 ocean-off) 
+          ((#t)
+           (set! *ocean-off* #t)
+           )
+          (('mid)
+           (set! *ocean-mid-off* #t)
+           )
+          (('near)
+           (set! *ocean-near-off* #t)
+           )
+          )
+    gp-0
     )
-   (let ((v1-60 (-> *display* frames (-> *display* on-screen) display))
-         (f0-39 (-> gp-0 bg-a))
-         )
-    (if (!= (-> gp-0 bg-a-force) 0.0)
-     (set! f0-39 (-> gp-0 bg-a-force))
-     )
-    (set! (-> v1-60 bgcolor r) (the int (* 255.0 (-> gp-0 bg-r))))
-    (set! (-> v1-60 bgcolor g) (the int (* 255.0 (-> gp-0 bg-g))))
-    (set! (-> v1-60 bgcolor b) (the int (* 255.0 (-> gp-0 bg-b))))
-    (set! (-> v1-60 pmode alp) (the int (* 255.0 (- 1.0 f0-39))))
-    )
-   (set! (-> *level* border?) (-> gp-0 border-mode))
-   (set! (-> *texture-pool* common-page-mask) (-> gp-0 common-page))
-   (set! (-> *cpad-list* cpads 0 buzz) (-> gp-0 vibration))
-
-   (case (-> gp-0 ocean-off) 
-    ((#t)
-      (set! *ocean-off* #t)
-      )
-    (('mid)
-     (set! *ocean-mid-off* #t)
-     )
-    (('near)
-     (set! *ocean-near-off* #t)
-     )
-    )
-   gp-0
-   )
   )
 
 

--- a/goal_src/engine/game/task/process-taskable.gc
+++ b/goal_src/engine/game/task/process-taskable.gc
@@ -6,3 +6,2027 @@
 ;; dgos: GAME, ENGINE
 
 ;; DECOMP BEGINS
+;; definition for method 52 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod dummy-52 process-taskable ((obj process-taskable))
+  (let ((v1-1 (-> obj draw shadow-ctrl)))
+   (when v1-1
+    (let ((a0-1 v1-1))
+     (set! (-> a0-1 settings bot-plane w) (- -12288.0))
+     )
+    0
+    (set! (-> v1-1 settings top-plane w) (- 4096.0))
+    0
+    )
+   )
+  (none)
+  )
+
+;; definition for method 9 of type gui-query
+;; INFO: Return type mismatch int vs none.
+(defmethod
+  init!
+  gui-query
+  ((obj gui-query)
+   (arg0 symbol)
+   (arg1 int)
+   (arg2 int)
+   (arg3 int)
+   (arg4 symbol)
+   (arg5 symbol)
+   )
+  (set! (-> obj x-position) arg1)
+  (set! (-> obj y-position) arg2)
+  (set! (-> obj message-space) arg3)
+  (set! (-> obj only-allow-cancel) arg4)
+  (set! (-> obj message) arg0)
+  (set! (-> obj decision) 'undecided)
+  (set! (-> obj no-msg) arg5)
+  0
+  (none)
+  )
+
+;; definition for method 10 of type gui-query
+(defmethod dummy-10 gui-query ((obj gui-query))
+  (kill-current-level-hint '() '(sidekick voicebox stinger) 'exit)
+  (level-hint-surpress!)
+  (hide-hud)
+  (when (hud-hidden?)
+   (when (-> obj message)
+    (let
+     ((a1-2
+       (new
+        'stack
+        'font-context
+        *font-default-matrix*
+        (-> obj x-position)
+        (-> obj y-position)
+        0.0
+        (font-color default)
+        (font-flags shadow kerning)
+        )
+       )
+      )
+     (let ((v1-4 a1-2))
+      (set! (-> v1-4 width) (the float (- 512 (-> obj x-position))))
+      )
+     (let ((v1-5 a1-2))
+      (set! (-> v1-5 height) (the float 40))
+      )
+     (let ((v1-6 a1-2))
+      (set! (-> v1-6 scale) 0.9)
+      )
+     (set! (-> a1-2 flags) (font-flags shadow kerning left large))
+     (print-game-text (the-as string (-> obj message)) a1-2 #f 128 22)
+     )
+    )
+   (cond
+    ((-> obj only-allow-cancel)
+     (when (-> obj no-msg)
+      (clear *temp-string*)
+      (format *temp-string* "; = ~S" (-> obj no-msg))
+      (let*
+       ((s4-0 (-> *display* frames (-> *display* on-screen) frame global-buf))
+        (s5-0 (-> s4-0 base))
+        )
+       (draw-string-xy
+        *temp-string*
+        s4-0
+        (-> obj x-position)
+        (+ (-> obj y-position) 5 (-> obj message-space))
+        (font-color default)
+        (font-flags shadow kerning large)
+        )
+       (let ((a3-4 (-> s4-0 base)))
+        (let ((v1-17 (the-as object (-> s4-0 base))))
+         (set!
+          (-> (the-as dma-packet v1-17) dma)
+          (new 'static 'dma-tag :id (dma-tag-id next))
+          )
+         (set! (-> (the-as dma-packet v1-17) vif0) (new 'static 'vif-tag))
+         (set! (-> (the-as dma-packet v1-17) vif1) (new 'static 'vif-tag))
+         (set! (-> s4-0 base) (&+ (the-as pointer v1-17) 16))
+         )
+        (dma-bucket-insert-tag
+         (-> *display* frames (-> *display* on-screen) frame bucket-group)
+         (bucket-id debug-draw0)
+         s5-0
+         (the-as (pointer dma-tag) a3-4)
+         )
+        )
+       )
+      )
+     )
+    (else
+     (let*
+      ((s4-1 (-> *display* frames (-> *display* on-screen) frame global-buf))
+       (s5-1 (-> s4-1 base))
+       )
+      (draw-string-xy
+       (lookup-text! *common-text* (game-text-id confirm) #f)
+       s4-1
+       (-> obj x-position)
+       (+ (-> obj y-position) 5 (-> obj message-space))
+       (font-color default)
+       (font-flags shadow kerning large)
+       )
+      (let ((a3-7 (-> s4-1 base)))
+       (let ((v1-29 (the-as object (-> s4-1 base))))
+        (set!
+         (-> (the-as dma-packet v1-29) dma)
+         (new 'static 'dma-tag :id (dma-tag-id next))
+         )
+        (set! (-> (the-as dma-packet v1-29) vif0) (new 'static 'vif-tag))
+        (set! (-> (the-as dma-packet v1-29) vif1) (new 'static 'vif-tag))
+        (set! (-> s4-1 base) (&+ (the-as pointer v1-29) 16))
+        )
+       (dma-bucket-insert-tag
+        (-> *display* frames (-> *display* on-screen) frame bucket-group)
+        (bucket-id debug-draw0)
+        s5-1
+        (the-as (pointer dma-tag) a3-7)
+        )
+       )
+      )
+     )
+    )
+   (cond
+    ((!= (-> obj decision) 'undecided)
+     )
+    ((and
+      (logtest? (-> *cpad-list* cpads 0 button0-rel 0) (pad-buttons x))
+      (not (-> obj only-allow-cancel))
+      )
+     (logclear! (-> *cpad-list* cpads 0 button0-abs 0) (pad-buttons x))
+     (logclear! (-> *cpad-list* cpads 0 button0-rel 0) (pad-buttons x))
+     (set! (-> obj decision) 'yes)
+     )
+    ((logtest? (-> *cpad-list* cpads 0 button0-rel 0) (pad-buttons triangle))
+     (logclear! (-> *cpad-list* cpads 0 button0-abs 0) (pad-buttons triangle))
+     (logclear! (-> *cpad-list* cpads 0 button0-rel 0) (pad-buttons triangle))
+     (set! (-> obj decision) 'no)
+     )
+    )
+   )
+  (-> obj decision)
+  )
+
+;; definition for method 7 of type process-taskable
+;; INFO: Return type mismatch process-drawable vs process-taskable.
+(defmethod relocate process-taskable ((obj process-taskable) (arg0 int))
+  (the-as
+   process-taskable
+   ((method-of-type process-drawable relocate) obj arg0)
+   )
+  )
+
+;; definition for method 46 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod dummy-46 process-taskable ((obj process-taskable))
+  (with-pp
+   (when (nonzero? (-> obj sound-flava))
+    (let
+     ((s5-1
+       (vector-!
+        (new 'stack-no-clear 'vector)
+        (target-pos 0)
+        (the-as vector (-> obj root-override root-prim prim-core))
+        )
+       )
+      )
+     (set! (-> s5-1 y) (* 4.0 (-> s5-1 y)))
+     (cond
+      ((< (vector-length s5-1) 102400.0)
+       (when (not (-> obj have-flava))
+        (set! (-> obj have-flava) #t)
+        (set-setting!
+         *setting-control*
+         pp
+         'sound-flava
+         #f
+         20.0
+         (the-as int (-> obj sound-flava))
+         )
+        )
+       )
+      ((-> obj have-flava)
+       (clear-pending-settings-from-process *setting-control* pp 'sound-flava)
+       (set! (-> obj have-flava) #f)
+       )
+      )
+     )
+    )
+   (when (-> obj music)
+    (let
+     ((s5-3
+       (vector-!
+        (new 'stack-no-clear 'vector)
+        (target-pos 0)
+        (the-as vector (-> obj root-override root-prim prim-core))
+        )
+       )
+      )
+     (set! (-> s5-3 y) (* 4.0 (-> s5-3 y)))
+     (cond
+      ((< (vector-length s5-3) 102400.0)
+       (when (not (-> obj have-music))
+        (set! (-> obj have-music) #t)
+        (set-setting!
+         *setting-control*
+         pp
+         'music
+         (the-as symbol (-> obj music))
+         0.0
+         0
+         )
+        )
+       )
+      ((-> obj have-music)
+       (clear-pending-settings-from-process *setting-control* pp 'music)
+       (set! (-> obj have-music) #f)
+       )
+      )
+     )
+    )
+   0
+   (none)
+   )
+  )
+
+;; definition for method 31 of type process-taskable
+;; INFO: Return type mismatch art-joint-anim vs art-element.
+(defmethod get-art-elem process-taskable ((obj process-taskable))
+  (the-as art-element (if (> (-> obj skel active-channels) 0)
+                       (-> obj skel root-channel 0 frame-group)
+                       )
+   )
+  )
+
+;; definition for method 32 of type process-taskable
+;; INFO: Return type mismatch symbol vs basic.
+(defmethod play-anim! process-taskable ((obj process-taskable) (arg0 symbol))
+  (the-as basic #f)
+  )
+
+;; definition for method 33 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod dummy-33 process-taskable ((obj process-taskable))
+  (let ((s5-0 (play-anim! obj #f)))
+   (if (type-type? (-> s5-0 type) spool-anim)
+    (spool-push *art-control* (-> (the-as spool-anim s5-0) name) 0 obj -99.0)
+    )
+   )
+  0
+  (none)
+  )
+
+;; definition for method 51 of type process-taskable
+(defmethod close-anim-file! process-taskable ((obj process-taskable))
+  (let* ((gp-0 (play-anim! obj #f))
+         (v1-2 (if (and (nonzero? gp-0) (type-type? (-> gp-0 type) spool-anim))
+                gp-0
+                )
+          )
+         )
+   (if v1-2
+    (file-status *art-control* (-> (the-as spool-anim v1-2) name) 0)
+    )
+   )
+  )
+
+;; definition for method 34 of type process-taskable
+(defmethod TODO-RENAME-34 process-taskable ((obj process-taskable) (arg0 symbol))
+  #f
+  )
+
+;; definition for method 35 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod dummy-35 process-taskable ((obj process-taskable))
+  (let ((s5-0 (the-as basic (TODO-RENAME-34 obj #f))))
+   (if (type-type? (-> (the-as symbol s5-0) type) spool-anim)
+    (spool-push *art-control* (-> (the-as spool-anim s5-0) name) 0 obj -99.0)
+    )
+   )
+  0
+  (none)
+  )
+
+;; definition for method 36 of type process-taskable
+;; INFO: Return type mismatch symbol vs basic.
+(defmethod
+  get-spool-anim-or-??
+  process-taskable
+  ((obj process-taskable) (arg0 symbol))
+  (the-as basic #f)
+  )
+
+;; definition for method 37 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod spool-push-anim process-taskable ((obj process-taskable))
+  (let ((s5-0 (get-spool-anim-or-?? obj #f)))
+   (if (type-type? (-> s5-0 type) spool-anim)
+    (spool-push *art-control* (-> (the-as spool-anim s5-0) name) 0 obj -99.0)
+    )
+   )
+  0
+  (none)
+  )
+
+;; definition for method 38 of type process-taskable
+(defmethod dummy-38 process-taskable ((obj process-taskable))
+  (if (nonzero? (-> obj cell-for-task))
+   (go (method-of-object obj give-cell))
+   )
+  (go (method-of-object obj release))
+  (none)
+  )
+
+;; definition for function process-taskable-anim-loop
+(defbehavior process-taskable-anim-loop process-taskable ()
+  (when (!= (if (> (-> self skel active-channels) 0)
+             (-> self skel root-channel 0 frame-group)
+             )
+         (get-art-elem self)
+         )
+   (ja-channel-push! 1 60)
+   (let ((gp-0 (-> self skel root-channel 0)))
+    (set! (-> gp-0 frame-group) (the-as art-joint-anim (get-art-elem self)))
+    )
+   )
+  (while #t
+   (suspend)
+   (let ((a0-8 (-> self skel root-channel 0)))
+    (set! (-> a0-8 param 0) 1.0)
+    (joint-control-channel-group-eval!
+     a0-8
+     (the-as art-joint-anim #f)
+     num-func-loop!
+     )
+    )
+   (if (= (-> self next-state name) 'idle)
+    (TODO-RENAME-43 self)
+    )
+   )
+  (the-as none 0)
+  (none)
+  )
+
+;; failed to figure out what this is:
+(defstate release (process-taskable)
+  :virtual #t
+  :trans
+  (behavior ()
+   (when (process-release? *target*)
+    (let ((a1-0 (new 'stack-no-clear 'event-message-block)))
+     (set! (-> a1-0 from) self)
+     (set! (-> a1-0 num-params) 2)
+     (set! (-> a1-0 message) 'trans)
+     (set! (-> a1-0 param 0) (the-as uint 'restore))
+     (set! (-> a1-0 param 1) (the-as uint (-> self old-target-pos)))
+     (send-event-function *target* a1-0)
+     )
+    (if (should-display? self)
+     (go-virtual idle)
+     (go-virtual hidden)
+     )
+    )
+   (dummy-33 self)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  process-taskable-anim-loop
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate give-cell (process-taskable)
+  :virtual #t
+  :trans
+  (behavior ()
+   (cond
+    ((nonzero? (-> self cell-for-task))
+     (let ((gp-0 (handle->process (-> self cell-x))))
+      (when gp-0
+       (let ((a1-1 (new 'stack-no-clear 'event-message-block)))
+        (set! (-> a1-1 from) self)
+        (set! (-> a1-1 num-params) 1)
+        (set! (-> a1-1 message) 'trans)
+        (set! (-> a1-1 param 0) (the-as uint 'reset))
+        (send-event-function *target* a1-1)
+        )
+       (let ((s5-0 (new 'stack-no-clear 'event-message-block)))
+        (set! (-> s5-0 from) self)
+        (set! (-> s5-0 num-params) 1)
+        (set! (-> s5-0 message) 'pickup)
+        (set! (-> s5-0 param 0) (the-as uint (target-pos 0)))
+        (send-event-function gp-0 s5-0)
+        )
+       (go-virtual idle)
+       )
+      )
+     (format #t "ERROR<GMJ>: ~S no cell spawned~%" (-> self name))
+     (let ((a1-4 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-4 from) self)
+      (set! (-> a1-4 num-params) 2)
+      (set! (-> a1-4 message) 'get-pickup)
+      (set! (-> a1-4 param 0) (the-as uint 6))
+      (set! (-> a1-4 param 1) (the-as uint (the float (-> self cell-for-task))))
+      (send-event-function *target* a1-4)
+      )
+     )
+    (else
+     (format
+      #t
+      "ERROR<GMJ>: ~S got into give-cell with give-cell == #f task = ~S~%"
+      (-> self name)
+      (game-task->string (the-as game-task (current-task (-> self tasks))))
+      )
+     )
+    )
+   (go-virtual release)
+   (dummy-33 self)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  process-taskable-anim-loop
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate lose (process-taskable)
+  :virtual #t
+  :enter
+  (behavior ()
+   (set!
+    (-> self state-time)
+    (the-as seconds (-> *display* base-frame-counter))
+    )
+   (none)
+   )
+  :trans
+  (behavior ()
+   (if
+    (and
+     (>=
+      (- (-> *display* base-frame-counter) (the-as int (-> self state-time)))
+      1500
+      )
+     (or
+      (not *target*)
+      (<
+       20480.0
+       (vector-vector-distance
+        (-> self root-override trans)
+        (-> *target* control trans)
+        )
+       )
+      )
+     )
+    (go-virtual idle)
+    )
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  process-taskable-anim-loop
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate enter-playing (process-taskable)
+  :virtual #t
+  :code
+  process-taskable-anim-loop
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; definition for function process-taskable-play-anim-enter
+(defbehavior process-taskable-play-anim-enter process-taskable ()
+  (init! (-> self query) #f 40 150 25 #t #f)
+  (logior! (-> self skel status) 8)
+  (let ((gp-0 (get-process *default-dead-pool* othercam #x4000)))
+   (set! (-> self camera) (ppointer->handle (when gp-0
+                                             (let
+                                              ((t9-2
+                                                (method-of-type
+                                                 othercam
+                                                 activate
+                                                 )
+                                                )
+                                               )
+                                              (t9-2
+                                               (the-as othercam gp-0)
+                                               self
+                                               'othercam
+                                               (the-as pointer #x70004000)
+                                               )
+                                              )
+                                             (run-now-in-process
+                                              gp-0
+                                              othercam-init-by-other
+                                              self
+                                              (-> self cam-joint-index)
+                                              #f
+                                              #t
+                                              )
+                                             (-> gp-0 ppointer)
+                                             )
+                           )
+    )
+   )
+  (set! (-> self cell-for-task) (game-task none))
+  (set! (-> self skippable) #f)
+  (set! (-> self blend-on-exit) #f)
+  (set! (-> self will-talk) #f)
+  #f
+  )
+
+;; definition for function process-taskable-play-anim-exit
+(defbehavior process-taskable-play-anim-exit process-taskable ()
+  (set! (-> self skel status) (logand -9 (-> self skel status)))
+  (let ((a0-4 (handle->process (-> self camera))))
+   (if a0-4
+    (deactivate a0-4)
+    )
+   )
+  (set! (-> self last-talk) (the-as uint (-> *display* game-frame-counter)))
+  (dummy-52 self)
+  (none)
+  )
+
+;; definition for function process-taskable-play-anim-trans
+(defbehavior process-taskable-play-anim-trans process-taskable ()
+  (if (nonzero? *camera-look-through-other*)
+   (set! *camera-look-through-other* 2)
+   )
+  (set-letterbox-frames 5)
+  (draw-npc-shadow self)
+  (none)
+  )
+
+;; definition for function process-taskable-play-anim-code
+(defbehavior
+  process-taskable-play-anim-code process-taskable
+  ((arg0 art-joint-anim) (arg1 basic))
+  (when (nonzero? (-> self cell-for-task))
+   (cond
+    ((name= (-> self state name) "play-anim")
+     (let ((s4-0 (get-process *default-dead-pool* fuel-cell #x4000)))
+      (set! (-> self cell-x) (ppointer->handle (when s4-0
+                                                (let
+                                                 ((t9-2
+                                                   (method-of-type
+                                                    fuel-cell
+                                                    activate
+                                                    )
+                                                   )
+                                                  )
+                                                 (t9-2
+                                                  (the-as fuel-cell s4-0)
+                                                  self
+                                                  'fuel-cell
+                                                  (the-as pointer #x70004000)
+                                                  )
+                                                 )
+                                                (run-now-in-process
+                                                 s4-0
+                                                 fuel-cell-init-as-clone
+                                                 (process->handle self)
+                                                 (-> self cell-for-task)
+                                                 )
+                                                (-> s4-0 ppointer)
+                                                )
+                              )
+       )
+      )
+     )
+    (else
+     (format
+      #t
+      "ERROR<GMJ>: ~S ~S trying to give cell on release~%"
+      (-> self name)
+      (-> self state name)
+      )
+     )
+    )
+   )
+  (cond
+   ((and arg1 (type-type? (-> arg1 type) spool-anim))
+    (when *target*
+     (while (let ((a1-9 (new 'stack-no-clear 'event-message-block)))
+             (set! (-> a1-9 from) self)
+             (set! (-> a1-9 num-params) 1)
+             (set! (-> a1-9 message) 'clone-anim)
+             (set! (-> a1-9 param 0) (the-as uint self))
+             (not (send-event-function *target* a1-9))
+             )
+      (spool-push *art-control* (-> (the-as spool-anim arg1) name) 0 self -99.0)
+      (format #t "WARNING: ~A stall on not cloning.~%" (-> self name))
+      (suspend)
+      )
+     (let ((a1-10 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-10 from) self)
+      (set! (-> a1-10 num-params) 1)
+      (set! (-> a1-10 message) 'matrix)
+      (set! (-> a1-10 param 0) (the-as uint 'play-anim))
+      (send-event-function (ppointer->process (-> *target* sidekick)) a1-10)
+      )
+     (let ((a1-11 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-11 from) self)
+      (set! (-> a1-11 num-params) 1)
+      (set! (-> a1-11 message) 'blend-shape)
+      (set! (-> a1-11 param 0) (the-as uint #t))
+      (send-event-function *target* a1-11)
+      )
+     )
+    (push-setting!
+     *setting-control*
+     self
+     'music-volume
+     'rel
+     (-> *setting-control* current music-volume-movie)
+     0
+     )
+    (push-setting!
+     *setting-control*
+     self
+     'sfx-volume
+     'rel
+     (-> *setting-control* current sfx-volume-movie)
+     0
+     )
+    (push-setting!
+     *setting-control*
+     self
+     'ambient-volume
+     'rel
+     (-> *setting-control* current ambient-volume-movie)
+     0
+     )
+    (if (-> self blend-on-exit)
+     (set! (-> self blend-on-exit) arg0)
+     )
+    (if (and *debug-segment* *cheat-mode*)
+     (ja-play-spooled-anim
+      (the-as spool-anim arg1)
+      arg0
+      (the-as art-joint-anim (-> self blend-on-exit))
+      (lambda ((arg0 process-taskable))
+       (= (dummy-10 (-> arg0 query)) 'no)
+       )
+      )
+     (ja-play-spooled-anim
+      (the-as spool-anim arg1)
+      arg0
+      (the-as art-joint-anim (-> self blend-on-exit))
+      (the-as (function process-drawable symbol) false-func)
+      )
+     )
+    (clear-pending-settings-from-process *setting-control* self 'music-volume)
+    (clear-pending-settings-from-process *setting-control* self 'sfx-volume)
+    (clear-pending-settings-from-process *setting-control* self 'ambient-volume)
+    (let ((a1-20 (new 'stack-no-clear 'event-message-block)))
+     (set! (-> a1-20 from) self)
+     (set! (-> a1-20 num-params) 1)
+     (set! (-> a1-20 message) 'blend-shape)
+     (set! (-> a1-20 param 0) (the-as uint #f))
+     (send-event-function *target* a1-20)
+     )
+    )
+   (else
+    (when (not arg1)
+     (format
+      #t
+      "ERROR<GMJ>: ~S ~S got #f from anim picker~%"
+      (-> self name)
+      (-> self state name)
+      )
+     (set! arg1 (if (> (-> self skel active-channels) 0)
+                 (-> self skel root-channel 0 frame-group)
+                 )
+      )
+     )
+    (when (not (type-type? (-> arg1 type) art-joint-anim))
+     (format
+      0
+      "ERROR<GMJ>: ~S ~S anim picker didn't return spool-anim or joint-art-anim (probably need to override it)~%"
+      (-> self name)
+      (-> self state name)
+      )
+     (set! arg1 (if (> (-> self skel active-channels) 0)
+                 (-> self skel root-channel 0 frame-group)
+                 )
+      )
+     )
+    (format
+     #t
+     "~S ~S anim ~S~%"
+     (-> self name)
+     (-> self state name)
+     (-> (the-as art-joint-anim arg1) name)
+     )
+    (ja-channel-push! 1 60)
+    (set!
+     (-> self skel root-channel 0 frame-group)
+     (the-as art-joint-anim arg1)
+     )
+    (when (< (ja-num-frames 0) 3)
+     (suspend)
+     (suspend)
+     0
+     )
+    (let ((a0-30 (-> self skel root-channel 0)))
+     (set! (-> a0-30 frame-group) (if (> (-> self skel active-channels) 0)
+                                   (-> self skel root-channel 0 frame-group)
+                                   )
+      )
+     (set!
+      (-> a0-30 param 0)
+      (the float (+ (-> (if (> (-> self skel active-channels) 0)
+                         (-> self skel root-channel 0 frame-group)
+                         )
+                     data
+                     0
+                     length
+                     )
+                  -1
+                  )
+       )
+      )
+     (set! (-> a0-30 param 1) 1.0)
+     (set! (-> a0-30 frame-num) 0.0)
+     (joint-control-channel-group!
+      a0-30
+      (if (> (-> self skel active-channels) 0)
+       (-> self skel root-channel 0 frame-group)
+       )
+      num-func-seek!
+      )
+     )
+    (until (ja-done? 0)
+     (when (and *debug-segment* (= (dummy-10 (-> self query)) 'no))
+      (let ((v1-106 (-> self skel root-channel 0)))
+       (set! (-> v1-106 num-func) num-func-identity)
+       (set!
+        (-> v1-106 frame-num)
+        (the float (+ (-> v1-106 frame-group data 0 length) -1))
+        )
+       )
+      )
+     (suspend)
+     (let ((a0-38 (-> self skel root-channel 0)))
+      (set!
+       (-> a0-38 param 0)
+       (the float (+ (-> a0-38 frame-group data 0 length) -1))
+       )
+      (set! (-> a0-38 param 1) 1.0)
+      (joint-control-channel-group-eval!
+       a0-38
+       (the-as art-joint-anim #f)
+       num-func-seek!
+       )
+      )
+     )
+    #f
+    )
+   )
+  )
+
+;; failed to figure out what this is:
+(defstate play-accept (process-taskable)
+  :virtual #t
+  :enter
+  (the-as
+   (function none :behavior process-taskable)
+   process-taskable-play-anim-enter
+   )
+  :exit
+  process-taskable-play-anim-exit
+  :trans
+  (behavior ()
+   (process-taskable-play-anim-trans)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  (behavior ()
+   (process-taskable-play-anim-code
+    (the-as art-joint-anim (get-art-elem self))
+    (TODO-RENAME-34 self #t)
+    )
+   (while (not (process-release? *target*))
+    (suspend)
+    )
+   (go-virtual enter-playing)
+   (none)
+   )
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate play-reject (process-taskable)
+  :virtual #t
+  :enter
+  (the-as
+   (function none :behavior process-taskable)
+   process-taskable-play-anim-enter
+   )
+  :exit
+  process-taskable-play-anim-exit
+  :trans
+  (behavior ()
+   (process-taskable-play-anim-trans)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  (behavior ()
+   (process-taskable-play-anim-code
+    (the-as art-joint-anim (get-art-elem self))
+    (get-spool-anim-or-?? self #t)
+    )
+   (go-virtual release)
+   (none)
+   )
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate query (process-taskable)
+  :virtual #t
+  :enter
+  (behavior ()
+   (init!
+    (-> self query)
+    (the-as symbol (lookup-text! *common-text* (game-text-id confirm-play) #f))
+    40
+    150
+    25
+    #f
+    (the-as symbol (lookup-text! *common-text* (game-text-id quit) #f))
+    )
+   (none)
+   )
+  :exit
+  process-taskable-play-anim-exit
+  :trans
+  (behavior ()
+   (case (current-status (-> self tasks)) 
+    ((4)
+      (case (dummy-10 (-> self query)) 
+       (('yes)
+         (go-virtual play-accept)
+         )
+       (('no)
+        (go-virtual play-reject)
+        )
+       )
+      (dummy-35 self)
+      )
+    (else
+     (let ((gp-0 (dummy-10 (-> self query))))
+      (cond
+       ((and (= gp-0 'yes) (process-release? *target*))
+        (go-virtual enter-playing)
+        )
+       ((= gp-0 'no)
+        (go-virtual play-reject)
+        )
+       )
+      )
+     )
+    )
+   (spool-push-anim self)
+   (set! *camera-look-through-other* 2)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  process-taskable-anim-loop
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; failed to figure out what this is:
+(defstate play-anim (process-taskable)
+  :virtual #t
+  :event
+  (behavior ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
+   (case arg2 
+    (('shadow)
+      (cond
+       ((-> arg3 param 0)
+        (let ((v0-0 (the-as object (-> self shadow-backup))))
+         (set! (-> self draw shadow) (the-as shadow-geo v0-0))
+         v0-0
+         )
+        )
+       (else
+        (set! (-> self draw shadow) #f)
+        #f
+        )
+       )
+      )
+    (('shadow-min-max)
+     (let ((v1-5 (-> self draw shadow-ctrl)))
+      (let ((a0-4 v1-5))
+       (set!
+        (-> a0-4 settings bot-plane w)
+        (- (the-as float (-> arg3 param 0)))
+        )
+       )
+      0
+      (set! (-> v1-5 settings top-plane w) (- (the-as float (-> arg3 param 1))))
+      )
+     0
+     )
+    )
+   )
+  :enter
+  (the-as
+   (function none :behavior process-taskable)
+   process-taskable-play-anim-enter
+   )
+  :exit
+  process-taskable-play-anim-exit
+  :trans
+  (behavior ()
+   (process-taskable-play-anim-trans)
+   (let ((a3-0 (handle->process (-> self cell-x))))
+    (if a3-0
+     (spool-push *art-control* (-> self fuel-cell-anim name) 0 a3-0 -99.0)
+     )
+    )
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  (behavior ()
+   (process-taskable-play-anim-code
+    (the-as art-joint-anim (get-art-elem self))
+    (play-anim! self #t)
+    )
+   (dummy-38 self)
+   (none)
+   )
+  :post
+  (the-as (function none :behavior process-taskable) ja-post)
+  )
+
+;; definition for function process-taskable-clean-up-after-talking
+(defbehavior process-taskable-clean-up-after-talking process-taskable ()
+  (set! (-> self draw status) (logand -3 (-> self draw status)))
+  (set! (-> self skel status) (logand -2 (-> self skel status)))
+  (clear-pending-settings-from-process *setting-control* self 'border-mode)
+  (clear-pending-settings-from-process *setting-control* self 'talking)
+  (none)
+  )
+
+;; definition for method 39 of type process-taskable
+(defmethod should-display? process-taskable ((obj process-taskable))
+  #t
+  )
+
+;; definition for function process-taskable-hide-handler
+(defbehavior
+  process-taskable-hide-handler process-taskable
+  ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
+  (case arg2 
+   (('clone)
+     (go-virtual be-clone (the-as handle (-> arg3 param 0)))
+     )
+   (('play-anim)
+    (logclear! (-> self mask) (process-mask actor-pause))
+    (set! (-> self been-kicked) #t)
+    (go-virtual idle)
+    )
+   (('hidden-other)
+    (go-virtual hidden-other)
+    )
+   )
+  (none)
+  )
+
+;; definition for function process-taskable-hide-enter
+;; INFO: Return type mismatch none vs int.
+(defbehavior process-taskable-hide-enter process-taskable ()
+  (set! (-> self state-time) (the-as seconds (-> *display* base-frame-counter)))
+  (let ((v1-3 (-> self draw shadow-ctrl)))
+   (logior! (-> v1-3 settings flags) 32)
+   )
+  0
+  (process-taskable-clean-up-after-talking)
+  (dummy-48 (-> self root-override))
+  (ja-channel-set! 0)
+  (the-as int (ja-post))
+  )
+
+;; definition for function process-taskable-hide-exit
+;; INFO: Return type mismatch int vs none.
+(defbehavior process-taskable-hide-exit process-taskable ((arg0 symbol))
+  (cond
+   (arg0
+    (process-entity-status! self (entity-perm-status bit-3) #f)
+    )
+   (else
+    (ja-channel-set! 1)
+    (let ((gp-0 (-> self skel root-channel 0)))
+     (set! (-> gp-0 frame-group) (the-as art-joint-anim (get-art-elem self)))
+     )
+    (dummy-49 (-> self root-override))
+    (process-entity-status! self (entity-perm-status bit-3) #t)
+    (let ((v1-7 (-> self draw shadow-ctrl)))
+     (set! (-> v1-7 settings flags) (logand -33 (-> v1-7 settings flags)))
+     )
+    0
+    )
+   )
+  (none)
+  )
+
+;; failed to figure out what this is:
+(defstate hidden (process-taskable)
+  :virtual #t
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior process-taskable)
+   process-taskable-hide-handler
+   )
+  :enter
+  (the-as
+   (function none :behavior process-taskable)
+   process-taskable-hide-enter
+   )
+  :exit
+  (behavior ()
+   (process-taskable-hide-exit (= (-> self next-state name) 'hidden))
+   (none)
+   )
+  :trans
+  (behavior ()
+   (if
+    (>=
+     (- (-> *display* base-frame-counter) (the-as int (-> self state-time)))
+     300
+     )
+    (process-entity-status! self (entity-perm-status bit-3) #f)
+    )
+   (if (or (-> self been-kicked) (should-display? self))
+    (go-virtual idle)
+    )
+   (none)
+   )
+  :code
+  (the-as (function none :behavior process-taskable) anim-loop)
+  )
+
+;; definition for method 50 of type process-taskable
+;; WARN: disable def twice: 4. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
+(defmethod TODO-RENAME-50 process-taskable ((obj process-taskable))
+  (if *target*
+   (or
+    (not *target*)
+    (<
+     245760.0
+     (vector-vector-distance
+      (-> obj root-override trans)
+      (-> *target* control trans)
+      )
+     )
+    )
+   (<
+    60397978000.0
+    (vector-vector-distance-squared
+     (the-as vector (-> obj root-override root-prim prim-core))
+     (camera-pos)
+     )
+    )
+   )
+  )
+
+;; failed to figure out what this is:
+(defstate hidden-other (process-taskable)
+  :virtual #t
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior process-taskable)
+   process-taskable-hide-handler
+   )
+  :enter
+  (the-as
+   (function none :behavior process-taskable)
+   process-taskable-hide-enter
+   )
+  :exit
+  (behavior ()
+   (process-taskable-hide-exit (= (-> self next-state name) 'hidden-other))
+   (none)
+   )
+  :trans
+  (behavior ()
+   (if
+    (>=
+     (- (-> *display* base-frame-counter) (the-as int (-> self state-time)))
+     300
+     )
+    (process-entity-status! self (entity-perm-status bit-3) #f)
+    )
+   (cond
+    ((-> self been-kicked)
+     (go-virtual idle)
+     )
+    ((TODO-RENAME-50 self)
+     (if (should-display? self)
+      (go-virtual idle)
+      (go-virtual hidden)
+      )
+     )
+    )
+   (none)
+   )
+  :code
+  (the-as (function none :behavior process-taskable) anim-loop)
+  )
+
+;; failed to figure out what this is:
+(defstate be-clone (process-taskable)
+  :virtual #t
+  :event
+  (behavior ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
+   (let ((v1-0 arg2))
+    (the-as object (cond
+                    ((= v1-0 'shadow)
+                     (the-as shadow-geo (cond
+                                         ((-> arg3 param 0)
+                                          (let ((v0-0 (-> self shadow-backup)))
+                                           (set! (-> self draw shadow) v0-0)
+                                           v0-0
+                                           )
+                                          )
+                                         (else
+                                          (set! (-> self draw shadow) #f)
+                                          (the-as shadow-geo #f)
+                                          )
+                                         )
+                      )
+                     )
+                    ((= v1-0 'shadow-min-max)
+                     (let ((v1-5 (-> self draw shadow-ctrl)))
+                      (let ((a0-5 v1-5))
+                       (set!
+                        (-> a0-5 settings bot-plane w)
+                        (- (the-as float (-> arg3 param 0)))
+                        )
+                       )
+                      0
+                      (set!
+                       (-> v1-5 settings top-plane w)
+                       (- (the-as float (-> arg3 param 1)))
+                       )
+                      )
+                     (the-as shadow-geo 0)
+                     )
+                    ((= v1-0 'end-mode)
+                     (the-as shadow-geo (if (should-display? self)
+                                         (the-as shadow-geo (go-virtual idle))
+                                         (the-as shadow-geo (go-virtual hidden))
+                                         )
+                      )
+                     )
+                    )
+     )
+    )
+   )
+  :enter
+  (behavior ((arg0 handle))
+   (logior! (-> self skel status) 8)
+   (logclear! (-> self mask) (process-mask actor-pause))
+   (set-vector!
+    (-> self draw bounds)
+    0.0
+    (-> self draw-bounds-y-offset)
+    0.0
+    (-> self draw bounds w)
+    )
+   (none)
+   )
+  :exit
+  (behavior ()
+   (set! (-> self skel status) (logand -41 (-> self skel status)))
+   (logior! (-> self mask) (process-mask actor-pause))
+   (let ((v1-6 (-> self entity extra trans)))
+    (if v1-6
+     (set! (-> self root-override trans quad) (-> v1-6 quad))
+     )
+    )
+   (ja-channel-set! 0)
+   (none)
+   )
+  :trans
+  (behavior ()
+   (draw-npc-shadow self)
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  (behavior ((arg0 handle))
+   (clone-anim arg0 (-> self center-joint-index) #t "")
+   (format #t "ERROR<GMJ>: handle invalid while ~S is cloning~%" (-> self name))
+   (go-virtual hidden)
+   (none)
+   )
+  )
+
+;; definition for method 47 of type process-taskable
+(defmethod target-above-threshold? process-taskable ((obj process-taskable))
+  #t
+  )
+
+;; failed to figure out what this is:
+(defstate idle (process-taskable)
+  :virtual #t
+  :event
+  (behavior ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
+   (let ((v1-0 arg2))
+    (the-as object (cond
+                    ((= v1-0 'attack)
+                     (the-as symbol (when (-> self bounce-away)
+                                     (let
+                                      ((a1-3
+                                        (new 'stack-no-clear 'event-message-block
+                                         )
+                                        )
+                                       )
+                                      (set! (-> a1-3 from) self)
+                                      (set! (-> a1-3 num-params) 2)
+                                      (set! (-> a1-3 message) 'shove)
+                                      (set! (-> a1-3 param 0) (the-as uint #f))
+                                      (let
+                                       ((v1-4
+                                         (new 'static 'attack-info :mask #xc0)
+                                         )
+                                        )
+                                       (set! (-> v1-4 shove-back) 12288.0)
+                                       (set! (-> v1-4 shove-up) 4096.0)
+                                       (set!
+                                        (-> a1-3 param 1)
+                                        (the-as uint v1-4)
+                                        )
+                                       )
+                                      (the-as
+                                       symbol
+                                       (send-event-function arg0 a1-3)
+                                       )
+                                      )
+                                     )
+                      )
+                     )
+                    ((= v1-0 'touch)
+                     (the-as
+                      symbol
+                      (dummy-55
+                       (-> self root-override)
+                       arg0
+                       (-> arg3 param 0)
+                       0.7
+                       6144.0
+                       16384.0
+                       )
+                      )
+                     )
+                    ((= v1-0 'clone)
+                     (the-as
+                      symbol
+                      (go-virtual be-clone (the-as handle (-> arg3 param 0)))
+                      )
+                     )
+                    ((= v1-0 'play-anim)
+                     (logclear! (-> self mask) (process-mask actor-pause))
+                     (let ((v0-0 #t))
+                      (set! (-> self been-kicked) v0-0)
+                      v0-0
+                      )
+                     )
+                    ((= v1-0 'hidden-other)
+                     (the-as symbol (go-virtual hidden-other))
+                     )
+                    )
+     )
+    )
+   )
+  :enter
+  (behavior ()
+   (set!
+    (-> self state-time)
+    (the-as seconds (-> *display* base-frame-counter))
+    )
+   (process-taskable-clean-up-after-talking)
+   (none)
+   )
+  :exit
+  (behavior ()
+   (cond
+    ((or
+      (= (-> self next-state name) 'dead-state)
+      (= (-> self next-state name) 'idle)
+      )
+     (process-entity-status! self (entity-perm-status bit-3) #f)
+     )
+    (else
+     (kill-current-level-hint '() '() 'exit)
+     (logior! (-> self skel status) 1)
+     (logclear! (-> self mask) (process-mask actor-pause))
+     (process-entity-status! self (entity-perm-status bit-3) #t)
+     (set-setting! *setting-control* self 'border-mode #f 0.0 0)
+     (set-setting!
+      *setting-control*
+      self
+      'talking
+      (the-as symbol (process->ppointer self))
+      0.0
+      0
+      )
+     (copy-settings-from-target! *setting-control*)
+     )
+    )
+   (none)
+   )
+  :trans
+  (behavior ()
+   (when
+    (>=
+     (- (-> *display* base-frame-counter) (the-as int (-> self state-time)))
+     60
+     )
+    (logior! (-> self mask) (process-mask actor-pause))
+    (process-entity-status! self (entity-perm-status bit-3) #f)
+    )
+   (cond
+    ((not *target*)
+     )
+    ((not (-> self will-talk))
+     (if
+      (>=
+       (- (-> *display* game-frame-counter) (the-as int (-> self last-talk)))
+       3000
+       )
+      (set! (-> self will-talk) #t)
+      )
+     )
+    ((begin
+      (dummy-46 self)
+      (and
+       (not
+        (and
+         (logtest? (-> *target* control unknown-surface00 flags) 2048)
+         (zero? (logand (-> *target* control status) 1))
+         )
+        )
+       (<
+        (-> (target-pos 0) y)
+        (+ 8192.0 (-> self root-override root-prim prim-core world-sphere y))
+        )
+       (<
+        (vector-vector-distance
+         (target-pos 0)
+         (the-as vector (-> self root-override root-prim prim-core))
+         )
+        32768.0
+        )
+       (= (-> *level* loading-level) (-> *level* level-default))
+       (not (movie?))
+       (not (level-hint-displayed?))
+       (none-reserved? *art-control*)
+       (not *progress-process*)
+       (and
+        (not (handle->process (-> *game-info* other-camera-handle)))
+        (close-anim-file! self)
+        )
+       )
+      )
+     (first-any (-> self tasks) #t)
+     (when (target-above-threshold? self)
+      (case (current-status (-> self tasks)) 
+       ((2 3 5 4 6)
+         (kill-current-level-hint '() '(sidekick voicebox ambient) 'exit)
+         (level-hint-surpress!)
+         (hide-hud)
+         (when (and (hud-hidden?) (can-grab-display? self))
+          (let
+           ((gp-1
+             (new
+              'stack
+              'font-context
+              *font-default-matrix*
+              32
+              140
+              0.0
+              (font-color default)
+              (font-flags shadow kerning)
+              )
+             )
+            )
+           (let ((v1-57 gp-1))
+            (set! (-> v1-57 width) (the float 440))
+            )
+           (let ((v1-58 gp-1))
+            (set! (-> v1-58 height) (the float 60))
+            )
+           (let ((v1-59 gp-1))
+            (set! (-> v1-59 scale) 0.9)
+            )
+           (set! (-> gp-1 flags) (font-flags shadow kerning left large))
+           (print-game-text
+            (lookup-text!
+             *common-text*
+             (the-as game-text-id (-> self talk-message))
+             #f
+             )
+            gp-1
+            #f
+            128
+            22
+            )
+           )
+          (when
+           (and
+            (logtest?
+             (-> *cpad-list* cpads 0 button0-rel 0)
+             (pad-buttons circle)
+             )
+            (process-grab? *target*)
+            )
+           (logclear!
+            (-> *cpad-list* cpads 0 button0-abs 0)
+            (pad-buttons circle)
+            )
+           (logclear!
+            (-> *cpad-list* cpads 0 button0-rel 0)
+            (pad-buttons circle)
+            )
+           (let ((a1-12 (new 'stack-no-clear 'event-message-block)))
+            (set! (-> a1-12 from) self)
+            (set! (-> a1-12 num-params) 2)
+            (set! (-> a1-12 message) 'trans)
+            (set! (-> a1-12 param 0) (the-as uint 'save))
+            (set! (-> a1-12 param 1) (the-as uint (-> self old-target-pos)))
+            (send-event-function *target* a1-12)
+            )
+           (go-virtual play-anim)
+           )
+          )
+         )
+       )
+      )
+     )
+    )
+   (if (= (-> *level* loading-level) (-> *level* level-default))
+    (dummy-33 self)
+    )
+   (draw-npc-shadow self)
+   (when
+    (and
+     (-> self been-kicked)
+     (and
+      (not *progress-process*)
+      (process-grab? *target*)
+      (not (handle->process (-> *game-info* other-camera-handle)))
+      )
+     )
+    (set! (-> self been-kicked) #f)
+    (let ((a1-14 (new 'stack-no-clear 'event-message-block)))
+     (set! (-> a1-14 from) self)
+     (set! (-> a1-14 num-params) 2)
+     (set! (-> a1-14 message) 'trans)
+     (set! (-> a1-14 param 0) (the-as uint 'save))
+     (set! (-> a1-14 param 1) (the-as uint (-> self old-target-pos)))
+     (send-event-function *target* a1-14)
+     )
+    (go-virtual play-anim)
+    )
+   ((-> self cur-trans-hook))
+   (none)
+   )
+  :code
+  process-taskable-anim-loop
+  :post
+  (behavior ()
+   (when *target*
+    (when (!= (-> self neck-joint-index) -1)
+     (let ((gp-0 (new 'stack-no-clear 'vector)))
+      (vector<-cspace! gp-0 (-> self node-list data (-> self neck-joint-index)))
+      (if *target*
+       (look-at-enemy! (-> *target* neck) gp-0 'nothing self)
+       )
+      )
+     )
+    )
+   (transform-post)
+   (none)
+   )
+  )
+
+;; definition for method 41 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod
+  initialize-collision
+  process-taskable
+  ((obj process-taskable) (arg0 int) (arg1 vector))
+  (let
+   ((s5-0 (new 'process 'collide-shape obj (collide-list-enum hit-by-player))))
+   (let ((s4-0 (new 'process 'collide-shape-prim-sphere s5-0 (the-as uint 0))))
+    (set! (-> s4-0 prim-core collide-as) (the-as uint 256))
+    (set! (-> s4-0 collide-with) (the-as uint 16))
+    (set! (-> s4-0 prim-core action) (the-as uint 1))
+    (set! (-> s4-0 prim-core offense) 4)
+    (set! (-> s4-0 transform-index) arg0)
+    (set-vector!
+     (-> s4-0 local-sphere)
+     (-> arg1 x)
+     (-> arg1 y)
+     (-> arg1 z)
+     (-> arg1 w)
+     )
+    )
+   (dummy-46 s5-0)
+   (set! (-> s5-0 nav-radius) (* 0.75 (-> s5-0 root-prim local-sphere w)))
+   (dummy-50 s5-0)
+   (set! (-> obj root-override) s5-0)
+   )
+  0
+  (none)
+  )
+
+;; definition for method 40 of type process-taskable
+;; INFO: Return type mismatch int vs none.
+(defmethod
+  dummy-40
+  process-taskable
+  ((obj process-taskable)
+   (arg0 object)
+   (arg1 skeleton-group)
+   (arg2 int)
+   (arg3 int)
+   (arg4 vector)
+   (arg5 int)
+   )
+  (let ((s3-0 arg2)
+        (s4-0 arg3)
+        (s0-0 arg4)
+        (s5-0 arg5)
+        )
+   (stack-size-set! (-> obj main-thread) 512)
+   (initialize-collision obj s3-0 s0-0)
+   (process-drawable-from-entity! obj (the-as res-lump arg0))
+   (let* ((a0-4 obj)
+          (t9-3 (method-of-object a0-4 dummy-14))
+          (a2-2 '())
+          (a1-4 arg1)
+          )
+    (t9-3 a0-4 a1-4 a2-2)
+    (set! (-> obj shadow-backup) (-> obj draw shadow))
+    (logior! (-> obj skel status) 256)
+    (set! (-> obj root-override pause-adjust-distance) -122880.0)
+    (set! (-> obj fuel-cell-anim) (the-as spool-anim (fuel-cell-pick-anim obj)))
+    (set! (-> obj draw origin-joint-index) (the-as uint s3-0))
+    (set! (-> obj draw shadow-joint-index) (the-as uint s3-0))
+    (set! (-> obj center-joint-index) s3-0)
+    (set! (-> obj draw-bounds-y-offset) (-> obj draw bounds y))
+    (set! (-> obj have-flava) #f)
+    (set! (-> obj music) #f)
+    (set! (-> obj have-music) #f)
+    (set! (-> obj cam-joint-index) s4-0)
+    (set! (-> obj cell-x) (the-as handle #f))
+    (set! (-> obj cell-for-task) (game-task none))
+    (set! (-> obj camera) (the-as handle #f))
+    (set! (-> obj will-talk) #t)
+    (set! (-> obj talk-message) (the-as uint 260))
+    (set! (-> obj last-talk) (the-as uint 0))
+    (set! (-> obj bounce-away) #t)
+    (set! (-> obj been-kicked) #f)
+    (set! (-> obj neck-joint-index) s5-0)
+    (set! (-> obj cur-trans-hook) nothing)
+    (dummy-9
+     (-> obj ambient)
+     (the-as vector a1-4)
+     (the-as int a2-2)
+     (the-as float arg2)
+     (the-as process-drawable arg3)
+     )
+    )
+   )
+  (set! (-> obj event-hook) (-> (method-of-object obj idle) event))
+  (set!
+   (-> obj draw shadow-ctrl)
+   (new 'process 'shadow-control 0.0 0.0 614400.0 (the-as float 60) 245760.0)
+   )
+  (dummy-52 obj)
+  0
+  (none)
+  )
+
+;; definition for method 42 of type process-taskable
+(defmethod dummy-42 process-taskable ((obj process-taskable))
+  (cond
+   ((not (should-display? obj))
+    (go (method-of-object obj hidden))
+    )
+   ((= (current-status (-> obj tasks)) 7)
+    (go (method-of-object obj give-cell))
+    )
+   (else
+    (go (method-of-object obj idle))
+    )
+   )
+  (none)
+  )
+
+;; definition for method 43 of type process-taskable
+;; INFO: Return type mismatch int vs symbol.
+(defmethod TODO-RENAME-43 process-taskable ((obj process-taskable))
+  (the-as symbol 0)
+  )
+
+;; definition for method 9 of type ambient-control
+;; INFO: Return type mismatch int vs none.
+(defmethod
+  dummy-9
+  ambient-control
+  ((obj ambient-control)
+   (arg0 vector)
+   (arg1 int)
+   (arg2 float)
+   (arg3 process-drawable)
+   )
+  (set!
+   (-> obj last-ambient-time)
+   (the-as uint (-> *display* game-frame-counter))
+   )
+  0
+  (none)
+  )
+
+;; definition for method 10 of type ambient-control
+(defmethod
+  TODO-RENAME-10
+  ambient-control
+  ((obj ambient-control)
+   (arg0 vector)
+   (arg1 int)
+   (arg2 float)
+   (arg3 process-drawable)
+   )
+  (when
+   (<
+    (-
+     (-> *display* game-frame-counter)
+     (the-as int (-> obj last-ambient-time))
+     )
+    arg1
+    )
+   (set! arg0 (the-as vector #f))
+   (goto cfg-6)
+   )
+  (vector-for-ambient arg3 arg0)
+  (when (< arg2 (vector-length arg0))
+   (set! arg0 (the-as vector #f))
+   (goto cfg-6)
+   )
+  (label cfg-6)
+  arg0
+  )
+
+;; definition for method 11 of type ambient-control
+(defmethod
+  dummy-11
+  ambient-control
+  ((obj ambient-control) (arg0 string) (arg1 symbol) (arg2 vector))
+  (when
+   (and
+    (not (string= arg0 (the-as string (-> obj last-ambient))))
+    (or arg1 (can-hint-be-played? 1 (the-as entity #f) (the-as string #f)))
+    (= (-> *level* loading-level) (-> *level* level-default))
+    (ambient-hint-spawn arg0 arg2 *entity-pool* 'ambient)
+    )
+   (set!
+    (-> obj last-ambient-time)
+    (the-as uint (-> *display* game-frame-counter))
+    )
+   (set! (-> obj last-ambient) arg0)
+   (return #t)
+   )
+  #f
+  )
+
+;; definition for function vector-for-ambient
+(defun vector-for-ambient ((arg0 process-drawable) (arg1 vector))
+  (if *target*
+   (vector-! arg1 (target-pos 0) (-> arg0 root trans))
+   (vector-! arg1 (camera-pos) (-> arg0 root trans))
+   )
+  arg1
+  )
+
+;; definition for function othercam-calc
+(defun othercam-calc ((arg0 float))
+  (let ((f0-3 (* 2.0 (atan (/ 14.941477 (* 20.3 arg0)) 1.0))))
+   (set! (-> *camera-other-fov* data) f0-3)
+   f0-3
+   )
+  )
+
+;; failed to figure out what this is:
+(defstate othercam-running (othercam)
+  :event
+  (behavior ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
+   (local-vars (v0-0 object))
+   (case arg2 
+    (('die)
+      (set! v0-0 #t)
+      (set! (-> self die?) (the-as symbol v0-0))
+      v0-0
+      )
+    (('joint)
+     (let ((t9-0 type-type?)
+           (v1-1 (-> arg3 param 0))
+           )
+      (cond
+       ((t9-0 (rtype-of v1-1) string)
+        (let
+         ((v1-8
+           (dummy-10
+            (-> (the-as process-taskable (-> self hand process 0)) draw jgeo)
+            (the-as string (-> arg3 param 0))
+            (the-as type #f)
+            )
+           )
+          )
+         (when v1-8
+          (set! v0-0 (+ (-> v1-8 number) 1))
+          (set! (-> self cam-joint-index) (the-as int v0-0))
+          v0-0
+          )
+         )
+        )
+       ((zero? (logand (-> arg3 param 0) 7))
+        (set! v0-0 (-> arg3 param 0))
+        (set! (-> self cam-joint-index) (the-as int v0-0))
+        v0-0
+        )
+       )
+      )
+     )
+    (('mask)
+     (set! v0-0 (-> arg3 param 0))
+     (set! (-> self mask-to-clear) (the-as uint v0-0))
+     v0-0
+     )
+    )
+   )
+  :enter
+  (behavior ()
+   (hide-hud-quick)
+   (case (-> self spooling?) 
+    (('logo)
+      )
+    (else
+     (push-setting!
+      *setting-control*
+      self
+      'process-mask
+      'set
+      0.0
+      (-> self mask-to-clear)
+      )
+     (push-setting!
+      *setting-control*
+      self
+      'movie
+      (process->ppointer self)
+      0.0
+      0
+      )
+     (if (not (-> self border-value))
+      (push-setting!
+       *setting-control*
+       self
+       'border-mode
+       (-> self border-value)
+       0.0
+       0
+       )
+      )
+     )
+    )
+   (set! (-> self had-valid-frame) #f)
+   (let ((gp-0 (-> self hand process 0)))
+    (vector<-cspace!
+     (-> self old-pos)
+     (->
+      (the-as process-taskable gp-0)
+      node-list
+      data
+      (-> self cam-joint-index)
+      )
+     )
+    (let
+     ((v1-19
+       (->
+        (the-as process-taskable gp-0)
+        node-list
+        data
+        (-> self cam-joint-index)
+        bone
+        transform
+        )
+       )
+      )
+     (vector-normalize-copy! (-> self old-mat-z) (-> v1-19 vector 2) -1.0)
+     )
+    )
+   (copy-settings-from-target! *setting-control*)
+   (none)
+   )
+  :exit
+  (behavior ()
+   (clear-pending-settings-from-process *setting-control* self 'process-mask)
+   (copy-settings-from-target! *setting-control*)
+   (none)
+   )
+  :code
+  (behavior ()
+   (while #t
+    (let ((s2-0 (-> self hand process 0)))
+     (when (not s2-0)
+      (format #t "ERROR<GMJ>: othercam parent invalid~%")
+      (deactivate self)
+      )
+     (set!
+      (-> *camera-other-root* quad)
+      (-> (the-as process-taskable s2-0) root-override trans quad)
+      )
+     (let
+      ((s4-0
+        (->
+         (the-as process-taskable s2-0)
+         node-list
+         data
+         (-> self cam-joint-index)
+         bone
+         transform
+         )
+        )
+       (s3-0
+        (->
+         (the-as process-taskable s2-0)
+         node-list
+         data
+         (-> self cam-joint-index)
+         bone
+         scale
+         )
+        )
+       (gp-0 (new 'stack-no-clear 'vector))
+       (s5-0 (new 'stack-no-clear 'vector))
+       (s1-0
+        (or
+         (!= (-> self spooling?) #t)
+         (logtest? (-> (the-as process-taskable s2-0) skel status) 32)
+         )
+        )
+       )
+      (vector<-cspace!
+       s5-0
+       (->
+        (the-as process-taskable s2-0)
+        node-list
+        data
+        (-> self cam-joint-index)
+        )
+       )
+      (vector-normalize-copy! gp-0 (-> s4-0 vector 2) -1.0)
+      (when s1-0
+       (when (not (-> self had-valid-frame))
+        (set! (-> self had-valid-frame) #t)
+        (set! (-> self old-pos quad) (-> s5-0 quad))
+        (set! (-> self old-mat-z quad) (-> gp-0 quad))
+        )
+       (when #t
+        (set! (-> *camera-other-trans* quad) (-> s5-0 quad))
+        (vector-normalize-copy!
+         (the-as vector (-> *camera-other-matrix* vector))
+         (the-as vector (-> s4-0 vector))
+         -1.0
+         )
+        (set! (-> *camera-other-matrix* vector 0 w) 0.0)
+        (vector-normalize-copy!
+         (-> *camera-other-matrix* vector 1)
+         (-> s4-0 vector 1)
+         1.0
+         )
+        (set! (-> *camera-other-matrix* vector 1 w) 0.0)
+        (vector-normalize-copy!
+         (-> *camera-other-matrix* vector 2)
+         (-> s4-0 vector 2)
+         -1.0
+         )
+        (set! (-> *camera-other-matrix* vector 2 w) 0.0)
+        (vector-reset! (-> *camera-other-matrix* vector 3))
+        (othercam-calc (-> s3-0 x))
+        )
+       (set! *camera-look-through-other* 2)
+       (set! (-> self old-pos quad) (-> s5-0 quad))
+       (set! (-> self old-mat-z quad) (-> gp-0 quad))
+       )
+      )
+     )
+    (suspend)
+    (-> self hand process 0)
+    (when
+     (or (-> self die?) (and (not (-> self survive-anim-end?)) (ja-anim-done?)))
+     (let ((gp-1 (-> *display* base-frame-counter)))
+      (while
+       (and
+        (< (- (-> *display* base-frame-counter) gp-1) #x4650)
+        (or
+         (and
+          (-> self entity)
+          (not
+           (is-object-visible?
+            (-> self entity extra level)
+            (-> self entity extra vis-id)
+            )
+           )
+          )
+         (<
+          81920.0
+          (vector-vector-distance (camera-pos) (-> *math-camera* trans))
+          )
+         )
+        )
+       (suspend)
+       )
+      )
+     (deactivate self)
+     )
+    )
+   (none)
+   )
+  )
+
+;; definition for function othercam-init-by-other
+;; INFO: Return type mismatch int vs none.
+(defbehavior
+  othercam-init-by-other othercam
+  ((arg0 process-taskable) (arg1 symbol) (arg2 symbol) (arg3 symbol))
+  (set! (-> self spooling?) arg3)
+  (case (-> self spooling?) 
+   (('logo)
+     )
+   (else
+    (set! (-> *game-info* other-camera-handle) (process->handle self))
+    )
+   )
+  (set! (-> self hand) (process->handle arg0))
+  (set! (-> self cam-joint-index) (the-as int arg1))
+  (logclear! (-> self mask) (process-mask pause menu actor-pause))
+  (set! (-> self border-value) #f)
+  (set! (-> self die?) #f)
+  (set! (-> self survive-anim-end?) arg2)
+  (set! (-> self mask-to-clear) (the-as uint #x4a0800))
+  (set! (-> self event-hook) (-> othercam-running event))
+  (go othercam-running)
+  0
+  (none)
+  )
+
+;; definition for method 48 of type process-taskable
+(defmethod draw-npc-shadow process-taskable ((obj process-taskable))
+  (let ((gp-0 (-> obj draw shadow-ctrl)))
+   (cond
+    ((and
+      (-> obj draw shadow)
+      (zero? (-> obj draw cur-lod))
+      (logtest? (-> obj draw status) 8)
+      )
+     (dummy-15 gp-0 (-> obj draw origin) -4096.0 4096.0 32768.0)
+     (dummy-14 gp-0)
+     )
+    (else
+     (let ((v1-10 gp-0))
+      (logior! (-> v1-10 settings flags) 32)
+      )
+     0
+     )
+    )
+   )
+  (none)
+  )

--- a/goal_src/engine/nav/navigate-h.gc
+++ b/goal_src/engine/nav/navigate-h.gc
@@ -312,7 +312,7 @@
            ;; connect the nav-mesh engine:
            (add-connection (-> entity-nav-mesh user-list)
                            proc ;; to the given process
-                           (the-as (function object object object object object) nothing) ;; no function
+                           nothing ;; no function
                            ;; and some weird parameters.
                            proc
                            nav-cont

--- a/goal_src/engine/target/logic-target.gc
+++ b/goal_src/engine/target/logic-target.gc
@@ -2826,14 +2826,7 @@
    )
   (set! (-> self control pad 5) (the-as uint (new-sound-id)))
   (if *debug-segment*
-   (add-connection
-    *debug-engine*
-    self
-    (the-as (function object object object object object) target-print-stats)
-    self
-    *stdcon0*
-    #f
-    )
+   (add-connection *debug-engine* self target-print-stats self *stdcon0* #f)
    )
   (activate-hud self)
   (set! (-> self fp-hud) (the-as uint #f))

--- a/goal_src/engine/ui/progress/progress.gc
+++ b/goal_src/engine/ui/progress/progress.gc
@@ -3269,14 +3269,7 @@
   (behavior ()
    (sound-group-pause (the-as uint 255))
    (logclear! (-> *setting-control* default process-mask) (process-mask pause menu))
-   (push-setting!
-    *setting-control*
-    self
-    (the-as (function object object object object object) 'process-mask)
-    'set
-    0.0
-    16
-    )
+   (push-setting! *setting-control* self 'process-mask 'set 0.0 16)
    (copy-settings-from-target! *setting-control*)
    (sound-play-by-name
     (static-sound-name "select-menu")

--- a/goal_src/levels/common/static-screen.gc
+++ b/goal_src/levels/common/static-screen.gc
@@ -146,14 +146,7 @@
   (behavior ((arg0 int) (arg1 int) (arg2 symbol))
    (set! (-> *setting-control* current bg-a) 1.0)
    (set! (-> *setting-control* default bg-a) 0.0)
-   (push-setting!
-    *setting-control*
-    self
-    (the-as (function object object object object object) 'common-page)
-    'set
-    0.0
-    (ash 1 (+ arg0 1))
-    )
+   (push-setting! *setting-control* self 'common-page 'set 0.0 (ash 1 (+ arg0 1)))
    (none)
    )
   :trans

--- a/goal_src/levels/misty/muse.gc
+++ b/goal_src/levels/misty/muse.gc
@@ -46,938 +46,934 @@
   )
 
 
-; (defun analyze-point-on-path-segment ((arg0 point-on-path-segment-info))
-;   (vector-! (-> arg0 dir) (-> arg0 segment 1) (the-as vector (-> arg0 segment)))
-;   (vector-normalize! (-> arg0 dir) 1.0)
-;   (set!
-;    (-> arg0 segment-length)
-;    (vector-vector-distance
-;     (the-as vector (-> arg0 segment))
-;     (-> arg0 segment 1)
-;     )
-;    )
-;   (let ((s5-0 (new 'stack-no-clear 'vector)))
-;    (vector-! s5-0 (the-as vector (-> arg0 segment)) (-> arg0 point))
-;    (vector+*! s5-0 s5-0 (-> arg0 dir) (- (vector-dot s5-0 (-> arg0 dir))))
-;    (vector+! (-> arg0 nearest-point) (-> arg0 point) s5-0)
-;    (set! (-> arg0 distance-to-segment) (vector-length s5-0))
-;    (vector-! s5-0 (-> arg0 point) (the-as vector (-> arg0 segment)))
-;    (set!
-;     (-> arg0 parametric-index)
-;     (/ (vector-dot (-> arg0 dir) s5-0) (-> arg0 segment-length))
-;     )
-;    )
-;   (cond
-;    ((< (-> arg0 parametric-index) 0.0)
-;     (set! (-> arg0 parametric-index) 0.0)
-;     (set! (-> arg0 nearest-point quad) (-> arg0 segment 0 quad))
-;     (let
-;      ((f0-10 (vector-vector-distance (-> arg0 nearest-point) (-> arg0 point))))
-;      (set! (-> arg0 distance-to-segment) f0-10)
-;      f0-10
-;      )
-;     )
-;    ((< 1.0 (-> arg0 parametric-index))
-;     (set! (-> arg0 parametric-index) 1.0)
-;     (set! (-> arg0 nearest-point quad) (-> arg0 segment 1 quad))
-;     (let
-;      ((f0-13 (vector-vector-distance (-> arg0 nearest-point) (-> arg0 point))))
-;      (set! (-> arg0 distance-to-segment) f0-13)
-;      f0-13
-;      )
-;     )
-;    )
-;   )
+(defun analyze-point-on-path-segment ((arg0 point-on-path-segment-info))
+  (vector-! (-> arg0 dir) (-> arg0 segment 1) (the-as vector (-> arg0 segment)))
+  (vector-normalize! (-> arg0 dir) 1.0)
+  (set!
+   (-> arg0 segment-length)
+   (vector-vector-distance
+    (the-as vector (-> arg0 segment))
+    (-> arg0 segment 1)
+    )
+   )
+  (let ((s5-0 (new 'stack-no-clear 'vector)))
+   (vector-! s5-0 (the-as vector (-> arg0 segment)) (-> arg0 point))
+   (vector+*! s5-0 s5-0 (-> arg0 dir) (- (vector-dot s5-0 (-> arg0 dir))))
+   (vector+! (-> arg0 nearest-point) (-> arg0 point) s5-0)
+   (set! (-> arg0 distance-to-segment) (vector-length s5-0))
+   (vector-! s5-0 (-> arg0 point) (the-as vector (-> arg0 segment)))
+   (set!
+    (-> arg0 parametric-index)
+    (/ (vector-dot (-> arg0 dir) s5-0) (-> arg0 segment-length))
+    )
+   )
+  (cond
+   ((< (-> arg0 parametric-index) 0.0)
+    (set! (-> arg0 parametric-index) 0.0)
+    (set! (-> arg0 nearest-point quad) (-> arg0 segment 0 quad))
+    (let
+     ((f0-10 (vector-vector-distance (-> arg0 nearest-point) (-> arg0 point))))
+     (set! (-> arg0 distance-to-segment) f0-10)
+     f0-10
+     )
+    )
+   ((< 1.0 (-> arg0 parametric-index))
+    (set! (-> arg0 parametric-index) 1.0)
+    (set! (-> arg0 nearest-point quad) (-> arg0 segment 1 quad))
+    (let
+     ((f0-13 (vector-vector-distance (-> arg0 nearest-point) (-> arg0 point))))
+     (set! (-> arg0 distance-to-segment) f0-13)
+     f0-13
+     )
+    )
+   )
+  )
 
-; (defbehavior muse-get-path-point muse ((arg0 vector) (arg1 int))
-;   (eval-path-curve-div! (-> self path) arg0 (the float arg1) 'interp)
-;   0
-;   (none)
-;   )
+;; definition for function muse-get-path-point
+;; INFO: Return type mismatch int vs none.
+(defbehavior muse-get-path-point muse ((arg0 vector) (arg1 int))
+  (eval-path-curve-div! (-> self path) arg0 (the float arg1) 'interp)
+  0
+  (none)
+  )
 
-; (defbehavior muse-check-dest-point muse ()
-;   (let ((gp-0 (new 'stack-no-clear 'point-on-path-segment-info))
-;         (f26-0 4096000.0)
-;         (f30-0 0.0)
-;         (f24-0 4096000.0)
-;         (f28-0 0.0)
-;         )
-;    (let ((s5-0 (+ (-> self path curve num-cverts) -1))
-;          (s4-0 (target-pos 0))
-;          )
-;     (dotimes (s3-0 s5-0)
-;      (let ((f22-0 (the float s3-0)))
-;       (let ((f20-0 (the float (+ s3-0 1))))
-;        (eval-path-curve-div!
-;         (-> self path)
-;         (the-as vector (-> gp-0 segment))
-;         f22-0
-;         'interp
-;         )
-;        (eval-path-curve-div! (-> self path) (-> gp-0 segment 1) f20-0 'interp)
-;        )
-;       (set! (-> gp-0 point quad) (-> s4-0 quad))
-;       (analyze-point-on-path-segment gp-0)
-;       (when (< (-> gp-0 distance-to-segment) f24-0)
-;        (set! f24-0 (-> gp-0 distance-to-segment))
-;        (set! f28-0 (+ f22-0 (-> gp-0 parametric-index)))
-;        )
-;       (set! (-> gp-0 point quad) (-> self collide-info trans quad))
-;       (analyze-point-on-path-segment gp-0)
-;       (when (< (-> gp-0 distance-to-segment) f26-0)
-;        (set! f26-0 (-> gp-0 distance-to-segment))
-;        (set! f30-0 (+ f22-0 (-> gp-0 parametric-index)))
-;        )
-;       )
-;      0
-;      )
-;     )
-;    (let ((f0-6 (- f30-0 f28-0)))
-;     (if (< f0-6 (* -0.5 (-> self max-path-index)))
-;      (+! f0-6 (-> self max-path-index))
-;      )
-;     (if (< (* 0.5 (-> self max-path-index)) f0-6)
-;      (set! f0-6 (- f0-6 (-> self max-path-index)))
-;      )
-;     (cond
-;      ((>= f0-6 0.0)
-;       (set! (-> self dest-path-index) (the float (the int (+ 2.5 f30-0))))
-;       (if (>= (-> self dest-path-index) (-> self max-path-index))
-;        (set!
-;         (-> self dest-path-index)
-;         (- (-> self dest-path-index) (-> self max-path-index))
-;         )
-;        )
-;       )
-;      (else
-;       (set! (-> self dest-path-index) (+ -1.5 f30-0))
-;       (if (< (-> self dest-path-index) 0.0)
-;        (+! (-> self dest-path-index) (-> self max-path-index))
-;        )
-;       (set!
-;        (-> self dest-path-index)
-;        (the float (the int (-> self dest-path-index)))
-;        )
-;       )
-;      )
-;     )
-;    )
-;   (eval-path-curve-div!
-;    (-> self path)
-;    (-> self dest-point)
-;    (-> self dest-path-index)
-;    'interp
-;    )
-;   0
-;   (none)
-;   )
+;; definition for function muse-check-dest-point
+;; INFO: Return type mismatch int vs none.
+;; Used lq/sq
+(defbehavior muse-check-dest-point muse ()
+  (let ((gp-0 (new 'stack-no-clear 'point-on-path-segment-info))
+        (f26-0 4096000.0)
+        (f30-0 0.0)
+        (f24-0 4096000.0)
+        (f28-0 0.0)
+        )
+   (let ((s5-0 (+ (-> self path curve num-cverts) -1))
+         (s4-0 (target-pos 0))
+         )
+    (dotimes (s3-0 s5-0)
+     (let ((f22-0 (the float s3-0)))
+      (let ((f20-0 (the float (+ s3-0 1))))
+       (eval-path-curve-div!
+        (-> self path)
+        (the-as vector (-> gp-0 segment))
+        f22-0
+        'interp
+        )
+       (eval-path-curve-div! (-> self path) (-> gp-0 segment 1) f20-0 'interp)
+       )
+      (set! (-> gp-0 point quad) (-> s4-0 quad))
+      (analyze-point-on-path-segment gp-0)
+      (when (< (-> gp-0 distance-to-segment) f24-0)
+       (set! f24-0 (-> gp-0 distance-to-segment))
+       (set! f28-0 (+ f22-0 (-> gp-0 parametric-index)))
+       )
+      (set! (-> gp-0 point quad) (-> self collide-info trans quad))
+      (analyze-point-on-path-segment gp-0)
+      (when (< (-> gp-0 distance-to-segment) f26-0)
+       (set! f26-0 (-> gp-0 distance-to-segment))
+       (set! f30-0 (+ f22-0 (-> gp-0 parametric-index)))
+       )
+      )
+     0
+     )
+    )
+   (let ((f0-6 (- f30-0 f28-0)))
+    (if (< f0-6 (* -0.5 (-> self max-path-index)))
+     (+! f0-6 (-> self max-path-index))
+     )
+    (if (< (* 0.5 (-> self max-path-index)) f0-6)
+     (set! f0-6 (- f0-6 (-> self max-path-index)))
+     )
+    (cond
+     ((>= f0-6 0.0)
+      (set! (-> self dest-path-index) (the float (the int (+ 2.5 f30-0))))
+      (if (>= (-> self dest-path-index) (-> self max-path-index))
+       (set!
+        (-> self dest-path-index)
+        (- (-> self dest-path-index) (-> self max-path-index))
+        )
+       )
+      )
+     (else
+      (set! (-> self dest-path-index) (+ -1.5 f30-0))
+      (if (< (-> self dest-path-index) 0.0)
+       (+! (-> self dest-path-index) (-> self max-path-index))
+       )
+      (set!
+       (-> self dest-path-index)
+       (the float (the int (-> self dest-path-index)))
+       )
+      )
+     )
+    )
+   )
+  (eval-path-curve-div!
+   (-> self path)
+   (-> self dest-point)
+   (-> self dest-path-index)
+   'interp
+   )
+  0
+  (none)
+  )
 
-; (defmethod dummy-51 muse ((obj muse))
-;   (dotimes (s5-0 2)
-;    (let ((v1-2 (rand-vu-int-range 3 (+ (-> obj node-list length) -1))))
-;     (sp-launch-particles-var
-;      *sp-particle-system-2d*
-;      (-> *part-id-table* 271)
-;      (vector<-cspace!
-;       (new 'stack-no-clear 'vector)
-;       (-> obj node-list data v1-2)
-;       )
-;      #f
-;      #f
-;      1.0
-;      )
-;     )
-;    )
-;   0
-;   (none)
-;   )
+;; definition for method 51 of type muse
+;; INFO: Return type mismatch int vs float.
+(defmethod dummy-51 muse ((obj muse))
+  (dotimes (s5-0 2)
+   (let ((v1-2 (rand-vu-int-range 3 (+ (-> obj node-list length) -1))))
+    (sp-launch-particles-var
+     *sp-particle-system-2d*
+     (-> *part-id-table* 271)
+     (vector<-cspace!
+      (new 'stack-no-clear 'vector)
+      (-> obj node-list data v1-2)
+      )
+     (the-as sparticle-launch-state #f)
+     (the-as sparticle-launch-control #f)
+     1.0
+     )
+    )
+   )
+  (the-as float 0)
+  )
 
-; (defmethod TODO-RENAME-39 muse ((obj muse))
-;   (spool-push *art-control* (-> obj anim name) 0 obj -99.0)
-;   (dummy-51 obj)
-;   ((method-of-type nav-enemy TODO-RENAME-39) obj)
-;   (none)
-;   )
+;; definition for method 39 of type muse
+(defmethod common-post muse ((obj muse))
+  (spool-push *art-control* (-> obj anim name) 0 obj -99.0)
+  (dummy-51 obj)
+  ((method-of-type nav-enemy common-post) obj)
+  (none)
+  )
 
-; (let
-;   ((v1-5
-;     (new 'static 'skeleton-group
-;      :art-group-name "muse"
-;      :bounds
-;      (new 'static 'vector :y 8192.0 :w 12288.0)
-;      :version #x6
-;      :shadow 2
-;      )
-;     )
-;    )
-;   (set! (-> v1-5 jgeo) 0)
-;   (set! (-> v1-5 janim) 3)
-;   (set! (-> v1-5 mgeo 0) (the-as uint 1))
-;   (set! (-> v1-5 lod-dist 0) 4095996000.0)
-;   (set! *muse-sg* v1-5)
-;   )
+;; failed to figure out what this is:
+(let
+  ((v1-5
+    (new 'static 'skeleton-group
+     :art-group-name "muse"
+     :bounds
+     (new 'static 'vector :y 8192.0 :w 12288.0)
+     :version #x6
+     :shadow 2
+     )
+    )
+   )
+  (set! (-> v1-5 jgeo) 0)
+  (set! (-> v1-5 janim) 3)
+  (set! (-> v1-5 mgeo 0) (the-as uint 1))
+  (set! (-> v1-5 lod-dist 0) 4095996000.0)
+  (set! *muse-sg* v1-5)
+  )
 
-; (defmethod dummy-44 muse ((obj muse) (arg0 process) (arg1 event-message-block))
-;   (the-as object (go muse-caught))
-;   )
+;; definition for method 44 of type muse
+;; INFO: Return type mismatch none vs object.
+(defmethod dummy-44 muse ((obj muse) (arg0 process) (arg1 event-message-block))
+  (the-as object (go muse-caught))
+  )
 
-; (defmethod dummy-43 muse ((obj muse) (arg0 process) (arg1 event-message-block))
-;   (the-as object (go muse-caught))
-;   )
+;; definition for method 43 of type muse
+;; INFO: Return type mismatch none vs object.
+(defmethod dummy-43 muse ((obj muse) (arg0 process) (arg1 event-message-block))
+  (the-as object (go muse-caught))
+  )
 
-; nav-enemy-default-event-handler
+;; failed to figure out what this is:
+nav-enemy-default-event-handler
 
-; (defstate muse-idle (muse)
-;   :event
-;   (the-as
-;    (function process int symbol event-message-block object :behavior muse)
-;    nav-enemy-default-event-handler
-;    )
-;   :trans
-;   (behavior ()
-;    (set!
-;     (-> self sprint-distance)
-;     (seek
-;      (-> self sprint-distance)
-;      61440.0
-;      (* 8192.0 (-> *display* seconds-per-frame))
-;      )
-;     )
-;    (if
-;     (and
-;      *target*
-;      (>=
-;       102400.0
-;       (vector-vector-distance
-;        (-> self collide-info trans)
-;        (-> *target* control trans)
-;        )
-;       )
-;      )
-;     (level-hint-spawn
-;      (game-text-id zero)
-;      (the-as string #f)
-;      (the-as symbol (-> self entity))
-;      *entity-pool*
-;      0
-;      )
-;     )
-;    (if
-;     (and
-;      *target*
-;      (>=
-;       81920.0
-;       (vector-vector-distance
-;        (-> self collide-info trans)
-;        (-> *target* control trans)
-;        )
-;       )
-;      )
-;     (go-virtual nav-enemy-chase)
-;     )
-;    (none)
-;    )
-;   :code
-;   (behavior ()
-;    (when (= (if (> (-> self skel active-channels) 0)
-;              (-> self skel root-channel 0 frame-group)
-;              )
-;           (-> self draw art-group data 4)
-;           )
-;     (ja-channel-push! 1 30)
-;     (let ((a0-5 (-> self skel root-channel 0)))
-;      (set! (-> a0-5 param 0) 1.0)
-;      (joint-control-channel-group!
-;       a0-5
-;       (the-as art-joint-anim #f)
-;       num-func-loop!
-;       )
-;      )
-;     (let ((a0-6 (-> self skel root-channel 0)))
-;      (set!
-;       (-> a0-6 frame-group)
-;       (the-as art-joint-anim (-> self draw art-group data 6))
-;       )
-;      (set!
-;       (-> a0-6 param 0)
-;       (the
-;        float
-;        (+
-;         (->
-;          (the-as art-joint-anim (-> self draw art-group data 6))
-;          data
-;          0
-;          length
-;          )
-;         -1
-;         )
-;        )
-;       )
-;      (set! (-> a0-6 param 1) 1.0)
-;      (set! (-> a0-6 frame-num) 0.0)
-;      (joint-control-channel-group!
-;       a0-6
-;       (the-as art-joint-anim (-> self draw art-group data 6))
-;       num-func-seek!
-;       )
-;      )
-;     (until (ja-done? 0)
-;      (ja-blend-eval)
-;      (suspend)
-;      (let ((a0-7 (-> self skel root-channel 0)))
-;       (set!
-;        (-> a0-7 param 0)
-;        (the float (+ (-> a0-7 frame-group data 0 length) -1))
-;        )
-;       (set! (-> a0-7 param 1) 1.0)
-;       (joint-control-channel-group-eval!
-;        a0-7
-;        (the-as art-joint-anim #f)
-;        num-func-seek!
-;        )
-;       )
-;      )
-;     )
-;    (while #t
-;     (let ((a0-9 (-> self skel root-channel 0)))
-;      (set!
-;       (-> a0-9 frame-group)
-;       (the-as art-joint-anim (-> self draw art-group data 3))
-;       )
-;      (set!
-;       (-> a0-9 param 0)
-;       (the
-;        float
-;        (+
-;         (->
-;          (the-as art-joint-anim (-> self draw art-group data 3))
-;          data
-;          0
-;          length
-;          )
-;         -1
-;         )
-;        )
-;       )
-;      (set! (-> a0-9 param 1) 1.0)
-;      (set! (-> a0-9 frame-num) 0.0)
-;      (joint-control-channel-group!
-;       a0-9
-;       (the-as art-joint-anim (-> self draw art-group data 3))
-;       num-func-seek!
-;       )
-;      )
-;     (until (ja-done? 0)
-;      (spool-push *art-control* (-> self anim name) 0 self -99.0)
-;      (dummy-51 self)
-;      (suspend)
-;      (let ((a0-12 (-> self skel root-channel 0)))
-;       (set!
-;        (-> a0-12 param 0)
-;        (the float (+ (-> a0-12 frame-group data 0 length) -1))
-;        )
-;       (set! (-> a0-12 param 1) 1.0)
-;       (joint-control-channel-group-eval!
-;        a0-12
-;        (the-as art-joint-anim #f)
-;        num-func-seek!
-;        )
-;       )
-;      )
-;     )
-;    (none)
-;    )
-;   :post
-;   (the-as (function none :behavior muse) ja-post)
-;   )
+;; failed to figure out what this is:
+(defstate muse-idle (muse)
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior muse)
+   nav-enemy-default-event-handler
+   )
+  :trans
+  (behavior ()
+   (set!
+    (-> self sprint-distance)
+    (seek
+     (-> self sprint-distance)
+     61440.0
+     (* 8192.0 (-> *display* seconds-per-frame))
+     )
+    )
+   (if
+    (and
+     *target*
+     (>=
+      102400.0
+      (vector-vector-distance
+       (-> self collide-info trans)
+       (-> *target* control trans)
+       )
+      )
+     )
+    (level-hint-spawn
+     (game-text-id zero)
+     (the-as string #f)
+     (-> self entity)
+     *entity-pool*
+     (game-task none)
+     )
+    )
+   (if
+    (and
+     *target*
+     (>=
+      81920.0
+      (vector-vector-distance
+       (-> self collide-info trans)
+       (-> *target* control trans)
+       )
+      )
+     )
+    (go-virtual nav-enemy-chase)
+    )
+   (none)
+   )
+  :code
+  (behavior ()
+   (when (= (if (> (-> self skel active-channels) 0)
+             (-> self skel root-channel 0 frame-group)
+             )
+          (-> self draw art-group data 4)
+          )
+    (ja-channel-push! 1 30)
+    (let ((a0-5 (-> self skel root-channel 0)))
+     (set! (-> a0-5 param 0) 1.0)
+     (joint-control-channel-group!
+      a0-5
+      (the-as art-joint-anim #f)
+      num-func-loop!
+      )
+     )
+    (let ((a0-6 (-> self skel root-channel 0)))
+     (set!
+      (-> a0-6 frame-group)
+      (the-as art-joint-anim (-> self draw art-group data 6))
+      )
+     (set!
+      (-> a0-6 param 0)
+      (the
+       float
+       (+
+        (->
+         (the-as art-joint-anim (-> self draw art-group data 6))
+         data
+         0
+         length
+         )
+        -1
+        )
+       )
+      )
+     (set! (-> a0-6 param 1) 1.0)
+     (set! (-> a0-6 frame-num) 0.0)
+     (joint-control-channel-group!
+      a0-6
+      (the-as art-joint-anim (-> self draw art-group data 6))
+      num-func-seek!
+      )
+     )
+    (until (ja-done? 0)
+     (ja-blend-eval)
+     (suspend)
+     (let ((a0-7 (-> self skel root-channel 0)))
+      (set!
+       (-> a0-7 param 0)
+       (the float (+ (-> a0-7 frame-group data 0 length) -1))
+       )
+      (set! (-> a0-7 param 1) 1.0)
+      (joint-control-channel-group-eval!
+       a0-7
+       (the-as art-joint-anim #f)
+       num-func-seek!
+       )
+      )
+     )
+    )
+   (while #t
+    (let ((a0-9 (-> self skel root-channel 0)))
+     (set!
+      (-> a0-9 frame-group)
+      (the-as art-joint-anim (-> self draw art-group data 3))
+      )
+     (set!
+      (-> a0-9 param 0)
+      (the
+       float
+       (+
+        (->
+         (the-as art-joint-anim (-> self draw art-group data 3))
+         data
+         0
+         length
+         )
+        -1
+        )
+       )
+      )
+     (set! (-> a0-9 param 1) 1.0)
+     (set! (-> a0-9 frame-num) 0.0)
+     (joint-control-channel-group!
+      a0-9
+      (the-as art-joint-anim (-> self draw art-group data 3))
+      num-func-seek!
+      )
+     )
+    (until (ja-done? 0)
+     (spool-push *art-control* (-> self anim name) 0 self -99.0)
+     (dummy-51 self)
+     (suspend)
+     (let ((a0-12 (-> self skel root-channel 0)))
+      (set!
+       (-> a0-12 param 0)
+       (the float (+ (-> a0-12 frame-group data 0 length) -1))
+       )
+      (set! (-> a0-12 param 1) 1.0)
+      (joint-control-channel-group-eval!
+       a0-12
+       (the-as art-joint-anim #f)
+       num-func-seek!
+       )
+      )
+     )
+    )
+   (none)
+   )
+  :post
+  (the-as (function none :behavior muse) ja-post)
+  )
 
-; (defstate nav-enemy-chase (muse)
-;   :virtual #t
-;   :event
-;   (the-as
-;    (function process int symbol event-message-block object :behavior muse)
-;    nav-enemy-default-event-handler
-;    )
-;   :enter
-;   (behavior ()
-;    (set!
-;     (-> self state-time)
-;     (the-as seconds (-> *display* base-frame-counter))
-;     )
-;    (none)
-;    )
-;   :trans
-;   (behavior ()
-;    (cond
-;     ((or
-;       (not *target*)
-;       (<
-;        102400.0
-;        (vector-vector-distance
-;         (-> self collide-info trans)
-;         (-> *target* control trans)
-;         )
-;        )
-;       )
-;      (set! (-> self target-speed) 0.0)
-;      (if (= (-> self momentum-speed) 0.0)
-;       (go muse-idle)
-;       )
-;      )
-;     ((or
-;       (not *target*)
-;       (<
-;        (-> self sprint-distance)
-;        (vector-vector-distance
-;         (-> self collide-info trans)
-;         (-> *target* control trans)
-;         )
-;        )
-;       )
-;      (set! (-> self target-speed) 40960.0)
-;      )
-;     (else
-;      (set! (-> self target-speed) 61440.0)
-;      )
-;     )
-;    (set!
-;     (-> self sprint-distance)
-;     (seek
-;      (-> self sprint-distance)
-;      0.0
-;      (* 4096.0 (-> *display* seconds-per-frame))
-;      )
-;     )
-;    (muse-check-dest-point)
-;    (none)
-;    )
-;   :code
-;   (behavior ()
-;    (cond
-;     ((= (if (> (-> self skel active-channels) 0)
-;          (-> self skel root-channel 0 frame-group)
-;          )
-;       (-> self draw art-group data 3)
-;       )
-;      (ja-channel-push! 1 30)
-;      (let ((a0-5 (-> self skel root-channel 0)))
-;       (set! (-> a0-5 param 0) 1.0)
-;       (joint-control-channel-group!
-;        a0-5
-;        (the-as art-joint-anim #f)
-;        num-func-loop!
-;        )
-;       )
-;      (let ((a0-6 (-> self skel root-channel 0)))
-;       (set!
-;        (-> a0-6 frame-group)
-;        (the-as art-joint-anim (-> self draw art-group data 5))
-;        )
-;       (set!
-;        (-> a0-6 param 0)
-;        (the
-;         float
-;         (+
-;          (->
-;           (the-as art-joint-anim (-> self draw art-group data 5))
-;           data
-;           0
-;           length
-;           )
-;          -1
-;          )
-;         )
-;        )
-;       (set! (-> a0-6 param 1) 1.0)
-;       (set! (-> a0-6 frame-num) 0.0)
-;       (joint-control-channel-group!
-;        a0-6
-;        (the-as art-joint-anim (-> self draw art-group data 5))
-;        num-func-seek!
-;        )
-;       )
-;      (until (ja-done? 0)
-;       (ja-blend-eval)
-;       (suspend)
-;       (let ((a0-7 (-> self skel root-channel 0)))
-;        (set!
-;         (-> a0-7 param 0)
-;         (the float (+ (-> a0-7 frame-group data 0 length) -1))
-;         )
-;        (set! (-> a0-7 param 1) 1.0)
-;        (joint-control-channel-group-eval!
-;         a0-7
-;         (the-as art-joint-anim #f)
-;         num-func-seek!
-;         )
-;        )
-;       )
-;      )
-;     (else
-;      (ja-channel-push! 1 30)
-;      )
-;     )
-;    (let ((gp-0 (-> self skel root-channel 0)))
-;     (joint-control-channel-group-eval!
-;      gp-0
-;      (the-as art-joint-anim (-> self draw art-group data 4))
-;      num-func-identity
-;      )
-;     (set! (-> gp-0 frame-num) 0.0)
-;     )
-;    (while #t
-;     (suspend)
-;     (let ((a0-11 (-> self skel root-channel 0)))
-;      (set! (-> a0-11 param 0) (* 0.000016276043 (-> self momentum-speed)))
-;      (joint-control-channel-group-eval!
-;       a0-11
-;       (the-as art-joint-anim #f)
-;       num-func-loop!
-;       )
-;      )
-;     )
-;    (none)
-;    )
-;   :post
-;   (behavior ()
-;    (set! (-> self nav destination-pos quad) (-> self dest-point quad))
-;    (dummy-19
-;     (-> self nav)
-;     (-> self nav target-pos)
-;     (-> self collide-info)
-;     (-> self nav destination-pos)
-;     546133.3
-;     )
-;    (if (logtest? (nav-control-flags bit21) (-> self nav flags))
-;     (logclear! (-> self nav flags) (nav-control-flags bit10))
-;     )
-;    (nav-enemy-travel-post)
-;    (none)
-;    )
-;   )
+;; failed to figure out what this is:
+(defstate nav-enemy-chase (muse)
+  :virtual #t
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior muse)
+   nav-enemy-default-event-handler
+   )
+  :enter
+  (behavior ()
+   (set!
+    (-> self state-time)
+    (the-as seconds (-> *display* base-frame-counter))
+    )
+   (none)
+   )
+  :trans
+  (behavior ()
+   (cond
+    ((or
+      (not *target*)
+      (<
+       102400.0
+       (vector-vector-distance
+        (-> self collide-info trans)
+        (-> *target* control trans)
+        )
+       )
+      )
+     (set! (-> self target-speed) 0.0)
+     (if (= (-> self momentum-speed) 0.0)
+      (go muse-idle)
+      )
+     )
+    ((or
+      (not *target*)
+      (<
+       (-> self sprint-distance)
+       (vector-vector-distance
+        (-> self collide-info trans)
+        (-> *target* control trans)
+        )
+       )
+      )
+     (set! (-> self target-speed) 40960.0)
+     )
+    (else
+     (set! (-> self target-speed) 61440.0)
+     )
+    )
+   (set!
+    (-> self sprint-distance)
+    (seek
+     (-> self sprint-distance)
+     0.0
+     (* 4096.0 (-> *display* seconds-per-frame))
+     )
+    )
+   (muse-check-dest-point)
+   (none)
+   )
+  :code
+  (behavior ()
+   (cond
+    ((= (if (> (-> self skel active-channels) 0)
+         (-> self skel root-channel 0 frame-group)
+         )
+      (-> self draw art-group data 3)
+      )
+     (ja-channel-push! 1 30)
+     (let ((a0-5 (-> self skel root-channel 0)))
+      (set! (-> a0-5 param 0) 1.0)
+      (joint-control-channel-group!
+       a0-5
+       (the-as art-joint-anim #f)
+       num-func-loop!
+       )
+      )
+     (let ((a0-6 (-> self skel root-channel 0)))
+      (set!
+       (-> a0-6 frame-group)
+       (the-as art-joint-anim (-> self draw art-group data 5))
+       )
+      (set!
+       (-> a0-6 param 0)
+       (the
+        float
+        (+
+         (->
+          (the-as art-joint-anim (-> self draw art-group data 5))
+          data
+          0
+          length
+          )
+         -1
+         )
+        )
+       )
+      (set! (-> a0-6 param 1) 1.0)
+      (set! (-> a0-6 frame-num) 0.0)
+      (joint-control-channel-group!
+       a0-6
+       (the-as art-joint-anim (-> self draw art-group data 5))
+       num-func-seek!
+       )
+      )
+     (until (ja-done? 0)
+      (ja-blend-eval)
+      (suspend)
+      (let ((a0-7 (-> self skel root-channel 0)))
+       (set!
+        (-> a0-7 param 0)
+        (the float (+ (-> a0-7 frame-group data 0 length) -1))
+        )
+       (set! (-> a0-7 param 1) 1.0)
+       (joint-control-channel-group-eval!
+        a0-7
+        (the-as art-joint-anim #f)
+        num-func-seek!
+        )
+       )
+      )
+     )
+    (else
+     (ja-channel-push! 1 30)
+     )
+    )
+   (let ((gp-0 (-> self skel root-channel 0)))
+    (joint-control-channel-group-eval!
+     gp-0
+     (the-as art-joint-anim (-> self draw art-group data 4))
+     num-func-identity
+     )
+    (set! (-> gp-0 frame-num) 0.0)
+    )
+   (while #t
+    (suspend)
+    (let ((a0-11 (-> self skel root-channel 0)))
+     (set! (-> a0-11 param 0) (* 0.000016276043 (-> self momentum-speed)))
+     (joint-control-channel-group-eval!
+      a0-11
+      (the-as art-joint-anim #f)
+      num-func-loop!
+      )
+     )
+    )
+   (none)
+   )
+  :post
+  (behavior ()
+   (set! (-> self nav destination-pos quad) (-> self dest-point quad))
+   (dummy-19
+    (-> self nav)
+    (-> self nav target-pos)
+    (-> self collide-info)
+    (-> self nav destination-pos)
+    546133.3
+    )
+   (if (logtest? (nav-control-flags bit21) (-> self nav flags))
+    (logclear! (-> self nav flags) (nav-control-flags bit10))
+    )
+   (nav-enemy-travel-post)
+   (none)
+   )
+  )
 
-; (defstate nav-enemy-jump (muse)
-;   :virtual #t
-;   :event
-;   (the-as
-;    (function process int symbol event-message-block object :behavior muse)
-;    nav-enemy-default-event-handler
-;    )
-;   :enter
-;   (behavior ()
-;    ((-> (method-of-type nav-enemy nav-enemy-jump) enter))
-;    (set! (-> self nav-enemy-flags) (logand -513 (-> self nav-enemy-flags)))
-;    (none)
-;    )
-;   :code
-;   (-> (method-of-type nav-enemy nav-enemy-jump) code)
-;   )
+;; failed to figure out what this is:
+(defstate nav-enemy-jump (muse)
+  :virtual #t
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior muse)
+   nav-enemy-default-event-handler
+   )
+  :enter
+  (behavior ()
+   ((-> (method-of-type nav-enemy nav-enemy-jump) enter))
+   (set! (-> self nav-enemy-flags) (logand -513 (-> self nav-enemy-flags)))
+   (none)
+   )
+  :code
+  (-> (method-of-type nav-enemy nav-enemy-jump) code)
+  )
 
-; (defstate nav-enemy-jump-land (muse)
-;   :virtual #t
-;   :event
-;   (the-as
-;    (function process int symbol event-message-block object :behavior muse)
-;    nav-enemy-default-event-handler
-;    )
-;   :code
-;   (behavior ()
-;    (let ((a0-0 (-> self skel root-channel 0)))
-;     (set!
-;      (-> a0-0 param 0)
-;      (the float (+ (-> a0-0 frame-group data 0 length) -1))
-;      )
-;     (set! (-> a0-0 param 1) 1.0)
-;     (joint-control-channel-group!
-;      a0-0
-;      (the-as art-joint-anim #f)
-;      num-func-seek!
-;      )
-;     )
-;    (ja-channel-push! 1 22)
-;    (let ((gp-0 (-> self skel root-channel 0)))
-;     (set!
-;      (-> gp-0 frame-group)
-;      (the-as art-joint-anim (-> self draw art-group data 4))
-;      )
-;     (set!
-;      (-> gp-0 param 0)
-;      (the
-;       float
-;       (+
-;        (->
-;         (the-as art-joint-anim (-> self draw art-group data 4))
-;         data
-;         0
-;         length
-;         )
-;        -1
-;        )
-;       )
-;      )
-;     (set! (-> gp-0 param 1) 0.8)
-;     (set! (-> gp-0 frame-num) (ja-aframe 6.0 0))
-;     (joint-control-channel-group!
-;      gp-0
-;      (the-as art-joint-anim (-> self draw art-group data 4))
-;      num-func-seek!
-;      )
-;     )
-;    (until (ja-done? 0)
-;     (ja-blend-eval)
-;     (suspend)
-;     (let ((a0-4 (-> self skel root-channel 0)))
-;      (set!
-;       (-> a0-4 param 0)
-;       (the float (+ (-> a0-4 frame-group data 0 length) -1))
-;       )
-;      (set! (-> a0-4 param 1) 0.8)
-;      (joint-control-channel-group-eval!
-;       a0-4
-;       (the-as art-joint-anim #f)
-;       num-func-seek!
-;       )
-;      )
-;     )
-;    (go-virtual nav-enemy-chase)
-;    (none)
-;    )
-;   )
+;; failed to figure out what this is:
+(defstate nav-enemy-jump-land (muse)
+  :virtual #t
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior muse)
+   nav-enemy-default-event-handler
+   )
+  :code
+  (behavior ()
+   (let ((a0-0 (-> self skel root-channel 0)))
+    (set!
+     (-> a0-0 param 0)
+     (the float (+ (-> a0-0 frame-group data 0 length) -1))
+     )
+    (set! (-> a0-0 param 1) 1.0)
+    (joint-control-channel-group!
+     a0-0
+     (the-as art-joint-anim #f)
+     num-func-seek!
+     )
+    )
+   (ja-channel-push! 1 22)
+   (let ((gp-0 (-> self skel root-channel 0)))
+    (set!
+     (-> gp-0 frame-group)
+     (the-as art-joint-anim (-> self draw art-group data 4))
+     )
+    (set!
+     (-> gp-0 param 0)
+     (the
+      float
+      (+
+       (->
+        (the-as art-joint-anim (-> self draw art-group data 4))
+        data
+        0
+        length
+        )
+       -1
+       )
+      )
+     )
+    (set! (-> gp-0 param 1) 0.8)
+    (set! (-> gp-0 frame-num) (ja-aframe 6.0 0))
+    (joint-control-channel-group!
+     gp-0
+     (the-as art-joint-anim (-> self draw art-group data 4))
+     num-func-seek!
+     )
+    )
+   (until (ja-done? 0)
+    (ja-blend-eval)
+    (suspend)
+    (let ((a0-4 (-> self skel root-channel 0)))
+     (set!
+      (-> a0-4 param 0)
+      (the float (+ (-> a0-4 frame-group data 0 length) -1))
+      )
+     (set! (-> a0-4 param 1) 0.8)
+     (joint-control-channel-group-eval!
+      a0-4
+      (the-as art-joint-anim #f)
+      num-func-seek!
+      )
+     )
+    )
+   (go-virtual nav-enemy-chase)
+   (none)
+   )
+  )
 
-; (defstate muse-caught (muse)
-;   :event
-;   (the-as
-;    (function process int symbol event-message-block object :behavior muse)
-;    #f
-;    )
-;   :trans
-;   (behavior ()
-;    (spool-push *art-control* (-> self anim name) 0 self -1.0)
-;    (none)
-;    )
-;   :code
-;   (behavior ()
-;    (sound-play-by-name
-;     (static-sound-name "money-pickup")
-;     (new-sound-id)
-;     1024
-;     0
-;     0
-;     (the-as uint 1)
-;     (the-as vector #t)
-;     )
-;    (close-specific-task! (game-task misty-muse) (task-status need-reminder))
-;    (process-entity-status! self (entity-perm-status dead) #t)
-;    (suspend)
-;    (let ((a1-3 (new 'stack-no-clear 'event-message-block)))
-;     (set! (-> a1-3 from) self)
-;     (set! (-> a1-3 num-params) 1)
-;     (set! (-> a1-3 message) 'clone-anim)
-;     (set! (-> a1-3 param 0) (the-as uint self))
-;     (when (send-event-function *target* a1-3)
-;      (set-blackout-frames 3000)
-;      (let ((gp-1 (res-lump-struct (-> self entity) 'movie-pos vector)))
-;       (cond
-;        (gp-1
-;         (TODO-RENAME-30 (-> self collide-info) gp-1)
-;         (set-yaw-angle-clear-roll-pitch! (-> self collide-info) (-> gp-1 w))
-;         )
-;        (else
-;         (TODO-RENAME-30 (-> self collide-info) (-> *target* control trans))
-;         (quaternion-copy!
-;          (-> self collide-info quat)
-;          (-> *target* control quat)
-;          )
-;         (dummy-60 (-> self collide-info) 40960.0 40960.0 #f (the-as uint 1))
-;         )
-;        )
-;       )
-;      (let ((a1-10 (new 'stack-no-clear 'event-message-block)))
-;       (set! (-> a1-10 from) self)
-;       (set! (-> a1-10 num-params) 2)
-;       (set! (-> a1-10 message) 'trans)
-;       (set! (-> a1-10 param 0) (the-as uint 'save))
-;       (set! (-> a1-10 param 1) (the-as uint (-> self old-target-pos)))
-;       (send-event-function *target* a1-10)
-;       )
-;      (let ((a1-11 (new 'stack-no-clear 'event-message-block)))
-;       (set! (-> a1-11 from) self)
-;       (set! (-> a1-11 num-params) 1)
-;       (set! (-> a1-11 message) 'matrix)
-;       (set! (-> a1-11 param 0) (the-as uint 'play-anim))
-;       (send-event-function (ppointer->process (-> *target* sidekick)) a1-11)
-;       )
-;      (let ((a1-12 (new 'stack-no-clear 'event-message-block)))
-;       (set! (-> a1-12 from) self)
-;       (set! (-> a1-12 num-params) 1)
-;       (set! (-> a1-12 message) 'blend-shape)
-;       (set! (-> a1-12 param 0) (the-as uint #t))
-;       (send-event-function *target* a1-12)
-;       )
-;      (if (!= *kernel-boot-message* 'play)
-;       (set!
-;        (-> self trans-hook)
-;        (lambda :behavior muse
-;         ()
-;         (spool-push *art-control* (-> self victory-anim name) 0 self -1.0)
-;         (none)
-;         )
-;        )
-;       )
-;      (push-setting!
-;       *setting-control*
-;       self
-;       (the-as (function object object object object object) 'music-volume)
-;       'rel
-;       (-> *setting-control* current music-volume-movie)
-;       0
-;       )
-;      (push-setting!
-;       *setting-control*
-;       self
-;       (the-as (function object object object object object) 'sfx-volume)
-;       'rel
-;       (-> *setting-control* current sfx-volume-movie)
-;       0
-;       )
-;      (push-setting!
-;       *setting-control*
-;       self
-;       (the-as (function object object object object object) 'ambient-volume)
-;       'rel
-;       (-> *setting-control* current ambient-volume-movie)
-;       0
-;       )
-;      (logclear! (-> self mask) (process-mask enemy))
-;      (let ((gp-2 (get-process *default-dead-pool* othercam #x4000)))
-;       (when gp-2
-;        (let ((t9-19 (method-of-type othercam activate)))
-;         (t9-19
-;          (the-as othercam gp-2)
-;          self
-;          'othercam
-;          (the-as pointer #x70004000)
-;          )
-;         )
-;        (run-now-in-process gp-2 othercam-init-by-other self 3 #f #t)
-;        (-> gp-2 ppointer)
-;        )
-;       )
-;      (auto-save-command 'auto-save 0 0 *default-pool*)
-;      (ja-play-spooled-anim
-;       (-> self anim)
-;       (the-as art-joint-anim (-> self draw art-group data 3))
-;       (the-as art-joint-anim (-> self draw art-group data 3))
-;       (the-as (function process-drawable symbol) false-func)
-;       )
-;      (clear-pending-settings-from-process *setting-control* self 'music-volume)
-;      (clear-pending-settings-from-process *setting-control* self 'sfx-volume)
-;      (clear-pending-settings-from-process
-;       *setting-control*
-;       self
-;       'ambient-volume
-;       )
-;      (let ((a1-24 (new 'stack-no-clear 'event-message-block)))
-;       (set! (-> a1-24 from) self)
-;       (set! (-> a1-24 num-params) 1)
-;       (set! (-> a1-24 message) 'blend-shape)
-;       (set! (-> a1-24 param 0) (the-as uint #f))
-;       (send-event-function *target* a1-24)
-;       )
-;      (cond
-;       ((!= *kernel-boot-message* 'play)
-;        (set-blackout-frames 0)
-;        (ja-channel-set! 0)
-;        (ja-post)
-;        (dummy-48 (-> self collide-info))
-;        (let ((a1-25 (new 'stack-no-clear 'event-message-block)))
-;         (set! (-> a1-25 from) self)
-;         (set! (-> a1-25 num-params) 1)
-;         (set! (-> a1-25 message) 'trans)
-;         (set! (-> a1-25 param 0) (the-as uint 'reset))
-;         (send-event-function *target* a1-25)
-;         )
-;        (let
-;         ((gp-4
-;           (ppointer->handle
-;            (birth-pickup-at-point
-;             (target-pos 0)
-;             6
-;             (the float (-> self entity extra perm task))
-;             #f
-;             self
-;             #f
-;             )
-;            )
-;           )
-;          )
-;         (let ((a1-27 (new 'stack-no-clear 'event-message-block)))
-;          (set! (-> a1-27 from) self)
-;          (set! (-> a1-27 num-params) 0)
-;          (set! (-> a1-27 message) 'pickup)
-;          (send-event-function (handle->process (the-as handle gp-4)) a1-27)
-;          )
-;         (while (handle->process (the-as handle gp-4))
-;          (suspend)
-;          )
-;         )
-;        )
-;       (else
-;        (let ((a1-29 (new 'stack-no-clear 'event-message-block)))
-;         (set! (-> a1-29 from) self)
-;         (set! (-> a1-29 num-params) 2)
-;         (set! (-> a1-29 message) 'trans)
-;         (set! (-> a1-29 param 0) (the-as uint 'restore))
-;         (set! (-> a1-29 param 1) (the-as uint (-> self old-target-pos)))
-;         (send-event-function *target* a1-29)
-;         )
-;        (set-blackout-frames 0)
-;        (set-blackout-frames 30)
-;        )
-;       )
-;      )
-;     )
-;    (none)
-;    )
-;   :post
-;   (behavior ()
-;    (dummy-51 self)
-;    (level-hint-surpress!)
-;    (kill-current-level-hint '() '() 'exit)
-;    (ja-post)
-;    (none)
-;    )
-;   )
+;; failed to figure out what this is:
+(defstate muse-caught (muse)
+  :event
+  (the-as
+   (function process int symbol event-message-block object :behavior muse)
+   #f
+   )
+  :trans
+  (behavior ()
+   (spool-push *art-control* (-> self anim name) 0 self -1.0)
+   (none)
+   )
+  :code
+  (behavior ()
+   (sound-play-by-name
+    (static-sound-name "money-pickup")
+    (new-sound-id)
+    1024
+    0
+    0
+    (the-as uint 1)
+    (the-as vector #t)
+    )
+   (close-specific-task! (game-task misty-muse) (task-status need-reminder))
+   (process-entity-status! self (entity-perm-status dead) #t)
+   (suspend)
+   (let ((a1-3 (new 'stack-no-clear 'event-message-block)))
+    (set! (-> a1-3 from) self)
+    (set! (-> a1-3 num-params) 1)
+    (set! (-> a1-3 message) 'clone-anim)
+    (set! (-> a1-3 param 0) (the-as uint self))
+    (when (send-event-function *target* a1-3)
+     (set-blackout-frames 3000)
+     (let ((gp-1 (res-lump-struct (-> self entity) 'movie-pos vector)))
+      (cond
+       (gp-1
+        (TODO-RENAME-30 (-> self collide-info) gp-1)
+        (set-yaw-angle-clear-roll-pitch! (-> self collide-info) (-> gp-1 w))
+        )
+       (else
+        (TODO-RENAME-30 (-> self collide-info) (-> *target* control trans))
+        (quaternion-copy!
+         (-> self collide-info quat)
+         (-> *target* control quat)
+         )
+        (dummy-60 (-> self collide-info) 40960.0 40960.0 #f (the-as uint 1))
+        )
+       )
+      )
+     (let ((a1-10 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-10 from) self)
+      (set! (-> a1-10 num-params) 2)
+      (set! (-> a1-10 message) 'trans)
+      (set! (-> a1-10 param 0) (the-as uint 'save))
+      (set! (-> a1-10 param 1) (the-as uint (-> self old-target-pos)))
+      (send-event-function *target* a1-10)
+      )
+     (let ((a1-11 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-11 from) self)
+      (set! (-> a1-11 num-params) 1)
+      (set! (-> a1-11 message) 'matrix)
+      (set! (-> a1-11 param 0) (the-as uint 'play-anim))
+      (send-event-function (ppointer->process (-> *target* sidekick)) a1-11)
+      )
+     (let ((a1-12 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-12 from) self)
+      (set! (-> a1-12 num-params) 1)
+      (set! (-> a1-12 message) 'blend-shape)
+      (set! (-> a1-12 param 0) (the-as uint #t))
+      (send-event-function *target* a1-12)
+      )
+     (if (!= *kernel-boot-message* 'play)
+      (set!
+       (-> self trans-hook)
+       (lambda :behavior muse
+        ()
+        (spool-push *art-control* (-> self victory-anim name) 0 self -1.0)
+        (none)
+        )
+       )
+      )
+     (push-setting! *setting-control* self 'music-volume 'rel (-> *setting-control* current music-volume-movie) 0)
+     (push-setting! *setting-control* self 'sfx-volume 'rel (-> *setting-control* current sfx-volume-movie) 0)
+     (push-setting! *setting-control* self 'ambient-volume 'rel (-> *setting-control* current ambient-volume-movie) 0)
+     (logclear! (-> self mask) (process-mask enemy))
+     (let ((gp-2 (get-process *default-dead-pool* othercam #x4000)))
+      (when gp-2
+       (let ((t9-19 (method-of-type othercam activate)))
+        (t9-19
+         (the-as othercam gp-2)
+         self
+         'othercam
+         (the-as pointer #x70004000)
+         )
+        )
+       (run-now-in-process gp-2 othercam-init-by-other self 3 #f #t)
+       (-> gp-2 ppointer)
+       )
+      )
+     (auto-save-command 'auto-save 0 0 *default-pool*)
+     (ja-play-spooled-anim
+      (-> self anim)
+      (the-as art-joint-anim (-> self draw art-group data 3))
+      (the-as art-joint-anim (-> self draw art-group data 3))
+      (the-as (function process-drawable symbol) false-func)
+      )
+     (clear-pending-settings-from-process *setting-control* self 'music-volume)
+     (clear-pending-settings-from-process *setting-control* self 'sfx-volume)
+     (clear-pending-settings-from-process
+      *setting-control*
+      self
+      'ambient-volume
+      )
+     (let ((a1-24 (new 'stack-no-clear 'event-message-block)))
+      (set! (-> a1-24 from) self)
+      (set! (-> a1-24 num-params) 1)
+      (set! (-> a1-24 message) 'blend-shape)
+      (set! (-> a1-24 param 0) (the-as uint #f))
+      (send-event-function *target* a1-24)
+      )
+     (cond
+      ((!= *kernel-boot-message* 'play)
+       (set-blackout-frames 0)
+       (ja-channel-set! 0)
+       (ja-post)
+       (dummy-48 (-> self collide-info))
+       (let ((a1-25 (new 'stack-no-clear 'event-message-block)))
+        (set! (-> a1-25 from) self)
+        (set! (-> a1-25 num-params) 1)
+        (set! (-> a1-25 message) 'trans)
+        (set! (-> a1-25 param 0) (the-as uint 'reset))
+        (send-event-function *target* a1-25)
+        )
+       (let
+        ((gp-4
+          (ppointer->handle
+           (birth-pickup-at-point
+            (target-pos 0)
+            6
+            (the float (-> self entity extra perm task))
+            #f
+            self
+            #f
+            )
+           )
+          )
+         )
+        (let ((a1-27 (new 'stack-no-clear 'event-message-block)))
+         (set! (-> a1-27 from) self)
+         (set! (-> a1-27 num-params) 0)
+         (set! (-> a1-27 message) 'pickup)
+         (send-event-function (handle->process (the-as handle gp-4)) a1-27)
+         )
+        (while (handle->process (the-as handle gp-4))
+         (suspend)
+         )
+        )
+       )
+      (else
+       (let ((a1-29 (new 'stack-no-clear 'event-message-block)))
+        (set! (-> a1-29 from) self)
+        (set! (-> a1-29 num-params) 2)
+        (set! (-> a1-29 message) 'trans)
+        (set! (-> a1-29 param 0) (the-as uint 'restore))
+        (set! (-> a1-29 param 1) (the-as uint (-> self old-target-pos)))
+        (send-event-function *target* a1-29)
+        )
+       (set-blackout-frames 0)
+       (set-blackout-frames 30)
+       )
+      )
+     )
+    )
+   (none)
+   )
+  :post
+  (behavior ()
+   (dummy-51 self)
+   (level-hint-surpress!)
+   (kill-current-level-hint '() '() 'exit)
+   (ja-post)
+   (none)
+   )
+  )
 
-; (define
-;   *muse-nav-enemy-info*
-;   (new 'static 'nav-enemy-info
-;    :idle-anim 3
-;    :walk-anim 4
-;    :turn-anim -1
-;    :notice-anim 3
-;    :run-anim 4
-;    :jump-anim 7
-;    :jump-land-anim 8
-;    :victory-anim 3
-;    :taunt-anim 3
-;    :die-anim 3
-;    :neck-joint 6
-;    :player-look-at-joint 5
-;    :run-travel-speed (meters 10.0)
-;    :run-rotate-speed (degrees 999.99994)
-;    :run-acceleration (meters 5.0)
-;    :run-turn-time #x2d
-;    :walk-travel-speed (meters 10.0)
-;    :walk-rotate-speed (degrees 999.99994)
-;    :walk-acceleration (meters 1.0)
-;    :walk-turn-time #x2d
-;    :attack-shove-back (meters 3.0)
-;    :attack-shove-up (meters 2.0)
-;    :shadow-size (meters 2.0)
-;    :notice-nav-radius (meters 1.0)
-;    :nav-nearest-y-threshold (meters 10.0)
-;    :notice-distance (meters 30.0)
-;    :stop-chase-distance (meters 40.0)
-;    :frustration-distance (meters 8.0)
-;    :frustration-time #x4b0
-;    :die-anim-hold-frame 10000000000.0
-;    :jump-anim-start-frame 6.5
-;    :jump-land-anim-end-frame 10000000000.0
-;    :jump-height-min (meters 1.0)
-;    :jump-height-factor 0.5
-;    :jump-start-anim-speed 1.0
-;    :shadow-max-y (meters 1.0)
-;    :shadow-min-y (meters -1.0)
-;    :shadow-locus-dist (meters 150.0)
-;    :use-align #f
-;    :draw-shadow #t
-;    :move-to-ground #t
-;    :hover-if-no-ground #f
-;    :use-momentum #f
-;    :use-flee #f
-;    :use-proximity-notice #f
-;    :use-jump-blocked #f
-;    :use-jump-patrol #f
-;    :gnd-collide-with #x1
-;    :debug-draw-neck #f
-;    :debug-draw-jump #f
-;    )
-;   )
+;; definition for symbol *muse-nav-enemy-info*, type nav-enemy-info
+(define
+  *muse-nav-enemy-info*
+  (new 'static 'nav-enemy-info
+   :idle-anim 3
+   :walk-anim 4
+   :turn-anim -1
+   :notice-anim 3
+   :run-anim 4
+   :jump-anim 7
+   :jump-land-anim 8
+   :victory-anim 3
+   :taunt-anim 3
+   :die-anim 3
+   :neck-joint 6
+   :player-look-at-joint 5
+   :run-travel-speed (meters 10.0)
+   :run-rotate-speed (degrees 999.99994)
+   :run-acceleration (meters 5.0)
+   :run-turn-time #x2d
+   :walk-travel-speed (meters 10.0)
+   :walk-rotate-speed (degrees 999.99994)
+   :walk-acceleration (meters 1.0)
+   :walk-turn-time #x2d
+   :attack-shove-back (meters 3.0)
+   :attack-shove-up (meters 2.0)
+   :shadow-size (meters 2.0)
+   :notice-nav-radius (meters 1.0)
+   :nav-nearest-y-threshold (meters 10.0)
+   :notice-distance (meters 30.0)
+   :stop-chase-distance (meters 40.0)
+   :frustration-distance (meters 8.0)
+   :frustration-time #x4b0
+   :die-anim-hold-frame 10000000000.0
+   :jump-anim-start-frame 6.5
+   :jump-land-anim-end-frame 10000000000.0
+   :jump-height-min (meters 1.0)
+   :jump-height-factor 0.5
+   :jump-start-anim-speed 1.0
+   :shadow-max-y (meters 1.0)
+   :shadow-min-y (meters -1.0)
+   :shadow-locus-dist (meters 150.0)
+   :use-align #f
+   :draw-shadow #t
+   :move-to-ground #t
+   :hover-if-no-ground #f
+   :use-momentum #f
+   :use-flee #f
+   :use-proximity-notice #f
+   :use-jump-blocked #f
+   :use-jump-patrol #f
+   :gnd-collide-with #x1
+   :debug-draw-neck #f
+   :debug-draw-jump #f
+   )
+  )
 
-; (defmethod copy-defaults! muse ((obj muse) (arg0 res-lump))
-;   (stack-size-set! (-> obj main-thread) 512)
-;   (set! (-> obj mask) (logior (process-mask enemy) (-> obj mask)))
-;   (let
-;    ((s4-0
-;      (new 'process 'collide-shape-moving obj (collide-list-enum hit-by-player))
-;      )
-;     )
-;    (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
-;    (set! (-> s4-0 reaction) default-collision-reaction)
-;    (set! (-> s4-0 no-reaction) nothing)
-;    (let ((s3-0 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
-;     (set! (-> s3-0 prim-core collide-as) (the-as uint 256))
-;     (set! (-> s3-0 collide-with) (the-as uint 16))
-;     (set! (-> s3-0 prim-core action) (the-as uint 1))
-;     (set! (-> s3-0 prim-core offense) 4)
-;     (set-vector! (-> s3-0 local-sphere) 0.0 2457.6 0.0 2457.6)
-;     )
-;    (dummy-46 s4-0)
-;    (set! (-> s4-0 nav-radius) (* 0.75 (-> s4-0 root-prim local-sphere w)))
-;    (dummy-50 s4-0)
-;    (set! (-> obj collide-info) s4-0)
-;    )
-;   (process-drawable-from-entity! obj arg0)
-;   (dummy-14 obj *muse-sg* '())
-;   (logclear! (-> obj mask) (process-mask actor-pause))
-;   (TODO-RENAME-45 obj *muse-nav-enemy-info*)
-;   (set!
-;    (-> obj max-path-index)
-;    (the float (+ (-> obj path curve num-cverts) -1))
-;    )
-;   (set! (-> obj current-path-index) 7.0)
-;   (set! (-> obj prev-path-index) 7.0)
-;   (set! (-> obj dest-path-index) 7.0)
-;   (set! (-> obj player-path-index) 0.0)
-;   (eval-path-curve-div!
-;    (-> obj path)
-;    (-> obj dest-point)
-;    (-> obj current-path-index)
-;    'interp
-;    )
-;   (set! (-> obj collide-info trans quad) (-> obj dest-point quad))
-;   (set! (-> obj nav nearest-y-threshold) 20480.0)
-;   (set-vector! (-> obj neck twist-max) 8192.0 8192.0 0.0 1.0)
-;   (set! (-> obj neck up) (the-as uint 0))
-;   (set! (-> obj neck nose) (the-as uint 1))
-;   (set! (-> obj neck ear) (the-as uint 2))
-;   (set! (-> obj neck max-dist) 102400.0)
-;   (set! (-> obj neck ignore-angle) 16384.0)
-;   (set!
-;    (-> obj anim)
-;    (new 'static 'spool-anim
-;     :name "muse-victory"
-;     :index 9
-;     :parts 2
-;     :command-list
-;     '(
-;       ((the binteger 1)
-;         blackout
-;         0
-;         )
-;       ((the binteger 219) blackout (the binteger 60))
-;       )
-;     )
-;    )
-;   (set!
-;    (-> obj victory-anim)
-;    (the-as spool-anim (fuel-cell-pick-anim (the-as process-taskable obj)))
-;    )
-;   (go muse-idle)
-;   (none)
-;   )
-
-
-
-
+;; definition for method 11 of type muse
+;; Used lq/sq
+(defmethod copy-defaults! muse ((obj muse) (arg0 res-lump))
+  (stack-size-set! (-> obj main-thread) 512)
+  (set! (-> obj mask) (logior (process-mask enemy) (-> obj mask)))
+  (let
+   ((s4-0
+     (new 'process 'collide-shape-moving obj (collide-list-enum hit-by-player))
+     )
+    )
+   (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
+   (set! (-> s4-0 reaction) default-collision-reaction)
+   (set! (-> s4-0 no-reaction) nothing)
+   (let ((s3-0 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
+    (set! (-> s3-0 prim-core collide-as) (the-as uint 256))
+    (set! (-> s3-0 collide-with) (the-as uint 16))
+    (set! (-> s3-0 prim-core action) (the-as uint 1))
+    (set! (-> s3-0 prim-core offense) 4)
+    (set-vector! (-> s3-0 local-sphere) 0.0 2457.6 0.0 2457.6)
+    )
+   (dummy-46 s4-0)
+   (set! (-> s4-0 nav-radius) (* 0.75 (-> s4-0 root-prim local-sphere w)))
+   (dummy-50 s4-0)
+   (set! (-> obj collide-info) s4-0)
+   )
+  (process-drawable-from-entity! obj arg0)
+  (dummy-14 obj *muse-sg* '())
+  (logclear! (-> obj mask) (process-mask actor-pause))
+  (TODO-RENAME-45 obj *muse-nav-enemy-info*)
+  (set!
+   (-> obj max-path-index)
+   (the float (+ (-> obj path curve num-cverts) -1))
+   )
+  (set! (-> obj current-path-index) 7.0)
+  (set! (-> obj prev-path-index) 7.0)
+  (set! (-> obj dest-path-index) 7.0)
+  (set! (-> obj player-path-index) 0.0)
+  (eval-path-curve-div!
+   (-> obj path)
+   (-> obj dest-point)
+   (-> obj current-path-index)
+   'interp
+   )
+  (set! (-> obj collide-info trans quad) (-> obj dest-point quad))
+  (set! (-> obj nav nearest-y-threshold) 20480.0)
+  (set-vector! (-> obj neck twist-max) 8192.0 8192.0 0.0 1.0)
+  (set! (-> obj neck up) (the-as uint 0))
+  (set! (-> obj neck nose) (the-as uint 1))
+  (set! (-> obj neck ear) (the-as uint 2))
+  (set! (-> obj neck max-dist) 102400.0)
+  (set! (-> obj neck ignore-angle) 16384.0)
+  (set!
+   (-> obj anim)
+   (new 'static 'spool-anim
+    :name "muse-victory"
+    :index 9
+    :parts 2
+    :command-list
+    '(
+      ((the binteger 1)
+        blackout
+        0
+        )
+      ((the binteger 219) blackout (the binteger 60))
+      )
+    )
+   )
+  (set!
+   (-> obj victory-anim)
+   (the-as spool-anim (fuel-cell-pick-anim (the-as process-taskable obj)))
+   )
+  (go muse-idle)
+  (none)
+  )

--- a/goal_src/levels/racer_common/racer-part.gc
+++ b/goal_src/levels/racer_common/racer-part.gc
@@ -499,14 +499,7 @@
 
 (defmethod init-particles! hud-bike-heat ((obj hud-bike-heat) (arg0 int))
   (with-pp
-   (push-setting!
-    *setting-control*
-    pp
-    (the-as (function object object object object object) 'common-page)
-    'set
-    0.0
-    2
-    )
+   (push-setting! *setting-control* pp 'common-page 'set 0.0 2)
    (when (< (-> obj nb-of-particles) (-> obj max-nb-of-particles))
     (let ((s5-0 (-> obj nb-of-particles)))
      (set! (-> obj particles s5-0) (new 'static 'hud-particle))
@@ -595,14 +588,7 @@
 
 (defmethod init-particles! hud-bike-speed ((obj hud-bike-speed) (arg0 int))
   (with-pp
-   (push-setting!
-    *setting-control*
-    pp
-    (the-as (function object object object object object) 'common-page)
-    'set
-    0.0
-    2
-    )
+   (push-setting! *setting-control* pp 'common-page 'set 0.0 2)
    (when (< (-> obj nb-of-particles) (-> obj max-nb-of-particles))
     (let ((s5-0 (-> obj nb-of-particles)))
      (set! (-> obj particles s5-0) (new 'static 'hud-particle))

--- a/goalc/compiler/compilation/State.cpp
+++ b/goalc/compiler/compilation/State.cpp
@@ -240,7 +240,6 @@ Val* Compiler::compile_go_hook(const goos::Object& form, const goos::Object& res
   }
 
   // typechecking here will make sure the go is possible.
-  compile_real_function_call(form, enter_state_func->to_gpr(form, env), function_arguments, env);
-
-  return get_none();
+  return compile_real_function_call(form, enter_state_func->to_gpr(form, env), function_arguments,
+                                    env);
 }

--- a/test/decompiler/reference/decompiler-macros.gc
+++ b/test/decompiler/reference/decompiler-macros.gc
@@ -264,10 +264,10 @@
        (set! (-> vec w) ,wv)))
      )
 
+;; cause the current process to change state
 (defmacro go (next-state &rest args)
   `(with-pp
-     (set! (-> pp next-state) ,next-state)
-     ((the (function _varargs_ object) enter-state) ,@args)
+     (go-hook pp ,next-state ,@args)
      )
   )
 

--- a/test/decompiler/reference/engine/collide/collide-shape-h_REF.gc
+++ b/test/decompiler/reference/engine/collide/collide-shape-h_REF.gc
@@ -742,44 +742,16 @@
    (vector-identity! (-> obj scale))
    (cond
     ((= collide-list-kind (collide-list-enum hit-by-player))
-     (add-connection
-      *collide-hit-by-player-list*
-      proc
-      (the-as (function object object object object object) #f)
-      obj
-      #f
-      #f
-      )
+     (add-connection *collide-hit-by-player-list* proc #f obj #f #f)
      )
     ((= collide-list-kind (collide-list-enum usually-hit-by-player))
-     (add-connection
-      *collide-usually-hit-by-player-list*
-      proc
-      (the-as (function object object object object object) #f)
-      obj
-      #f
-      #f
-      )
+     (add-connection *collide-usually-hit-by-player-list* proc #f obj #f #f)
      )
     ((= collide-list-kind (collide-list-enum hit-by-others))
-     (add-connection
-      *collide-hit-by-others-list*
-      proc
-      (the-as (function object object object object object) #f)
-      obj
-      #f
-      #f
-      )
+     (add-connection *collide-hit-by-others-list* proc #f obj #f #f)
      )
     ((= collide-list-kind (collide-list-enum player))
-     (add-connection
-      *collide-player-list*
-      proc
-      (the-as (function object object object object object) #f)
-      obj
-      #f
-      #f
-      )
+     (add-connection *collide-player-list* proc #f obj #f #f)
      )
     (else
      (format 0 "Unsupported collide-list-enum in collide-shape constructor!~%")

--- a/test/decompiler/reference/engine/engine/connect_REF.gc
+++ b/test/decompiler/reference/engine/engine/connect_REF.gc
@@ -25,11 +25,11 @@
 
 ;; definition of type connection
 (deftype connection (connectable)
-  ((param0 (function object object object object object)   :offset-assert  16)
-   (param1 basic                                           :offset-assert  20)
-   (param2 basic                                           :offset-assert  24)
-   (param3 basic                                           :offset-assert  28)
-   (quad   uint128                                       2 :offset          0)
+  ((param0 basic     :offset-assert  16)
+   (param1 basic     :offset-assert  20)
+   (param2 basic     :offset-assert  24)
+   (param3 basic     :offset-assert  28)
+   (quad   uint128 2 :offset          0)
    )
   :method-count-assert 14
   :size-assert         #x20
@@ -81,7 +81,7 @@
     (execute-connections (engine object) int 12)
     (execute-connections-and-move-to-dead (engine object) int 13)
     (execute-connections-if-needed (engine object) int 14)
-    (add-connection (engine process (function object object object object object) object object object) connection 15)
+    (add-connection (engine process object object object object) connection 15)
     (remove-from-process (engine process) int 16)
     (remove-matching (engine (function connection engine symbol)) int 17)
     (remove-all (engine) int 18)
@@ -328,7 +328,12 @@
   (set! (-> obj engine-time) (-> *display* real-frame-counter))
   (let ((ct (the-as connection (-> obj alive-list-end prev0))))
    (while (!= ct (-> obj alive-list))
-    ((-> ct param0) (-> ct param1) (-> ct param2) (-> ct param3) arg0)
+    ((the-as (function basic basic basic object object) (-> ct param0))
+     (-> ct param1)
+     (-> ct param2)
+     (-> ct param3)
+     arg0
+     )
     (set! ct (the-as connection (-> ct prev0)))
     )
    )
@@ -345,7 +350,12 @@
    (while (!= ct (-> obj alive-list))
     (let
      ((result
-       ((-> ct param0) (-> ct param1) (-> ct param2) (-> ct param3) arg0)
+       ((the-as (function basic basic basic object object) (-> ct param0))
+        (-> ct param1)
+        (-> ct param2)
+        (-> ct param3)
+        arg0
+        )
        )
       )
      (set! ct (the-as connection (-> ct prev0)))
@@ -396,14 +406,14 @@
   engine
   ((obj engine)
    (proc process)
-   (func (function object object object object object))
+   (func object)
    (p1 object)
    (p2 object)
    (p3 object)
    )
   (let ((con (the-as connection (-> obj dead-list next0))))
    (when (not (or (not proc) (= con (-> obj dead-list-end))))
-    (set! (-> con param0) func)
+    (set! (-> con param0) (the-as basic func))
     (set! (-> con param1) (the-as basic p1))
     (set! (-> con param2) (the-as basic p2))
     (set! (-> con param3) (the-as basic p3))

--- a/test/decompiler/reference/engine/game/settings-h_REF.gc
+++ b/test/decompiler/reference/engine/game/settings-h_REF.gc
@@ -106,7 +106,7 @@
   :flag-assert         #xe00000278
   (:methods
     (new (symbol type int) _type_ 0)
-    (push-setting! (_type_ process (function object object object object object) object object object) none 9)
+    (push-setting! (_type_ process symbol object object object) none 9)
     (set-setting! (_type_ process symbol symbol float int) none 10)
     (clear-pending-settings-from-process (_type_ process symbol) none 11)
     (copy-settings-from-target! (_type_) setting-data 12)

--- a/test/decompiler/reference/engine/game/settings-h_REF.gc
+++ b/test/decompiler/reference/engine/game/settings-h_REF.gc
@@ -46,7 +46,7 @@
   :size-assert         #xc4
   :flag-assert         #xa000000c4
   (:methods
-    (handle-pending-updates (_type_ engine) setting-data 9)
+    (update-from-engine (_type_ engine) setting-data 9)
     )
   )
 

--- a/test/decompiler/reference/engine/game/settings_REF.gc
+++ b/test/decompiler/reference/engine/game/settings_REF.gc
@@ -233,7 +233,7 @@
   setting-control
   ((obj setting-control)
    (arg0 process)
-   (arg1 (function object object object object object))
+   (arg1 symbol)
    (arg2 object)
    (arg3 object)
    (arg4 object)
@@ -256,14 +256,7 @@
    (arg4 int)
    )
   (clear-pending-settings-from-process obj arg0 arg1)
-  (add-connection
-   (-> obj engine)
-   arg0
-   (the-as (function object object object object object) arg1)
-   arg2
-   arg3
-   arg4
-   )
+  (add-connection (-> obj engine) arg0 arg1 arg2 arg3 arg4)
   0
   (none)
   )

--- a/test/decompiler/reference/engine/game/settings_REF.gc
+++ b/test/decompiler/reference/engine/game/settings_REF.gc
@@ -2,7 +2,7 @@
 (in-package goal)
 
 ;; definition for method 9 of type setting-data
-(defmethod handle-pending-updates setting-data ((obj setting-data) (arg0 engine))
+(defmethod update-from-engine setting-data ((obj setting-data) (arg0 engine))
   (let ((conn (the-as connection (-> arg0 alive-list-end)))
         (s4-0 (-> arg0 alive-list-end prev0))
         )
@@ -296,7 +296,7 @@
      (-> s5-0 ambient-volume)
      (* 0.01 (-> obj default ambient-volume) (-> obj default sfx-volume))
      )
-    (handle-pending-updates s5-0 (-> obj engine))
+    (update-from-engine s5-0 (-> obj engine))
     (set! (-> gp-0 border-mode) (-> s5-0 border-mode))
     (set! (-> gp-0 common-page) (-> s5-0 common-page))
     (set! (-> gp-0 vibration) (-> s5-0 vibration))

--- a/test/decompiler/reference/engine/game/task/process-taskable_REF.gc
+++ b/test/decompiler/reference/engine/game/task/process-taskable_REF.gc
@@ -643,7 +643,7 @@
     (push-setting!
      *setting-control*
      self
-     (the-as (function object object object object object) 'music-volume)
+     'music-volume
      'rel
      (-> *setting-control* current music-volume-movie)
      0
@@ -651,7 +651,7 @@
     (push-setting!
      *setting-control*
      self
-     (the-as (function object object object object object) 'sfx-volume)
+     'sfx-volume
      'rel
      (-> *setting-control* current sfx-volume-movie)
      0
@@ -659,7 +659,7 @@
     (push-setting!
      *setting-control*
      self
-     (the-as (function object object object object object) 'ambient-volume)
+     'ambient-volume
      'rel
      (-> *setting-control* current ambient-volume-movie)
      0
@@ -1796,7 +1796,7 @@
      (push-setting!
       *setting-control*
       self
-      (the-as (function object object object object object) 'process-mask)
+      'process-mask
       'set
       0.0
       (-> self mask-to-clear)
@@ -1804,7 +1804,7 @@
      (push-setting!
       *setting-control*
       self
-      (the-as (function object object object object object) 'movie)
+      'movie
       (process->ppointer self)
       0.0
       0
@@ -1813,7 +1813,7 @@
       (push-setting!
        *setting-control*
        self
-       (the-as (function object object object object object) 'border-mode)
+       'border-mode
        (-> self border-value)
        0.0
        0

--- a/test/decompiler/reference/engine/nav/navigate-h_REF.gc
+++ b/test/decompiler/reference/engine/nav/navigate-h_REF.gc
@@ -502,7 +502,7 @@
        (add-connection
         (-> entity-nav-mesh user-list)
         proc
-        (the-as (function object object object object object) nothing)
+        nothing
         proc
         nav-cont
         trans

--- a/test/decompiler/reference/engine/target/logic-target_REF.gc
+++ b/test/decompiler/reference/engine/target/logic-target_REF.gc
@@ -2889,14 +2889,7 @@
    )
   (set! (-> self control pad 5) (the-as uint (new-sound-id)))
   (if *debug-segment*
-   (add-connection
-    *debug-engine*
-    self
-    (the-as (function object object object object object) target-print-stats)
-    self
-    *stdcon0*
-    #f
-    )
+   (add-connection *debug-engine* self target-print-stats self *stdcon0* #f)
    )
   (activate-hud self)
   (set! (-> self fp-hud) (the-as uint #f))

--- a/test/decompiler/reference/levels/common/static-screen_REF.gc
+++ b/test/decompiler/reference/levels/common/static-screen_REF.gc
@@ -154,7 +154,7 @@
    (push-setting!
     *setting-control*
     self
-    (the-as (function object object object object object) 'common-page)
+    'common-page
     'set
     0.0
     (ash 1 (+ arg0 1))
@@ -281,7 +281,3 @@
    (-> sv-16 ppointer)
    )
   )
-
-
-
-

--- a/test/decompiler/reference/levels/misty/muse_REF.gc
+++ b/test/decompiler/reference/levels/misty/muse_REF.gc
@@ -772,7 +772,7 @@ nav-enemy-default-event-handler
      (push-setting!
       *setting-control*
       self
-      (the-as (function object object object object object) 'music-volume)
+      'music-volume
       'rel
       (-> *setting-control* current music-volume-movie)
       0
@@ -780,7 +780,7 @@ nav-enemy-default-event-handler
      (push-setting!
       *setting-control*
       self
-      (the-as (function object object object object object) 'sfx-volume)
+      'sfx-volume
       'rel
       (-> *setting-control* current sfx-volume-movie)
       0
@@ -788,7 +788,7 @@ nav-enemy-default-event-handler
      (push-setting!
       *setting-control*
       self
-      (the-as (function object object object object object) 'ambient-volume)
+      'ambient-volume
       'rel
       (-> *setting-control* current ambient-volume-movie)
       0

--- a/test/decompiler/reference/levels/racer_common/racer-part_REF.gc
+++ b/test/decompiler/reference/levels/racer_common/racer-part_REF.gc
@@ -527,14 +527,7 @@
 ;; INFO: Return type mismatch int vs none.
 (defmethod init-particles! hud-bike-heat ((obj hud-bike-heat) (arg0 int))
   (with-pp
-   (push-setting!
-    *setting-control*
-    pp
-    (the-as (function object object object object object) 'common-page)
-    'set
-    0.0
-    2
-    )
+   (push-setting! *setting-control* pp 'common-page 'set 0.0 2)
    (when (< (-> obj nb-of-particles) (-> obj max-nb-of-particles))
     (let ((s5-0 (-> obj nb-of-particles)))
      (set! (-> obj particles s5-0) (new 'static 'hud-particle))
@@ -635,14 +628,7 @@
 ;; INFO: Return type mismatch int vs none.
 (defmethod init-particles! hud-bike-speed ((obj hud-bike-speed) (arg0 int))
   (with-pp
-   (push-setting!
-    *setting-control*
-    pp
-    (the-as (function object object object object object) 'common-page)
-    'set
-    0.0
-    2
-    )
+   (push-setting! *setting-control* pp 'common-page 'set 0.0 2)
    (when (< (-> obj nb-of-particles) (-> obj max-nb-of-particles))
     (let ((s5-0 (-> obj nb-of-particles)))
      (set! (-> obj particles s5-0) (new 'static 'hud-particle))


### PR DESCRIPTION
- fixed some types for `connection` that I got wrong a long time ago.  It's possible to create a connection that doesn't use a function as the first param.
- fixed related types for `setting-control`
- uncomment `muse.gc`. I don't know why it was commented out, but it seems fine
- Add `process-taskable.gc` (`_REF.gc` was already done, but not the normal `.gc`). This wasn't compiling due to `go-hook` returning `none` instead of the result of `enter-state`, which is fixed.
- Make `go` macro of the decompiler match the one in `gstate.gc`.