### PR TITLE
scripts: adjust fix Taskfile recipes to work with recent changes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,11 +17,15 @@ tasks:
     env:
       OPENGOAL_DECOMP_DIR: "jak1/"
     cmds:
-      # (mi) | (test-play)
+      - ./out/build/Release/bin/goalc.exe
+  repl-lt:
+    env:
+      OPENGOAL_DECOMP_DIR: "jak1/"
+    cmds:
       - ./out/build/Release/bin/goalc.exe -auto-lt
   decomp:
     cmds:
-      - ./out/build/Release/bin/decompiler.exe "./decompiler/config/jak1_ntsc_black_label.jsonc" "./iso_data/jak1" "./decompiler_out/jak1"
+      - ./out/build/Release/bin/decompiler.exe "./decompiler/config/jak1_ntsc_black_label.jsonc" "./iso_data" "./decompiler_out"
   decomp-clean:
     cmds:
       - rm ./decompiler_out/**/*.asm


### PR DESCRIPTION
- was double nesting with `jak1/jak1`
- if you've never built the kernel before `gk.exe` will crash and running the repl with it trying to connect to the game has too long of a time-out, so added another recipe that doesn't auto connect.