### PR TITLE
ci: retry on transient chocolatey failures

### DIFF
--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -48,7 +48,7 @@ jobs:
         run: git submodule update --init --recursive -j 2
 
       - name: Install Dependencies
-        run: choco install nasm
+        run: Choco-Install -PackageName nasm
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v1.2.2


### PR DESCRIPTION
this is a wrapper for `choco` that will retry on transient errors, hopefully making our build more consistent.