### PR TITLE
[goos/goal] user profiles

### DIFF
--- a/common/goos/Interpreter.cpp
+++ b/common/goos/Interpreter.cpp
@@ -26,10 +26,10 @@ Interpreter::Interpreter(const std::string& username) {
   define_var_in_env(goal_env, goal_env, "*goal-env*");
   define_var_in_env(goal_env, global_environment, "*global-env*");
 
-  // set user profile bool
-  define_var_in_env(global_environment, SymbolObject::make_new(reader.symbolTable, username),
-                    "*user*");
-  define_var_in_env(goal_env, SymbolObject::make_new(reader.symbolTable, username), "*user*");
+  // set user profile name
+  auto user = SymbolObject::make_new(reader.symbolTable, username);
+  define_var_in_env(global_environment, user, "*user*");
+  define_var_in_env(goal_env, user, "*user*");
 
   // setup maps
   special_forms = {

--- a/common/goos/Interpreter.cpp
+++ b/common/goos/Interpreter.cpp
@@ -6,10 +6,11 @@
 #include <utility>
 #include "Interpreter.h"
 #include "ParseHelpers.h"
+#include "common/util/FileUtil.h"
 #include <third-party/fmt/core.h>
 
 namespace goos {
-Interpreter::Interpreter() {
+Interpreter::Interpreter(const std::string& username) {
   // Interpreter startup:
   goal_to_goos.reset();
 
@@ -21,9 +22,14 @@ Interpreter::Interpreter() {
 
   // make both environments available in both.
   define_var_in_env(global_environment, global_environment, "*global-env*");
+  define_var_in_env(global_environment, goal_env, "*goal-env*");
   define_var_in_env(goal_env, goal_env, "*goal-env*");
   define_var_in_env(goal_env, global_environment, "*global-env*");
-  define_var_in_env(global_environment, goal_env, "*goal-env*");
+
+  // set user profile bool
+  define_var_in_env(global_environment, SymbolObject::make_new(reader.symbolTable, username),
+                    "*user*");
+  define_var_in_env(goal_env, SymbolObject::make_new(reader.symbolTable, username), "*user*");
 
   // setup maps
   special_forms = {
@@ -47,6 +53,7 @@ Interpreter::Interpreter() {
                    {"print", &Interpreter::eval_print},
                    {"inspect", &Interpreter::eval_inspect},
                    {"load-file", &Interpreter::eval_load_file},
+                   {"try-load-file", &Interpreter::eval_try_load_file},
                    {"eq?", &Interpreter::eval_equals},
                    {"gensym", &Interpreter::eval_gensym},
                    {"eval", &Interpreter::eval_eval},
@@ -1028,6 +1035,35 @@ Object Interpreter::eval_load_file(const Object& form,
     throw_eval_error(form, std::string("eval error inside of load-file:\n") + e.what());
   }
   return Object::make_empty_list();
+}
+
+/*!
+ * Combines read-file and eval to load in a file. Return #f if it doesn't exist.
+ */
+Object Interpreter::eval_try_load_file(const Object& form,
+                                       Arguments& args,
+                                       const std::shared_ptr<EnvironmentObject>& env) {
+  (void)env;
+  vararg_check(form, args, {ObjectType::STRING}, {});
+
+  auto path = {args.unnamed.at(0).as_string()->data};
+  if (!std::filesystem::exists(file_util::get_file_path(path))) {
+    return SymbolObject::make_new(reader.symbolTable, "#f");
+  }
+
+  Object o;
+  try {
+    o = reader.read_from_file(path);
+  } catch (std::runtime_error& e) {
+    throw_eval_error(form, std::string("reader error inside of try-load-file:\n") + e.what());
+  }
+
+  try {
+    return eval_with_rewind(o, global_environment.as_env_ptr());
+  } catch (std::runtime_error& e) {
+    throw_eval_error(form, std::string("eval error inside of try-load-file:\n") + e.what());
+  }
+  return SymbolObject::make_new(reader.symbolTable, "#t");
 }
 
 /*!

--- a/common/goos/Interpreter.h
+++ b/common/goos/Interpreter.h
@@ -13,7 +13,7 @@
 namespace goos {
 class Interpreter {
  public:
-  Interpreter();
+  Interpreter(const std::string& user_profile = "#f");
   ~Interpreter();
   void execute_repl(ReplWrapper& repl);
   void throw_eval_error(const Object& o, const std::string& err);
@@ -128,6 +128,9 @@ class Interpreter {
   Object eval_load_file(const Object& form,
                         Arguments& args,
                         const std::shared_ptr<EnvironmentObject>& env);
+  Object eval_try_load_file(const Object& form,
+                            Arguments& args,
+                            const std::shared_ptr<EnvironmentObject>& env);
   Object eval_print(const Object& form,
                     Arguments& args,
                     const std::shared_ptr<EnvironmentObject>& env);

--- a/common/goos/Reader.cpp
+++ b/common/goos/Reader.cpp
@@ -64,6 +64,7 @@ void TextStream::seek_past_whitespace_and_comments() {
       case ' ':
       case '\t':
       case '\n':
+      case '\r':
         // just a whitespace, eat it!
         read();
         break;

--- a/goal_src/engine/level/level.gc
+++ b/goal_src/engine/level/level.gc
@@ -1455,7 +1455,7 @@
   (let ((startup-level (case *kernel-boot-message*
                         (('play)
                      (if *debug-segment*
-                       'village1
+                       (#if (user? dass) 'finalboss 'village1)
                        'title
                        )
                          )

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -109,6 +109,10 @@
   `(#cond ((not ,clause) ,@body))
   )
 
+(defmacro #if (clause true false)
+  `(#cond (,clause ,true) (#t ,false))
+  )
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TARGET CONTROL
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/goal_src/goos-lib.gs
+++ b/goal_src/goos-lib.gs
@@ -288,7 +288,6 @@
   `(seval (desfun ,name ,args ,@body))
   )
 
-
 ;;;;;;;;;;;;;;;;;;;
 ;; enum stuff
 ;;;;;;;;;;;;;;;;;;;
@@ -341,3 +340,28 @@
 
 ;; this is checked in a test to see if this file is loaded.
 (define __goos-lib-loaded__ #t)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;
+;; USER PROFILES      ;;
+;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; *user* is defined when goos starts!
+(when *user*
+  (fmt #t "Loading user scripts for user: {}...\n" *user*)
+  ;; i'm not sure what naming scheme to sue here. user/<name>/user.gs?
+  ;; the GOAL one is loaded in Compiler.cpp
+  (load-file (fmt #f "goal_src/user/{}/user.gs" *user*))
+  )
+
+(defsmacro user? (&rest users)
+  (if (null? users)
+    #f
+    (if (eq? *user* (car users))
+      #t
+      `(user? ,@(cdr users))
+      )
+    )
+  )
+
+

--- a/goal_src/goos-lib.gs
+++ b/goal_src/goos-lib.gs
@@ -355,12 +355,16 @@
   )
 
 (defsmacro user? (&rest users)
-  (if (null? users)
-    #f
-    (if (eq? *user* (car users))
-      #t
-      `(user? ,@(cdr users))
-      )
+  (cond
+    ((null? users)
+     #f
+     )
+    ((eq? *user* (car users))
+     #t
+     )
+    (#t
+     `(user? ,@(cdr users))
+     )
     )
   )
 

--- a/goal_src/goos-lib.gs
+++ b/goal_src/goos-lib.gs
@@ -356,15 +356,9 @@
 
 (defsmacro user? (&rest users)
   (cond
-    ((null? users)
-     #f
-     )
-    ((eq? *user* (car users))
-     #t
-     )
-    (#t
-     `(user? ,@(cdr users))
-     )
+    ((null? users)            #f)
+    ((eq? *user* (car users)) #t)
+    (#t   `(user? ,@(cdr users)))
     )
   )
 

--- a/goal_src/goos-lib.gs
+++ b/goal_src/goos-lib.gs
@@ -349,7 +349,7 @@
 ;; *user* is defined when goos starts!
 (when *user*
   (fmt #t "Loading user scripts for user: {}...\n" *user*)
-  ;; i'm not sure what naming scheme to sue here. user/<name>/user.gs?
+  ;; i'm not sure what naming scheme to use here. user/<name>/user.gs?
   ;; the GOAL one is loaded in Compiler.cpp
   (load-file (fmt #f "goal_src/user/{}/user.gs" *user*))
   )

--- a/goal_src/user/.gitignore
+++ b/goal_src/user/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!readme.md

--- a/goal_src/user/readme.md
+++ b/goal_src/user/readme.md
@@ -1,0 +1,12 @@
+This directory holds the user profiles.
+
+To make your own profile, create a new directory here with your username.
+e.g. for username `mark` make a directory called `mark`
+Inside that directory, create `user.gs` and `user.gc` files.
+These are your own user scripts, loaded after the GOOS library and GOAL library respectively.
+
+The rest of the directory can be used however you please!
+
+To automatically log in as a specific user, create a `user.txt` file in this directory
+which contains just the username you want to log in as. That way you don't have to
+modify multiple scripts when you want to change users.

--- a/goal_src/user/readme.md
+++ b/goal_src/user/readme.md
@@ -10,3 +10,5 @@ The rest of the directory can be used however you please!
 To automatically log in as a specific user, create a `user.txt` file in this directory
 which contains just the username you want to log in as. That way you don't have to
 modify multiple scripts when you want to change users.
+
+If you want to make your profile public, edit the .gitignore in this directory.

--- a/goalc/compiler/Compiler.cpp
+++ b/goalc/compiler/Compiler.cpp
@@ -11,8 +11,8 @@
 
 using namespace goos;
 
-Compiler::Compiler(std::unique_ptr<ReplWrapper> repl)
-    : m_debugger(&m_listener, &m_goos.reader), m_repl(std::move(repl)) {
+Compiler::Compiler(const std::string& user_profile, std::unique_ptr<ReplWrapper> repl)
+    : m_goos(user_profile), m_debugger(&m_listener, &m_goos.reader), m_repl(std::move(repl)) {
   m_listener.add_debugger(&m_debugger);
   m_ts.add_builtin_types();
   m_global_env = std::make_unique<GlobalEnv>();
@@ -24,6 +24,11 @@ Compiler::Compiler(std::unique_ptr<ReplWrapper> repl)
   // load GOAL library
   Object library_code = m_goos.reader.read_from_file({"goal_src", "goal-lib.gc"});
   compile_object_file("goal-lib", library_code, false);
+
+  if (user_profile != "#f") {
+    Object user_code = m_goos.reader.read_from_file({"goal_src", "user", user_profile, "user.gc"});
+    compile_object_file(user_profile, user_code, false);
+  }
 
   // add built-in forms to symbol info
   for (auto& builtin : g_goal_forms) {

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -25,7 +25,7 @@ enum class ReplStatus { OK, WANT_EXIT, WANT_RELOAD };
 
 class Compiler {
  public:
-  Compiler(std::unique_ptr<ReplWrapper> repl = nullptr);
+  Compiler(const std::string& user_profile = "#f", std::unique_ptr<ReplWrapper> repl = nullptr);
   ReplStatus execute_repl(bool auto_listen = false, bool auto_debug = false);
   goos::Interpreter& get_goos() { return m_goos; }
   FileEnv* compile_object_file(const std::string& name, goos::Object code, bool allow_emit);

--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -35,20 +35,15 @@ int main(int argc, char** argv) {
   for (int i = 1; i < argc; i++) {
     if (std::string("-v") == argv[i]) {
       verbose = true;
-    }
-    if (std::string("-cmd") == argv[i] && i + 1 < argc) {
+    } else if (std::string("-cmd") == argv[i] && i + 1 < argc) {
       argument = argv[++i];
-    }
-    if (std::string("-auto-lt") == argv[i]) {
+    } else if (std::string("-auto-lt") == argv[i]) {
       auto_listen = true;
-    }
-    if (std::string("-auto-dbg") == argv[i]) {
+    } else if (std::string("-auto-dbg") == argv[i]) {
       auto_debug = true;
-    }
-    if (std::string("-user") == argv[i] && i + 1 < argc) {
+    } else if (std::string("-user") == argv[i] && i + 1 < argc) {
       username = argv[++i];
-    }
-    if (std::string("-user-auto") == argv[i]) {
+    } else if (std::string("-user-auto") == argv[i]) {
       try {
         auto text = std::make_shared<goos::FileText>(
             file_util::get_file_path({"goal_src", "user", "user.txt"}), "goal_src/user/user.txt");

--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv) {
   (void)argv;
 
   std::string argument;
+  std::string username = "#f";
   bool verbose = false;
   bool auto_listen = false;
   bool auto_debug = false;
@@ -44,6 +45,33 @@ int main(int argc, char** argv) {
     if (std::string("-auto-dbg") == argv[i]) {
       auto_debug = true;
     }
+    if (std::string("-user") == argv[i] && i < argc - 1) {
+      username = argv[++i];
+    }
+    if (std::string("-user-auto") == argv[i]) {
+      try {
+        auto text = std::make_shared<goos::FileText>(
+            file_util::get_file_path({"goal_src", "user", "user.txt"}), "goal_src/user/user.txt");
+        goos::TextStream ts(text);
+        ts.seek_past_whitespace_and_comments();
+        username.clear();
+        while (ts.text_remains()) {
+          char c = ts.read();
+          if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              c == '-' || c == '.' || c == '!' || c == '?' || c == '<' || c == '>') {
+            username.push_back(c);
+          } else {
+            break;
+          }
+        }
+        if (username.empty()) {
+          username = "#f";
+        }
+      } catch (std::runtime_error e) {
+        printf("error opening user desc file: %s\n", e.what());
+        username = "#f";
+      }
+    }
   }
   setup_logging(verbose);
 
@@ -56,7 +84,7 @@ int main(int argc, char** argv) {
     if (argument.empty()) {
       ReplStatus status = ReplStatus::WANT_RELOAD;
       while (status == ReplStatus::WANT_RELOAD) {
-        compiler = std::make_unique<Compiler>(std::make_unique<ReplWrapper>());
+        compiler = std::make_unique<Compiler>(username, std::make_unique<ReplWrapper>());
         status = compiler->execute_repl(auto_listen, auto_debug);
         if (status == ReplStatus::WANT_RELOAD) {
           fmt::print("Reloading compiler...\n");

--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     if (std::string("-v") == argv[i]) {
       verbose = true;
     }
-    if (std::string("-cmd") == argv[i] && i < argc - 1) {
+    if (std::string("-cmd") == argv[i] && i + 1 < argc) {
       argument = argv[++i];
     }
     if (std::string("-auto-lt") == argv[i]) {
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
     if (std::string("-auto-dbg") == argv[i]) {
       auto_debug = true;
     }
-    if (std::string("-user") == argv[i] && i < argc - 1) {
+    if (std::string("-user") == argv[i] && i + 1 < argc) {
       username = argv[++i];
     }
     if (std::string("-user-auto") == argv[i]) {
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
         if (username.empty()) {
           username = "#f";
         }
-      } catch (std::runtime_error e) {
+      } catch (std::exception& e) {
         printf("error opening user desc file: %s\n", e.what());
         username = "#f";
       }

--- a/scripts/batch/gc-no-lt.bat
+++ b/scripts/batch/gc-no-lt.bat
@@ -1,4 +1,4 @@
 @echo off
 cd ..\..
-out\build\Release\bin\goalc -v
+out\build\Release\bin\goalc -v -user-auto
 pause

--- a/scripts/batch/gc.bat
+++ b/scripts/batch/gc.bat
@@ -1,4 +1,4 @@
 @echo off
 cd ..\..
-out\build\Release\bin\goalc -v -auto-dbg
+out\build\Release\bin\goalc -v -auto-dbg -user-auto
 pause

--- a/scripts/batch/repo-settings-mark.bat
+++ b/scripts/batch/repo-settings-mark.bat
@@ -1,2 +1,2 @@
 cd ..\..
-git update-index --assume-unchanged decompiler\config\jak1_ntsc_black_label.jsonc decompiler\config\jak1_ntsc_black_label\inputs.jsonc
+git update-index --assume-unchanged decompiler\config\jak1_ntsc_black_label.jsonc decompiler\config\jak1_ntsc_black_label\inputs.jsonc goal_src\user\user.txt

--- a/scripts/batch/repo-settings-unmark.bat
+++ b/scripts/batch/repo-settings-unmark.bat
@@ -1,2 +1,2 @@
 cd ..\..
-git update-index --no-assume-unchanged decompiler\config\jak1_ntsc_black_label.jsonc decompiler\config\jak1_ntsc_black_label\inputs.jsonc
+git update-index --no-assume-unchanged decompiler\config\jak1_ntsc_black_label.jsonc decompiler\config\jak1_ntsc_black_label\inputs.jsonc goal_src\user\user.txt


### PR DESCRIPTION
Implements "user profiles" to GOOS/GOAL, allowing you to have extra custom code loaded at start-up that isnt part of the standard library. Also can be used for conditional compilation to tune settings for specific users.

A username can be selected with the `-user <username>` parameter in `gc`. The `-user-auto` parameter can also be used, and it reads the username from the file `goal_src/user/user.txt` (it reads the first uncommented valid word as the username).

There's a GOOS `user?` macro that will return `#t` if the current user matches any of its arguments. For example, `(user? mark john)` will return `#t` if the current user is either `mark` or `john`, and `#f` otherwise. You can use this for conditional compilation.

There is a `*user*` variable in both GOAL and GOOS which holds the username. Do not write to it, it won't magically reload user profiles and will just mess with the `user?` macro.

The default profile is `#f` and does not load any user code. It should be used for proper shareable builds, obviously.