### PR TITLE
[goalc] better control over debug-segment

### DIFF
--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -4,7 +4,7 @@
   // if you want to filter to only some object names.
   // it will make the decompiler much faster.
   "allowed_objects": [],
-  "banned_objects": [],
+  "banned_objects": ["collide-mesh"],
 
   ////////////////////////////
   // CODE ANALYSIS OPTIONS

--- a/docs/markdown/progress-notes/changelog.md
+++ b/docs/markdown/progress-notes/changelog.md
@@ -207,3 +207,4 @@
 - It is now possible to use a macro to provide a static inline array element definition
 - It is now possible to have symbol names that have a `#` in the middle of them
 - `go-hook` now returns the return value of the `enter-state` function it calls
+- Added a `(declare-file (debug))` to put things in the debug segment by default. This only changes _static_ objects. Dynamic allocation with forms like `cons` will continue to use the main segment like before.

--- a/goal_src/engine/camera/cam-layout.gc
+++ b/goal_src/engine/camera/cam-layout.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: cam-layout
 ;; dgos: GAME, ENGINE
 
+(declare-file (debug))
+
 ;; DECOMP BEGINS
 
 ;; this file is debug only

--- a/goal_src/engine/debug/anim-tester.gc
+++ b/goal_src/engine/debug/anim-tester.gc
@@ -8,6 +8,8 @@
 ;; NOTES - removed one of the 2 inspects
 ;; - also fixed up a basic file-stream constructor on the stack
 
+(declare-file (debug))
+
 (declare-type list-control structure)
 (define-extern anim-test-anim-list-handler (function int list-control symbol))
 (define-extern anim-test-edit-sequence-list-handler (function int list-control symbol))

--- a/goal_src/engine/debug/default-menu.gc
+++ b/goal_src/engine/debug/default-menu.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: default-menu
 ;; dgos: GAME, ENGINE
 
+(declare-file (debug))
+
 ;; Forward declarations for stuff we haven't written yet:
 (define-extern *edit-instance* string)
 

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -125,7 +125,7 @@ class Compiler {
   Val* compile_float(float value, Env* env, int seg);
   Val* compile_symbol(const goos::Object& form, Env* env);
   Val* compile_string(const goos::Object& form, Env* env);
-  Val* compile_string(const std::string& str, Env* env, int seg = MAIN_SEGMENT);
+  Val* compile_string(const std::string& str, Env* env, int seg);
   Val* compile_get_symbol_value(const goos::Object& form, const std::string& name, Env* env);
   Val* compile_function_or_method_call(const goos::Object& form, Env* env);
 
@@ -233,15 +233,20 @@ class Compiler {
                          Env* env,
                          bool call_constructor);
 
-  StaticResult fill_static_array(const goos::Object& form, const goos::Object& rest, Env* env);
+  StaticResult fill_static_array(const goos::Object& form,
+                                 const goos::Object& rest,
+                                 Env* env,
+                                 int seg);
 
   StaticResult fill_static_boxed_array(const goos::Object& form,
                                        const goos::Object& rest,
-                                       Env* env);
+                                       Env* env,
+                                       int seg);
 
   StaticResult fill_static_inline_array(const goos::Object& form,
                                         const goos::Object& rest,
-                                        Env* env);
+                                        Env* env,
+                                        int seg);
 
   void fill_static_inline_array_inline(const goos::Object& form,
                                        const TypeSpec& content_type,
@@ -330,10 +335,11 @@ class Compiler {
   Val* compile_new_static_structure_or_basic(const goos::Object& form,
                                              const TypeSpec& type,
                                              const goos::Object& field_defs,
-                                             Env* env);
-  Val* compile_static_pair(const goos::Object& form, Env* env);
+                                             Env* env,
+                                             int seg);
+  Val* compile_static_pair(const goos::Object& form, Env* env, int seg);
   StaticResult compile_static(const goos::Object& form, Env* env);
-  StaticResult compile_static_no_eval_for_pairs(const goos::Object& form, Env* env);
+  StaticResult compile_static_no_eval_for_pairs(const goos::Object& form, Env* env, int seg);
 
   Val* compile_bitfield_definition(const goos::Object& form,
                                    const TypeSpec& type,
@@ -343,7 +349,8 @@ class Compiler {
   StaticResult compile_new_static_structure(const goos::Object& form,
                                             const TypeSpec& type,
                                             const goos::Object& _field_defs,
-                                            Env* env);
+                                            Env* env,
+                                            int seg);
 
   void compile_static_structure_inline(const goos::Object& form,
                                        const TypeSpec& type,
@@ -606,6 +613,7 @@ class Compiler {
   Val* compile_inline(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_declare(const goos::Object& form, const goos::Object& rest, Env* env);
   Val* compile_local_vars(const goos::Object& form, const goos::Object& rest, Env* env);
+  Val* compile_declare_file(const goos::Object& form, const goos::Object& rest, Env* env);
 
   // Type
   Val* compile_deftype(const goos::Object& form, const goos::Object& rest, Env* env);

--- a/goalc/compiler/Env.h
+++ b/goalc/compiler/Env.h
@@ -118,12 +118,16 @@ class FileEnv : public Env {
     return (T*)m_vals.back().get();
   }
 
+  int default_segment() const { return m_default_segment; }
+  void set_debug_file() { m_default_segment = DEBUG_SEGMENT; }
+
  protected:
   std::string m_name;
   std::vector<std::shared_ptr<FunctionEnv>> m_functions;
   std::vector<std::unique_ptr<StaticObject>> m_statics;
   int m_anon_func_counter = 0;
   std::vector<std::unique_ptr<Val>> m_vals;
+  int m_default_segment = MAIN_SEGMENT;
 
   // statics
   FunctionEnv* m_top_level_func = nullptr;
@@ -191,6 +195,14 @@ class FunctionEnv : public DeclareEnv {
                                                    int size_bytes,
                                                    int align_bytes);
   int stack_slots_used_for_stack_vars() const { return m_stack_var_slots_used; }
+
+  int segment_for_static_data() {
+    if (segment == TOP_LEVEL_SEGMENT) {
+      return file_env()->default_segment();
+    } else {
+      return segment;
+    }
+  }
 
   int idx_in_file = -1;
 

--- a/goalc/compiler/compilation/Macro.cpp
+++ b/goalc/compiler/compilation/Macro.cpp
@@ -146,7 +146,7 @@ Val* Compiler::compile_quote(const goos::Object& form, const goos::Object& rest,
       return empty_pair;
     }
     case goos::ObjectType::PAIR:
-      return compile_static_pair(thing, env);
+      return compile_static_pair(thing, env, env->function_env()->segment_for_static_data());
     default:
       throw_compiler_error(form, "Quote is not yet implemented for {}.", thing.print());
   }

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -485,7 +485,7 @@ Val* Compiler::compile_defmethod(const goos::Object& form, const goos::Object& _
   place->func = nullptr;
 
   auto new_func_env = std::make_unique<FunctionEnv>(env, lambda.debug_name, &m_goos.reader);
-  new_func_env->set_segment(MAIN_SEGMENT);  // todo, how do we set debug?
+  new_func_env->set_segment(env->function_env()->segment_for_static_data());
   new_func_env->method_of_type_name = symbol_string(type_name);
 
   // set up arguments
@@ -1060,7 +1060,8 @@ Val* Compiler::compile_static_new(const goos::Object& form,
   } else {
     auto type_of_object = parse_typespec(unquote(type));
     if (is_structure(type_of_object)) {
-      return compile_new_static_structure_or_basic(form, type_of_object, *rest, env);
+      return compile_new_static_structure_or_basic(form, type_of_object, *rest, env,
+                                                   env->function_env()->segment_for_static_data());
     }
 
     if (is_bitfield(type_of_object)) {


### PR DESCRIPTION
This fixes a few places where we put things in the main segment when we should put it in debug.  There is also a `(declare-file (debug))` form to change the default segment to `debug`.

With these fixes, `default-menu`'s `main` segment is empty. In total we save ~109 kB of global heap after loading the engine.

This will fix https://github.com/water111/jak-project/issues/998

and improves https://github.com/water111/jak-project/issues/975 a bit more