### PR TITLE
clean up a few small things

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(common
         util/Timer.cpp
         util/print_float.cpp
         util/FontUtils.cpp
-        util/image_loading.h)
+        util/image_loading.cpp)
 
 target_link_libraries(common fmt lzokay replxx libzstd_static)
 

--- a/common/util/image_loading.cpp
+++ b/common/util/image_loading.cpp
@@ -1,0 +1,13 @@
+
+// hides warnings
+#ifdef __linux__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "third-party/stb_image.h"
+
+#ifdef __linux__
+#pragma GCC diagnostic pop
+#endif

--- a/common/util/image_loading.h
+++ b/common/util/image_loading.h
@@ -1,2 +1,1 @@
-#define STB_IMAGE_IMPLEMENTATION
 #include "third-party/stb_image.h"

--- a/common/util/print_float.cpp
+++ b/common/util/print_float.cpp
@@ -12,14 +12,14 @@
  * and, if you trust the dragonbox library, should be the shortest possible representation
  * that round-trips through a properly implemented string -> float conversion.
  */
-std::string float_to_string(float value) {
+std::string float_to_string(float value, bool append_trailing_decimal) {
   constexpr int buff_size = 128;
   char buff[buff_size];
-  float_to_cstr(value, buff);
+  float_to_cstr(value, buff, append_trailing_decimal);
   return {buff};
 }
 
-int float_to_cstr(float value, char* buffer) {
+int float_to_cstr(float value, char* buffer, bool append_trailing_decimal) {
   assert(std::isfinite(value));
   // dragonbox gives us:
   //  - an integer, representing the decimal value
@@ -32,8 +32,10 @@ int float_to_cstr(float value, char* buffer) {
   // so just handle that as a special case
   if (value == 0) {
     buffer[i++] = '0';
-    buffer[i++] = '.';
-    buffer[i++] = '0';
+    if (append_trailing_decimal) {
+      buffer[i++] = '.';
+      buffer[i++] = '0';
+    }
     buffer[i++] = '\0';
   }
 
@@ -70,8 +72,10 @@ int float_to_cstr(float value, char* buffer) {
     }
 
     // part 4
-    buffer[i++] = '.';
-    buffer[i++] = '0';
+    if (append_trailing_decimal) {
+      buffer[i++] = '.';
+      buffer[i++] = '0';
+    }
     buffer[i++] = '\0';
   } else {
     // some nonzero digits after decimal.

--- a/common/util/print_float.h
+++ b/common/util/print_float.h
@@ -2,5 +2,5 @@
 
 #include <string>
 
-std::string float_to_string(float value);
-int float_to_cstr(float value, char* buffer);
+std::string float_to_string(float value, bool append_trailing_decimal = true);
+int float_to_cstr(float value, char* buffer, bool append_trailing_decimal = true);

--- a/decompiler/IR2/Form.cpp
+++ b/decompiler/IR2/Form.cpp
@@ -7,6 +7,7 @@
 #include "common/type_system/TypeSystem.h"
 #include "decompiler/util/DecompilerTypeSystem.h"
 #include "decompiler/util/data_decompile.h"
+#include "common/util/print_float.h"
 
 namespace decompiler {
 
@@ -2987,11 +2988,14 @@ goos::Object DefskelgroupElement::to_form_internal(const Env& env) const {
   forms.push_back(pretty_print::build_list(lod_forms));
 
   forms.push_back(pretty_print::to_symbol(
-      fmt::format(":bounds (static-spherem {} {} {} {})", m_static_info.bounds.x() / METER_LENGTH,
-                  m_static_info.bounds.y() / METER_LENGTH, m_static_info.bounds.z() / METER_LENGTH,
-                  m_static_info.bounds.w() / METER_LENGTH)));
+      fmt::format(":bounds (static-spherem {} {} {} {})",
+                  float_to_string(m_static_info.bounds.x() / METER_LENGTH, false),
+                  float_to_string(m_static_info.bounds.y() / METER_LENGTH, false),
+                  float_to_string(m_static_info.bounds.z() / METER_LENGTH, false),
+                  float_to_string(m_static_info.bounds.w() / METER_LENGTH, false))));
   forms.push_back(pretty_print::to_symbol(
-      fmt::format(":longest-edge (meters {})", m_static_info.longest_edge / METER_LENGTH)));
+      fmt::format(":longest-edge (meters {})",
+                  float_to_string(m_static_info.longest_edge / METER_LENGTH, false))));
 
   if (m_static_info.shadow != 0) {
     forms.push_back(pretty_print::to_symbol(fmt::format(":shadow {}", m_static_info.shadow)));

--- a/game/fake_iso.txt
+++ b/game/fake_iso.txt
@@ -25,3 +25,4 @@ FIN.DGO out/iso/FIN.DGO
 FIC.DGO out/iso/FIC.DGO
 JUN.DGO out/iso/JUN.DGO
 MAI.DGO out/iso/MAI.DGO
+BEA.DGO out/iso/BEA.DGO

--- a/goal_src/examples/debug-draw-example.gc
+++ b/goal_src/examples/debug-draw-example.gc
@@ -264,7 +264,7 @@
   )
 
 ;; This will spawn a process the first time this file is loaded
-(define-perm *test-process* process (launch-wasd-process))
+;;(define-perm *test-process* process (launch-wasd-process))
 
 (defun kill-test-procs ()
   "Kill all processes started by launch-test-process"
@@ -319,7 +319,7 @@
   (none)
   )
 
-(test-make-target)
+;;(test-make-target)
 
 
 (define *debug-load-level* #f)

--- a/goal_src/game.gp
+++ b/goal_src/game.gp
@@ -217,6 +217,7 @@
        "out/iso/FIC.DGO"
        "out/iso/JUN.DGO"
        "out/iso/MAI.DGO"
+       "out/iso/BEA.DGO"
        )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;
@@ -248,6 +249,8 @@
 
    "common/blocking-plane.gc"
    "common/launcherdoor.gc"
+   "common/mistycannon.gc"
+   "common/babak-with-cannon.gc"
 
    "racer_common/target-racer-h-FIC-LAV-MIS-OGR-ROL.gc"
    "racer_common/racer-part.gc"
@@ -392,6 +395,66 @@
 
 (copy-textures 385 531 386 388 765)
 
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Beach
+;;;;;;;;;;;;;;;;;;;;;
+
+(cgo "BEA.DGO"
+  "bea.gd"
+  )
+
+(goal-src-sequence
+  "levels/beach/"
+  :deps ("out/obj/default-menu.o")
+  "air-h.gc"
+  "air.gc"
+  "wobbler.gc"
+  "twister.gc"
+  "beach-obs.gc"
+  "bird-lady.gc"
+  "bird-lady-beach.gc"
+  "mayor.gc"
+  "sculptor.gc"
+  "pelican.gc"
+  "lurkerworm.gc"
+  "lurkercrab.gc"
+  "lurkerpuppy.gc"
+  "beach-rocks.gc"
+  "seagull.gc"
+  "beach-part.gc"
+  )
+
+(copy-textures 212 214 213 215)
+
+(copy-gos
+  "barrel-ag-BEA"
+  "beachcam-ag"
+  "bird-lady-ag"
+  "bird-lady-beach-ag"
+  "bladeassm-ag"
+  "ecovalve-ag-BEA"
+  "ecoventrock-ag"
+  "flutflut-ag"
+  "flutflutegg-ag"
+  "grottopole-ag"
+  "harvester-ag"
+  "kickrock-ag"
+  "lrocklrg-ag"
+  "lurkercrab-ag"
+  "lurkerpuppy-ag"
+  "lurkerworm-ag"
+  "mayor-ag"
+  "mistycannon-ag"
+  "orb-cache-top-ag-BEA"
+  "pelican-ag"
+  "sack-ag-BEA"
+  "sculptor-ag"
+  "sculptor-muse-ag"
+  "seagull-ag"
+  "windmill-one-ag"
+  "beach-vis"
+  )
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Fire Canyon

--- a/goal_src/levels/common/water-anim.gc
+++ b/goal_src/levels/common/water-anim.gc
@@ -19,795 +19,388 @@
   )
 
 
-(let
-  ((v1-1
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken-dark-eco"
-     :bounds (new 'static 'vector :w 163840.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-1 jgeo) 0)
-  (set! (-> v1-1 janim) -1)
-  (set! (-> v1-1 mgeo 0) 1)
-  (set! (-> v1-1 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-dark-eco-qbert-sg* v1-1)
+(defskelgroup *water-anim-sunken-dark-eco-qbert-sg* water-anim-sunken-dark-eco
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 40)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-2
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken-dark-eco"
-     :bounds (new 'static 'vector :w 90112.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-2 jgeo) 2)
-  (set! (-> v1-2 janim) -1)
-  (set! (-> v1-2 mgeo 0) 3)
-  (set! (-> v1-2 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-dark-eco-platform-room-sg* v1-2)
+(defskelgroup *water-anim-sunken-dark-eco-platform-room-sg* water-anim-sunken-dark-eco
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 0 0 0 22)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-3
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken-dark-eco"
-     :bounds (new 'static 'vector :w 86016.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-3 jgeo) 4)
-  (set! (-> v1-3 janim) -1)
-  (set! (-> v1-3 mgeo 0) 5)
-  (set! (-> v1-3 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-dark-eco-helix-room-sg* v1-3)
+(defskelgroup *water-anim-sunken-dark-eco-helix-room-sg* water-anim-sunken-dark-eco
+  4
+  -1
+  ((5 (meters 999999)))
+  :bounds (static-spherem 0 0 0 21)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-4
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds
-     (new 'static 'vector :x 61440.0 :z -147456.0 :w 286720.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-4 jgeo) 0)
-  (set! (-> v1-4 janim) -1)
-  (set! (-> v1-4 mgeo 0) 1)
-  (set! (-> v1-4 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-big-room-sg* v1-4)
+(defskelgroup *water-anim-sunken-big-room-sg* water-anim-sunken
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 15 0 -36 70)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-5
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 204800.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-5 jgeo) 2)
-  (set! (-> v1-5 janim) -1)
-  (set! (-> v1-5 mgeo 0) 3)
-  (set! (-> v1-5 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-first-room-from-entrance-sg* v1-5)
+(defskelgroup *water-anim-sunken-first-room-from-entrance-sg* water-anim-sunken
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 0 0 0 50)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-6
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 196608.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-6 jgeo) 4)
-  (set! (-> v1-6 janim) -1)
-  (set! (-> v1-6 mgeo 0) 5)
-  (set! (-> v1-6 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-qbert-room-sg* v1-6)
+(defskelgroup *water-anim-sunken-qbert-room-sg* water-anim-sunken
+  4
+  -1
+  ((5 (meters 999999)))
+  :bounds (static-spherem 0 0 0 48)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-7
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 122880.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-7 jgeo) 6)
-  (set! (-> v1-7 janim) -1)
-  (set! (-> v1-7 mgeo 0) 7)
-  (set! (-> v1-7 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-first-right-branch-sg* v1-7)
+(defskelgroup *water-anim-sunken-first-right-branch-sg* water-anim-sunken
+  6
+  -1
+  ((7 (meters 999999)))
+  :bounds (static-spherem 0 0 0 30)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-8
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 61440.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-8 jgeo) 8)
-  (set! (-> v1-8 janim) -1)
-  (set! (-> v1-8 mgeo 0) 9)
-  (set! (-> v1-8 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-circular-with-bullys-sg* v1-8)
+(defskelgroup *water-anim-sunken-circular-with-bullys-sg* water-anim-sunken
+  8
+  -1
+  ((9 (meters 999999)))
+  :bounds (static-spherem 0 0 0 15)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-9
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 110592.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-9 jgeo) 10)
-  (set! (-> v1-9 janim) -1)
-  (set! (-> v1-9 mgeo 0) 11)
-  (set! (-> v1-9 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-hall-with-one-whirlpool-sg* v1-9)
+(defskelgroup *water-anim-sunken-hall-with-one-whirlpool-sg* water-anim-sunken
+  10
+  -1
+  ((11 (meters 999999)))
+  :bounds (static-spherem 0 0 0 27)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-10
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 106496.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-10 jgeo) 12)
-  (set! (-> v1-10 janim) -1)
-  (set! (-> v1-10 mgeo 0) 13)
-  (set! (-> v1-10 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-hall-with-three-whirlpools-sg* v1-10)
+(defskelgroup *water-anim-sunken-hall-with-three-whirlpools-sg* water-anim-sunken
+  12
+  -1
+  ((13 (meters 999999)))
+  :bounds (static-spherem 0 0 0 26)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-11
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 102400.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-11 jgeo) 14)
-  (set! (-> v1-11 janim) -1)
-  (set! (-> v1-11 mgeo 0) 15)
-  (set! (-> v1-11 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-start-of-helix-slide-sg* v1-11)
+(defskelgroup *water-anim-sunken-start-of-helix-slide-sg* water-anim-sunken
+  14
+  -1
+  ((15 (meters 999999)))
+  :bounds (static-spherem 0 0 0 25)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-12
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 184320.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-12 jgeo) 16)
-  (set! (-> v1-12 janim) -1)
-  (set! (-> v1-12 mgeo 0) 17)
-  (set! (-> v1-12 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-room-above-exit-chamber-sg* v1-12)
+(defskelgroup *water-anim-sunken-room-above-exit-chamber-sg* water-anim-sunken
+  16
+  -1
+  ((17 (meters 999999)))
+  :bounds (static-spherem 0 0 0 45)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-13
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds
-     (new 'static 'vector :x 20480.0 :z -12288.0 :w 98304.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-13 jgeo) 18)
-  (set! (-> v1-13 janim) -1)
-  (set! (-> v1-13 mgeo 0) 19)
-  (set! (-> v1-13 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-hall-before-big-room-sg* v1-13)
+(defskelgroup *water-anim-sunken-hall-before-big-room-sg* water-anim-sunken
+  18
+  -1
+  ((19 (meters 999999)))
+  :bounds (static-spherem 5 0 -3 24)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-14
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 81920.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-14 jgeo) 20)
-  (set! (-> v1-14 janim) -1)
-  (set! (-> v1-14 mgeo 0) 21)
-  (set! (-> v1-14 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-short-piece-sg* v1-14)
+(defskelgroup *water-anim-sunken-short-piece-sg* water-anim-sunken
+  20
+  -1
+  ((21 (meters 999999)))
+  :bounds (static-spherem 0 0 0 20)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-15
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-sunken"
-     :bounds (new 'static 'vector :w 110592.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-15 jgeo) 22)
-  (set! (-> v1-15 janim) -1)
-  (set! (-> v1-15 mgeo 0) 23)
-  (set! (-> v1-15 lod-dist 0) 4095996000.0)
-  (set! *water-anim-sunken-big-room-upper-water-sg* v1-15)
+(defskelgroup *water-anim-sunken-big-room-upper-water-sg* water-anim-sunken
+  22
+  -1
+  ((23 (meters 999999)))
+  :bounds (static-spherem 0 0 0 27)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-16
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave"
-     :bounds (new 'static 'vector :w 286720.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-16 jgeo) 0)
-  (set! (-> v1-16 janim) -1)
-  (set! (-> v1-16 mgeo 0) 1)
-  (set! (-> v1-16 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-center-pool-sg* v1-16)
+(defskelgroup *water-anim-maincave-center-pool-sg* water-anim-maincave
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 70)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-17
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave"
-     :bounds
-     (new 'static 'vector :x 24576.0 :z 20480.0 :w 249856.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-17 jgeo) 2)
-  (set! (-> v1-17 janim) -1)
-  (set! (-> v1-17 mgeo 0) 3)
-  (set! (-> v1-17 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-lower-right-pool-sg* v1-17)
+(defskelgroup *water-anim-maincave-lower-right-pool-sg* water-anim-maincave
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 6 0 5 61)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-18
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave"
-     :bounds (new 'static 'vector :w 151552.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-18 jgeo) 4)
-  (set! (-> v1-18 janim) -1)
-  (set! (-> v1-18 mgeo 0) 5)
-  (set! (-> v1-18 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-mid-right-pool-sg* v1-18)
+(defskelgroup *water-anim-maincave-mid-right-pool-sg* water-anim-maincave
+  4
+  -1
+  ((5 (meters 999999)))
+  :bounds (static-spherem 0 0 0 37)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-19
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave"
-     :bounds
-     (new 'static 'vector :x -4096.0 :w 81920.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-19 jgeo) 6)
-  (set! (-> v1-19 janim) -1)
-  (set! (-> v1-19 mgeo 0) 7)
-  (set! (-> v1-19 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-lower-left-pool-sg* v1-19)
+(defskelgroup *water-anim-maincave-lower-left-pool-sg* water-anim-maincave
+  6
+  -1
+  ((7 (meters 999999)))
+  :bounds (static-spherem -1 0 0 20)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-20
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave"
-     :bounds (new 'static 'vector :w 208896.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-20 jgeo) 8)
-  (set! (-> v1-20 janim) -1)
-  (set! (-> v1-20 mgeo 0) 9)
-  (set! (-> v1-20 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-mid-left-pool-sg* v1-20)
+(defskelgroup *water-anim-maincave-mid-left-pool-sg* water-anim-maincave
+  8
+  -1
+  ((9 (meters 999999)))
+  :bounds (static-spherem 0 0 0 51)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-21
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-maincave-water"
-     :bounds
-     (new 'static 'vector :z -12288.0 :w 90112.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-21 jgeo) 0)
-  (set! (-> v1-21 janim) -1)
-  (set! (-> v1-21 mgeo 0) 1)
-  (set! (-> v1-21 lod-dist 0) 4095996000.0)
-  (set! *water-anim-maincave-water-with-crystal-sg* v1-21)
+(defskelgroup *water-anim-maincave-water-with-crystal-sg* water-anim-maincave-water
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 -3 22)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-22
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-robocave"
-     :bounds (new 'static 'vector :w 221184.0)
-     :max-lod 1
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-22 jgeo) 0)
-  (set! (-> v1-22 janim) -1)
-  (set! (-> v1-22 mgeo 0) 1)
-  (set! (-> v1-22 lod-dist 0) 81920.0)
-  (set! (-> v1-22 mgeo 1) 2)
-  (set! (-> v1-22 lod-dist 1) 4095996000.0)
-  (set! *water-anim-robocave-main-pool-sg* v1-22)
+(defskelgroup *water-anim-robocave-main-pool-sg* water-anim-robocave
+  0
+  -1
+  ((1 (meters 20)) (2 (meters 999999)))
+  :bounds (static-spherem 0 0 0 54)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-23
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds
-     (new 'static 'vector :z -10240.0 :w 77824.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-23 jgeo) 0)
-  (set! (-> v1-23 janim) -1)
-  (set! (-> v1-23 mgeo 0) 1)
-  (set! (-> v1-23 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-by-arena-sg* v1-23)
+(defskelgroup *water-anim-misty-mud-by-arena-sg* water-anim-misty
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 -2.5 19)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-24
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 57344.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-24 jgeo) 2)
-  (set! (-> v1-24 janim) -1)
-  (set! (-> v1-24 mgeo 0) 3)
-  (set! (-> v1-24 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-above-skeleton-sg* v1-24)
+(defskelgroup *water-anim-misty-mud-above-skeleton-sg* water-anim-misty
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 0 0 0 14)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-25
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds
-     (new 'static 'vector :z 16384.0 :w 102400.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-25 jgeo) 4)
-  (set! (-> v1-25 janim) -1)
-  (set! (-> v1-25 mgeo 0) 5)
-  (set! (-> v1-25 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-behind-skeleton-sg* v1-25)
+(defskelgroup *water-anim-misty-mud-behind-skeleton-sg* water-anim-misty
+  4
+  -1
+  ((5 (meters 999999)))
+  :bounds (static-spherem 0 0 4 25)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-26
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 57344.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-26 jgeo) 6)
-  (set! (-> v1-26 janim) -1)
-  (set! (-> v1-26 mgeo 0) 7)
-  (set! (-> v1-26 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-above-skull-back-sg* v1-26)
+(defskelgroup *water-anim-misty-mud-above-skull-back-sg* water-anim-misty
+  6
+  -1
+  ((7 (meters 999999)))
+  :bounds (static-spherem 0 0 0 14)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-27
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 65536.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-27 jgeo) 8)
-  (set! (-> v1-27 janim) -1)
-  (set! (-> v1-27 mgeo 0) 9)
-  (set! (-> v1-27 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-above-skull-front-sg* v1-27)
+(defskelgroup *water-anim-misty-mud-above-skull-front-sg* water-anim-misty
+  8
+  -1
+  ((9 (meters 999999)))
+  :bounds (static-spherem 0 0 0 16)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-28
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 53248.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-28 jgeo) 10)
-  (set! (-> v1-28 janim) -1)
-  (set! (-> v1-28 mgeo 0) 11)
-  (set! (-> v1-28 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-other-near-skull-sg* v1-28)
+(defskelgroup *water-anim-misty-mud-other-near-skull-sg* water-anim-misty
+  10
+  -1
+  ((11 (meters 999999)))
+  :bounds (static-spherem 0 0 0 13)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-29
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 61440.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-29 jgeo) 12)
-  (set! (-> v1-29 janim) -1)
-  (set! (-> v1-29 mgeo 0) 13)
-  (set! (-> v1-29 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-near-skull-sg* v1-29)
+(defskelgroup *water-anim-misty-mud-near-skull-sg* water-anim-misty
+  12
+  -1
+  ((13 (meters 999999)))
+  :bounds (static-spherem 0 0 0 15)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-30
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 65536.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-30 jgeo) 14)
-  (set! (-> v1-30 janim) -1)
-  (set! (-> v1-30 mgeo 0) 15)
-  (set! (-> v1-30 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-under-spine-sg* v1-30)
+(defskelgroup *water-anim-misty-mud-under-spine-sg* water-anim-misty
+  14
+  -1
+  ((15 (meters 999999)))
+  :bounds (static-spherem 0 0 0 16)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-31
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 86016.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-31 jgeo) 16)
-  (set! (-> v1-31 janim) -1)
-  (set! (-> v1-31 mgeo 0) 17)
-  (set! (-> v1-31 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-by-dock-sg* v1-31)
+(defskelgroup *water-anim-misty-mud-by-dock-sg* water-anim-misty
+  16
+  -1
+  ((17 (meters 999999)))
+  :bounds (static-spherem 0 0 0 21)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-32
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds
-     (new 'static 'vector :x -4096.0 :z -4096.0 :w 61440.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-32 jgeo) 18)
-  (set! (-> v1-32 janim) -1)
-  (set! (-> v1-32 mgeo 0) 19)
-  (set! (-> v1-32 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-island-near-dock-sg* v1-32)
+(defskelgroup *water-anim-misty-mud-island-near-dock-sg* water-anim-misty
+  18
+  -1
+  ((19 (meters 999999)))
+  :bounds (static-spherem -1 0 -1 15)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-33
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 40960.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-33 jgeo) 20)
-  (set! (-> v1-33 janim) -1)
-  (set! (-> v1-33 mgeo 0) 21)
-  (set! (-> v1-33 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-mud-lonely-island-sg* v1-33)
+(defskelgroup *water-anim-misty-mud-lonely-island-sg* water-anim-misty
+  20
+  -1
+  ((21 (meters 999999)))
+  :bounds (static-spherem 0 0 0 10)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-34
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-misty"
-     :bounds (new 'static 'vector :w 69632.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-34 jgeo) 22)
-  (set! (-> v1-34 janim) -1)
-  (set! (-> v1-34 mgeo 0) 23)
-  (set! (-> v1-34 lod-dist 0) 4095996000.0)
-  (set! *water-anim-misty-dark-eco-pool-sg* v1-34)
+(defskelgroup *water-anim-misty-dark-eco-pool-sg* water-anim-misty
+  22
+  -1
+  ((23 (meters 999999)))
+  :bounds (static-spherem 0 0 0 17)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-35
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-ogre"
-     :bounds (new 'static 'vector :w 458752.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-35 jgeo) 0)
-  (set! (-> v1-35 janim) -1)
-  (set! (-> v1-35 mgeo 0) 1)
-  (set! (-> v1-35 lod-dist 0) 4095996000.0)
-  (set! *water-anim-ogre-lava-sg* v1-35)
+(defskelgroup *water-anim-ogre-lava-sg* water-anim-ogre
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 112)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-36
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-jungle"
-     :bounds (new 'static 'vector :w 372736.0)
-     :max-lod 1
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-36 jgeo) 0)
-  (set! (-> v1-36 janim) -1)
-  (set! (-> v1-36 mgeo 0) 1)
-  (set! (-> v1-36 lod-dist 0) 81920.0)
-  (set! (-> v1-36 mgeo 1) 2)
-  (set! (-> v1-36 lod-dist 1) 4095996000.0)
-  (set! *water-anim-jungle-river-sg* v1-36)
+(defskelgroup *water-anim-jungle-river-sg* water-anim-jungle
+  0
+  -1
+  ((1 (meters 20)) (2 (meters 999999)))
+  :bounds (static-spherem 0 0 0 91)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-37
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village3"
-     :bounds
-     (new 'static 'vector :x 61440.0 :z 40960.0 :w 667648.0)
-     :max-lod 1
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-37 jgeo) 0)
-  (set! (-> v1-37 janim) -1)
-  (set! (-> v1-37 mgeo 0) 1)
-  (set! (-> v1-37 lod-dist 0) 81920.0)
-  (set! (-> v1-37 mgeo 1) 2)
-  (set! (-> v1-37 lod-dist 1) 4095996000.0)
-  (set! *water-anim-village3-lava-sg* v1-37)
+(defskelgroup *water-anim-village3-lava-sg* water-anim-village3
+  0
+  -1
+  ((1 (meters 20)) (2 (meters 999999)))
+  :bounds (static-spherem 15 0 10 163)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-38
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-training"
-     :bounds
-     (new 'static 'vector :x -73728.0 :w 212992.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-38 jgeo) 0)
-  (set! (-> v1-38 janim) -1)
-  (set! (-> v1-38 mgeo 0) 1)
-  (set! (-> v1-38 lod-dist 0) 4095996000.0)
-  (set! *water-anim-training-lake-sg* v1-38)
+(defskelgroup *water-anim-training-lake-sg* water-anim-training
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem -18 0 0 52)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-39
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-darkcave"
-     :bounds (new 'static 'vector :w 77824.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-39 jgeo) 0)
-  (set! (-> v1-39 janim) -1)
-  (set! (-> v1-39 mgeo 0) 1)
-  (set! (-> v1-39 lod-dist 0) 4095996000.0)
-  (set! *water-anim-darkcave-water-with-crystal-sg* v1-39)
+(defskelgroup *water-anim-darkcave-water-with-crystal-sg* water-anim-darkcave
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 19)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-40
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-rolling"
-     :bounds
-     (new 'static 'vector :x -40960.0 :w 286720.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-40 jgeo) 0)
-  (set! (-> v1-40 janim) -1)
-  (set! (-> v1-40 mgeo 0) 1)
-  (set! (-> v1-40 lod-dist 0) 4095996000.0)
-  (set! *water-anim-rolling-water-back-sg* v1-40)
+(defskelgroup *water-anim-rolling-water-back-sg* water-anim-rolling
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem -10 0 0 70)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-41
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-rolling"
-     :bounds (new 'static 'vector :w 286720.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-41 jgeo) 2)
-  (set! (-> v1-41 janim) -1)
-  (set! (-> v1-41 mgeo 0) 3)
-  (set! (-> v1-41 lod-dist 0) 4095996000.0)
-  (set! *water-anim-rolling-water-front-sg* v1-41)
+(defskelgroup *water-anim-rolling-water-front-sg* water-anim-rolling
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 0 0 0 70)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-42
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-finalboss"
-     :bounds (new 'static 'vector :w 77824.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-42 jgeo) 0)
-  (set! (-> v1-42 janim) -1)
-  (set! (-> v1-42 mgeo 0) 1)
-  (set! (-> v1-42 lod-dist 0) 4095996000.0)
-  (set! *water-anim-finalboss-dark-eco-pool-sg* v1-42)
+(defskelgroup *water-anim-finalboss-dark-eco-pool-sg* water-anim-finalboss
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 19)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-43
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-lavatube"
-     :bounds
-     (new 'static 'vector :y -28672.0 :w 102400.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-43 jgeo) 0)
-  (set! (-> v1-43 janim) -1)
-  (set! (-> v1-43 mgeo 0) 1)
-  (set! (-> v1-43 lod-dist 0) 4095996000.0)
-  (set! *water-anim-lavatube-energy-lava-sg* v1-43)
+(defskelgroup *water-anim-lavatube-energy-lava-sg* water-anim-lavatube
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 -7 0 25)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-44
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village1"
-     :bounds
-     (new 'static 'vector :x -61440.0 :w 110592.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-44 jgeo) 0)
-  (set! (-> v1-44 janim) -1)
-  (set! (-> v1-44 mgeo 0) 1)
-  (set! (-> v1-44 lod-dist 0) 4095996000.0)
-  (set! *water-anim-village1-rice-paddy-sg* v1-44)
+(defskelgroup *water-anim-village1-rice-paddy-sg* water-anim-village1
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem -15 0 0 27)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-45
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village1"
-     :bounds (new 'static 'vector :w 18432.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-45 jgeo) 6)
-  (set! (-> v1-45 janim) -1)
-  (set! (-> v1-45 mgeo 0) 7)
-  (set! (-> v1-45 lod-dist 0) 4095996000.0)
-  (set! *water-anim-village1-fountain-sg* v1-45)
+(defskelgroup *water-anim-village1-fountain-sg* water-anim-village1
+  6
+  -1
+  ((7 (meters 999999)))
+  :bounds (static-spherem 0 0 0 4.5)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-46
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village1"
-     :bounds (new 'static 'vector :w 143360.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-46 jgeo) 2)
-  (set! (-> v1-46 janim) -1)
-  (set! (-> v1-46 mgeo 0) 3)
-  (set! (-> v1-46 lod-dist 0) 4095996000.0)
-  (set! *water-anim-village1-rice-paddy-mid-sg* v1-46)
+(defskelgroup *water-anim-village1-rice-paddy-mid-sg* water-anim-village1
+  2
+  -1
+  ((3 (meters 999999)))
+  :bounds (static-spherem 0 0 0 35)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-47
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village1"
-     :bounds
-     (new 'static 'vector :x 24576.0 :z -69632.0 :w 81920.0)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-47 jgeo) 4)
-  (set! (-> v1-47 janim) -1)
-  (set! (-> v1-47 mgeo 0) 5)
-  (set! (-> v1-47 lod-dist 0) 4095996000.0)
-  (set! *water-anim-village1-rice-paddy-top-sg* v1-47)
+(defskelgroup *water-anim-village1-rice-paddy-top-sg* water-anim-village1
+  4
+  -1
+  ((5 (meters 999999)))
+  :bounds (static-spherem 6 0 -17 20)
+  :longest-edge (meters 0)
   )
 
-(let
-  ((v1-48
-    (new 'static 'skeleton-group
-     :art-group-name "water-anim-village2"
-     :bounds (new 'static 'vector :w 2867.2)
-     :version #x6
-     )
-    )
-   )
-  (set! (-> v1-48 jgeo) 0)
-  (set! (-> v1-48 janim) -1)
-  (set! (-> v1-48 mgeo 0) 1)
-  (set! (-> v1-48 lod-dist 0) 4095996000.0)
-  (set! *water-anim-village2-bucket-sg* v1-48)
+(defskelgroup *water-anim-village2-bucket-sg* water-anim-village2
+  0
+  -1
+  ((1 (meters 999999)))
+  :bounds (static-spherem 0 0 0 0.7)
+  :longest-edge (meters 0)
   )
 
 (deftype water-anim-look (structure)

--- a/goal_src/levels/darkcave/darkcave-obs.gc
+++ b/goal_src/levels/darkcave/darkcave-obs.gc
@@ -47,7 +47,7 @@
   0
   -1
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 4.699999809265137 0 5.400000095367432)
+  :bounds (static-spherem 0 4.7 0 5.4)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/finalboss/green-eco-lurker.gc
+++ b/goal_src/levels/finalboss/green-eco-lurker.gc
@@ -40,7 +40,7 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 5.949999809265137)
+  :bounds (static-spherem 0 0 0 5.95)
   :longest-edge (meters 0)
   :shadow 2
   )

--- a/goal_src/levels/finalboss/robotboss-misc.gc
+++ b/goal_src/levels/finalboss/robotboss-misc.gc
@@ -170,8 +170,8 @@
   (none)
   )
 
-;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?
-;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?
+;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?. [OP: 28]
+;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?. [OP: 79]
 (defbehavior
   ecoclaw-handler ecoclaw
   ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
@@ -290,7 +290,7 @@
         (the-as part-tracker (-> self particles gp-0 tracker process 0))
         start-time
         )
-       (-> *display* base-frame-counter)
+       (the-as uint (-> *display* base-frame-counter))
        )
       )
      ((-> self particles gp-0 kind)

--- a/goal_src/levels/firecanyon/firecanyon-obs.gc
+++ b/goal_src/levels/firecanyon/firecanyon-obs.gc
@@ -277,7 +277,7 @@
   0
   3
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 8 0 10.199999809265137)
+  :bounds (static-spherem 0 8 0 10.2)
   :longest-edge (meters 5)
   )
 
@@ -565,7 +565,7 @@
   0
   3
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 1.600000023841858 0 3.299999952316284)
+  :bounds (static-spherem 0 1.6 0 3.3)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/jungle/jungle-obs.gc
+++ b/goal_src/levels/jungle/jungle-obs.gc
@@ -48,7 +48,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -200 0 -440 530)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *jungle-camera-sg* jungle-camera
@@ -1030,7 +1030,7 @@
   3
   ((1 (meters 20)) (2 (meters 999999)))
   :bounds (static-spherem 0 0 0 40)
-  :longest-edge (meters 3.5999999046325684)
+  :longest-edge (meters 3.6)
   )
 
 (defstate precurbridge-idle (precurbridge)

--- a/goal_src/levels/ogre/ogre-obs.gc
+++ b/goal_src/levels/ogre/ogre-obs.gc
@@ -1911,7 +1911,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 -3 8.199999809265137)
+  :bounds (static-spherem 0 0 -3 8.2)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/snow/snow-flutflut-obs.gc
+++ b/goal_src/levels/snow/snow-flutflut-obs.gc
@@ -90,7 +90,7 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 4.300000190734863)
+  :bounds (static-spherem 0 0 0 4.3)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/snow/yeti.gc
+++ b/goal_src/levels/snow/yeti.gc
@@ -51,8 +51,8 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0.75 0 3.9000000953674316)
-  :longest-edge (meters 1.2999999523162842)
+  :bounds (static-spherem 0 0.75 0 3.9)
+  :longest-edge (meters 1.3)
   )
 
 (define

--- a/goal_src/levels/sunken/steam-cap.gc
+++ b/goal_src/levels/sunken/steam-cap.gc
@@ -875,7 +875,7 @@
   )
 
 (defmethod copy-defaults! steam-cap ((obj steam-cap) (arg0 res-lump))
-  (local-vars (sv-16 int))
+  (local-vars (sv-16 res-tag))
   (set! (-> obj mask) (logior (process-mask platform) (-> obj mask)))
   (let
    ((s4-0
@@ -929,18 +929,9 @@
   (let ((f30-0 0.4)
         (f28-0 0.9)
         )
-   (set! sv-16 0)
+   (set! sv-16 (new 'static 'res-tag))
    (let
-    ((v1-36
-      (res-lump-data
-       arg0
-       'percent
-       (pointer float)
-       :tag-ptr
-       (the-as (pointer res-tag) (& sv-16))
-       )
-      )
-     )
+    ((v1-36 (res-lump-data arg0 'percent (pointer float) :tag-ptr (& sv-16))))
     (when v1-36
      (set! f30-0 (-> v1-36 0))
      (set! f28-0 (-> v1-36 1))

--- a/goal_src/levels/sunken/sun-iris-door.gc
+++ b/goal_src/levels/sunken/sun-iris-door.gc
@@ -434,7 +434,7 @@
   )
 
 (defmethod copy-defaults! sun-iris-door ((obj sun-iris-door) (arg0 res-lump))
-  (local-vars (sv-16 int))
+  (local-vars (sv-16 res-tag))
   (set! (-> obj move-to?) #f)
   (let
    ((s4-0 (new 'process 'collide-shape obj (collide-list-enum hit-by-others))))
@@ -481,7 +481,7 @@
     (set! (-> v1-25 local-sphere w) (* 24576.0 f0-11 f0-11))
     )
    )
-  (set! sv-16 0)
+  (set! sv-16 (new 'static 'res-tag))
   (let
    ((v1-28
      (res-lump-data
@@ -489,7 +489,7 @@
       'trans-offset
       (pointer float)
       :tag-ptr
-      (the-as (pointer res-tag) (& sv-16))
+      (& sv-16)
       )
      )
     )

--- a/goal_src/levels/sunken/whirlpool.gc
+++ b/goal_src/levels/sunken/whirlpool.gc
@@ -31,7 +31,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0.6000000238418579 0 3)
+  :bounds (static-spherem 0 0.6 0 3)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/village1/village-obs-VI1.gc
+++ b/goal_src/levels/village1/village-obs-VI1.gc
@@ -58,7 +58,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -80 0 -80 240)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-jungle1-sg* medres-jungle1
@@ -66,7 +66,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 30 0 -40 230)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-jungle2-sg* medres-jungle2
@@ -74,7 +74,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 90 0 130 110)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-beach-sg* medres-beach
@@ -82,7 +82,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -140 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-beach1-sg* medres-beach1
@@ -90,7 +90,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -360 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-beach2-sg* medres-beach2
@@ -98,7 +98,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -200 0 -450 180)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-beach3-sg* medres-beach3
@@ -106,7 +106,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 75 70 -480 100)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-misty-sg* medres-misty
@@ -114,7 +114,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -40 0 -20 260)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-village11-sg* medres-village11
@@ -122,7 +122,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -100 0 90 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-village12-sg* medres-village12
@@ -130,7 +130,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 40 0 -50 155)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-village13-sg* medres-village13
@@ -138,7 +138,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 180 -40 -40 180)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-training-sg* medres-training
@@ -146,7 +146,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -60 220)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (set!
@@ -307,7 +307,7 @@
   4
   ((1 (meters 20)) (2 (meters 40)) (3 (meters 999999)))
   :bounds (static-spherem 0 0 0 21)
-  :longest-edge (meters 14.899999618530273)
+  :longest-edge (meters 14.9)
   )
 
 (set!
@@ -456,7 +456,7 @@
   4
   ((1 (meters 20)) (2 (meters 40)) (3 (meters 999999)))
   :bounds (static-spherem 0 0 0 25.5)
-  :longest-edge (meters 24.200000762939453)
+  :longest-edge (meters 24.2)
   )
 
 (defstate sagesail-idle (sagesail)
@@ -1202,8 +1202,8 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 1 0 1.2000000476837158)
-  :longest-edge (meters 0.699999988079071)
+  :bounds (static-spherem 0 1 0 1.2)
+  :longest-edge (meters 0.7)
   )
 
 (defstate hutlamp-idle (hutlamp)
@@ -1248,7 +1248,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 2.200000047683716)
+  :bounds (static-spherem 0 0 0 2.2)
   :longest-edge (meters 0)
   )
 
@@ -1285,7 +1285,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 3.200000047683716)
+  :bounds (static-spherem 0 0 0 3.2)
   :longest-edge (meters 0)
   )
 

--- a/goal_src/levels/village1/yakow.gc
+++ b/goal_src/levels/village1/yakow.gc
@@ -159,8 +159,8 @@
   :shadow 3
   )
 
-;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?
-;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?
+;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?. [OP: 52]
+;; WARN: rewrite_to_get_var got a none typed variable. Is there unreachable code?. [OP: 54]
 (defbehavior
   yakow-default-event-handler yakow
   ((arg0 process-drawable) (arg1 int) (arg2 symbol) (arg3 event-message-block))

--- a/goal_src/levels/village2/village2-obs.gc
+++ b/goal_src/levels/village2/village2-obs.gc
@@ -183,7 +183,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -520 110 70 100)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-rolling1-sg* medres-rolling1
@@ -191,7 +191,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -300 30 -20 120)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (defskelgroup *med-res-village2-sg* medres-village2
@@ -199,7 +199,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -60 65 0 90)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 (deftype pontoon (rigid-body-platform)
@@ -835,7 +835,10 @@
     ((handle->process (-> self tracker))
      (let
       ((v1-6 (-> (the-as (pointer part-tracker) (-> self tracker process)) 0)))
-      (set! (-> v1-6 start-time) (-> *display* base-frame-counter))
+      (set!
+       (-> v1-6 start-time)
+       (the-as uint (-> *display* base-frame-counter))
+       )
       (set! v0-1 (-> v1-6 root trans))
       )
      (set! (-> (the-as vector v0-1) quad) (-> gp-0 quad))
@@ -1071,7 +1074,7 @@
          0
          start-time
          )
-        (-> *display* base-frame-counter)
+        (the-as uint (-> *display* base-frame-counter))
         )
        )
       (else

--- a/test/decompiler/reference/engine/ui/hud-classes_REF.gc
+++ b/test/decompiler/reference/engine/ui/hud-classes_REF.gc
@@ -1252,7 +1252,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 1 0 1.600000023841858)
+  :bounds (static-spherem 0 1 0 1.6)
   :longest-edge (meters 0)
   :texture-level 2
   )

--- a/test/decompiler/reference/levels/common/plat-button_REF.gc
+++ b/test/decompiler/reference/levels/common/plat-button_REF.gc
@@ -61,7 +61,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 -1 0 6.599999904632568)
+  :bounds (static-spherem 0 -1 0 6.6)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/common/plat_REF.gc
+++ b/test/decompiler/reference/levels/common/plat_REF.gc
@@ -126,7 +126,7 @@
   0
   4
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 -0.5 0 3.200000047683716)
+  :bounds (static-spherem 0 -0.5 0 3.2)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/common/water-anim_REF.gc
+++ b/test/decompiler/reference/levels/common/water-anim_REF.gc
@@ -451,7 +451,7 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 0.699999988079071)
+  :bounds (static-spherem 0 0 0 0.7)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/darkcave/darkcave-obs_REF.gc
+++ b/test/decompiler/reference/levels/darkcave/darkcave-obs_REF.gc
@@ -70,7 +70,7 @@
   0
   -1
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 4.699999809265137 0 5.400000095367432)
+  :bounds (static-spherem 0 4.7 0 5.4)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/finalboss/green-eco-lurker_REF.gc
+++ b/test/decompiler/reference/levels/finalboss/green-eco-lurker_REF.gc
@@ -58,7 +58,7 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 5.949999809265137)
+  :bounds (static-spherem 0 0 0 5.95)
   :longest-edge (meters 0)
   :shadow 2
   )

--- a/test/decompiler/reference/levels/finalboss/robotboss-h_REF.gc
+++ b/test/decompiler/reference/levels/finalboss/robotboss-h_REF.gc
@@ -185,5 +185,5 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 -10 0 80)
-  :longest-edge (meters 19.899999618530273)
+  :longest-edge (meters 19.9)
   )

--- a/test/decompiler/reference/levels/finalboss/robotboss-misc_REF.gc
+++ b/test/decompiler/reference/levels/finalboss/robotboss-misc_REF.gc
@@ -7,7 +7,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -360 100 100 380)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:

--- a/test/decompiler/reference/levels/firecanyon/firecanyon-obs_REF.gc
+++ b/test/decompiler/reference/levels/firecanyon/firecanyon-obs_REF.gc
@@ -284,7 +284,7 @@
   0
   3
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 8 0 10.199999809265137)
+  :bounds (static-spherem 0 8 0 10.2)
   :longest-edge (meters 5)
   )
 
@@ -578,7 +578,7 @@
   0
   3
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 1.600000023841858 0 3.299999952316284)
+  :bounds (static-spherem 0 1.6 0 3.3)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/jungle/jungle-obs_REF.gc
+++ b/test/decompiler/reference/levels/jungle/jungle-obs_REF.gc
@@ -7,7 +7,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -200 0 -440 530)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -1139,7 +1139,7 @@
   3
   ((1 (meters 20)) (2 (meters 999999)))
   :bounds (static-spherem 0 0 0 40)
-  :longest-edge (meters 3.5999999046325684)
+  :longest-edge (meters 3.6)
   )
 
 ;; failed to figure out what this is:

--- a/test/decompiler/reference/levels/ogre/flying-lurker_REF.gc
+++ b/test/decompiler/reference/levels/ogre/flying-lurker_REF.gc
@@ -666,7 +666,7 @@
   5
   ((1 (meters 20)) (2 (meters 40)) (3 (meters 999999)))
   :bounds (static-spherem 0 2 0 6)
-  :longest-edge (meters 2.299999952316284)
+  :longest-edge (meters 2.3)
   :shadow 4
   )
 

--- a/test/decompiler/reference/levels/ogre/ogre-obs_REF.gc
+++ b/test/decompiler/reference/levels/ogre/ogre-obs_REF.gc
@@ -2059,7 +2059,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 -3 8.199999809265137)
+  :bounds (static-spherem 0 0 -3 8.2)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/racer_common/target-racer-h-FIC-LAV-MIS-OGR-ROL_REF.gc
+++ b/test/decompiler/reference/levels/racer_common/target-racer-h-FIC-LAV-MIS-OGR-ROL_REF.gc
@@ -288,6 +288,6 @@
   0
   3
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 1.7000000476837158 0 3)
+  :bounds (static-spherem 0 1.7 0 3)
   :longest-edge (meters 0)
   )

--- a/test/decompiler/reference/levels/snow/snow-flutflut-obs_REF.gc
+++ b/test/decompiler/reference/levels/snow/snow-flutflut-obs_REF.gc
@@ -118,7 +118,7 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 4.300000190734863)
+  :bounds (static-spherem 0 0 0 4.3)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/snow/yeti_REF.gc
+++ b/test/decompiler/reference/levels/snow/yeti_REF.gc
@@ -59,8 +59,8 @@
   0
   -1
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0.75 0 3.9000000953674316)
-  :longest-edge (meters 1.2999999523162842)
+  :bounds (static-spherem 0 0.75 0 3.9)
+  :longest-edge (meters 1.3)
   )
 
 ;; definition for symbol *yeti-nav-enemy-info*, type nav-enemy-info

--- a/test/decompiler/reference/levels/sunken/whirlpool_REF.gc
+++ b/test/decompiler/reference/levels/sunken/whirlpool_REF.gc
@@ -38,7 +38,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0.6000000238418579 0 3)
+  :bounds (static-spherem 0 0.6 0 3)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/village1/fishermans-boat_REF.gc
+++ b/test/decompiler/reference/levels/village1/fishermans-boat_REF.gc
@@ -723,7 +723,7 @@
   3
   ((1 (meters 20)) (2 (meters 999999)))
   :bounds (static-spherem 0 3 0 15)
-  :longest-edge (meters 7.300000190734863)
+  :longest-edge (meters 7.3)
   )
 
 ;; failed to figure out what this is:

--- a/test/decompiler/reference/levels/village1/village-obs-VI1_REF.gc
+++ b/test/decompiler/reference/levels/village1/village-obs-VI1_REF.gc
@@ -7,7 +7,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -80 0 -80 240)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -16,7 +16,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 30 0 -40 230)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -25,7 +25,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 90 0 130 110)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -34,7 +34,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -140 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -43,7 +43,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -360 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -52,7 +52,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -200 0 -450 180)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -61,7 +61,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 75 70 -480 100)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -70,7 +70,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -40 0 -20 260)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -79,7 +79,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -100 0 90 200)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -88,7 +88,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 40 0 -50 155)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -97,7 +97,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 180 -40 -40 180)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -106,7 +106,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem 0 0 -60 220)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -288,7 +288,7 @@
   4
   ((1 (meters 20)) (2 (meters 40)) (3 (meters 999999)))
   :bounds (static-spherem 0 0 0 21)
-  :longest-edge (meters 14.899999618530273)
+  :longest-edge (meters 14.9)
   )
 
 ;; failed to figure out what this is:
@@ -454,7 +454,7 @@
   4
   ((1 (meters 20)) (2 (meters 40)) (3 (meters 999999)))
   :bounds (static-spherem 0 0 0 25.5)
-  :longest-edge (meters 24.200000762939453)
+  :longest-edge (meters 24.2)
   )
 
 ;; failed to figure out what this is:
@@ -1349,8 +1349,8 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 1 0 1.2000000476837158)
-  :longest-edge (meters 0.699999988079071)
+  :bounds (static-spherem 0 1 0 1.2)
+  :longest-edge (meters 0.7)
   )
 
 ;; failed to figure out what this is:
@@ -1407,7 +1407,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 2.200000047683716)
+  :bounds (static-spherem 0 0 0 2.2)
   :longest-edge (meters 0)
   )
 
@@ -1456,7 +1456,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 0 0 3.200000047683716)
+  :bounds (static-spherem 0 0 0 3.2)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/village1/yakow_REF.gc
+++ b/test/decompiler/reference/levels/village1/yakow_REF.gc
@@ -207,8 +207,8 @@
   0
   4
   ((1 (meters 20)) (2 (meters 999999)))
-  :bounds (static-spherem 0 2.5 0 4.400000095367432)
-  :longest-edge (meters 1.2999999523162842)
+  :bounds (static-spherem 0 2.5 0 4.4)
+  :longest-edge (meters 1.3)
   :shadow 3
   )
 

--- a/test/decompiler/reference/levels/village2/sunken-elevator_REF.gc
+++ b/test/decompiler/reference/levels/village2/sunken-elevator_REF.gc
@@ -33,7 +33,7 @@
   0
   2
   ((1 (meters 999999)))
-  :bounds (static-spherem 0 -1 0 6.599999904632568)
+  :bounds (static-spherem 0 -1 0 6.6)
   :longest-edge (meters 0)
   )
 

--- a/test/decompiler/reference/levels/village2/village2-obs_REF.gc
+++ b/test/decompiler/reference/levels/village2/village2-obs_REF.gc
@@ -156,7 +156,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -520 110 70 100)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -165,7 +165,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -300 30 -20 120)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; failed to figure out what this is:
@@ -174,7 +174,7 @@
   2
   ((1 (meters 999999)))
   :bounds (static-spherem -60 65 0 90)
-  :longest-edge (meters 0.009999999776482582)
+  :longest-edge (meters 0.01)
   )
 
 ;; definition of type pontoon


### PR DESCRIPTION
- hide compiler warnings on third-party image library
- add option in `float_to_string` to skip the trailing `.0`.
- use `float_to_string` in skelgroups
- update `debug-draw-example.gc`
- add the beach level
- fix a few `res-tag` stack types
- reset google test