### PR TITLE
[ref tests] pass filename through on compile failures

### DIFF
--- a/common/goos/Reader.cpp
+++ b/common/goos/Reader.cpp
@@ -217,9 +217,11 @@ std::optional<Object> Reader::read_from_stdin(const std::string& prompt, ReplWra
 /*!
  * Read a string.
  */
-Object Reader::read_from_string(const std::string& str, bool add_top_level) {
+Object Reader::read_from_string(const std::string& str,
+                                bool add_top_level,
+                                const std::optional<std::string>& string_name) {
   // create text fragment and add to the DB
-  auto textFrag = std::make_shared<ProgramString>(str);
+  auto textFrag = std::make_shared<ProgramString>(str, string_name.value_or("Program string"));
   db.insert(textFrag);
 
   // perform read

--- a/common/goos/Reader.h
+++ b/common/goos/Reader.h
@@ -72,7 +72,9 @@ struct Token {
 class Reader {
  public:
   Reader();
-  Object read_from_string(const std::string& str, bool add_top_level = true);
+  Object read_from_string(const std::string& str,
+                          bool add_top_level = true,
+                          const std::optional<std::string>& string_name = {});
   std::optional<Object> read_from_stdin(const std::string& prompt, ReplWrapper& repl);
   Object read_from_file(const std::vector<std::string>& file_path, bool check_encoding = false);
   bool check_string_is_valid(const std::string& str) const;

--- a/common/goos/TextDB.h
+++ b/common/goos/TextDB.h
@@ -65,9 +65,14 @@ class ReplText : public SourceText {
  */
 class ProgramString : public SourceText {
  public:
-  explicit ProgramString(const std::string& text_) : SourceText(text_) {}
-  std::string get_description() override { return "Program string"; }
+  explicit ProgramString(const std::string& text_,
+                         const std::string& string_name = "Program string")
+      : SourceText(text_), m_string_name(string_name) {}
+  std::string get_description() override { return m_string_name; }
   ~ProgramString() = default;
+
+ private:
+  std::string m_string_name;
 };
 
 /*!

--- a/goalc/compiler/Compiler.cpp
+++ b/goalc/compiler/Compiler.cpp
@@ -428,8 +428,9 @@ void Compiler::run_front_end_on_file(const std::vector<std::string>& path) {
  * Run the entire compilation process on the input source code. Will generate an object file, but
  * won't save it anywhere.
  */
-void Compiler::run_full_compiler_on_string_no_save(const std::string& src) {
-  auto code = m_goos.reader.read_from_string({src});
+void Compiler::run_full_compiler_on_string_no_save(const std::string& src,
+                                                   const std::optional<std::string>& string_name) {
+  auto code = m_goos.reader.read_from_string(src, true, string_name);
   auto compiled = compile_object_file("run-on-string", code, true);
   color_object_file(compiled);
   codegen_object_file(compiled);

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -42,7 +42,8 @@ class Compiler {
   void compile_and_send_from_string(const std::string& source_code);
   void run_front_end_on_string(const std::string& src);
   void run_front_end_on_file(const std::vector<std::string>& path);
-  void run_full_compiler_on_string_no_save(const std::string& src);
+  void run_full_compiler_on_string_no_save(const std::string& src,
+                                           const std::optional<std::string>& string_name);
   void shutdown_target();
   void enable_throw_on_redefines() { m_throw_on_define_extern_redefinition = true; }
   void add_ignored_define_extern_symbol(const std::string& name) {

--- a/test/offline/offline_test_main.cpp
+++ b/test/offline/offline_test_main.cpp
@@ -327,7 +327,7 @@ bool compile(Decompiler& dc,
     try {
       const auto& src = data.output_with_skips;
       total_lines += line_count(src);
-      compiler.run_full_compiler_on_string_no_save(src);
+      compiler.run_full_compiler_on_string_no_save(src, file.name_in_dgo);
     } catch (const std::exception& e) {
       fmt::print("Compiler exception: {}\n", e.what());
       return false;


### PR DESCRIPTION
```
-- Compilation Error! --
No method or function named obj for type type
Form:
(obj vec4s)
Location:
gcommon:108
  ((obj vec4s))
    ^
Code:
(obj vec4s)
```
errors with the real file name instead of just `string`.